### PR TITLE
remove "broken" links from sidebar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,3 +22,13 @@ title = "docs.cf.18f.us"
     identifier = "ops"
     pre = "<i class='fa fa-wrench'></i>"
     weight = -90
+[[menu.main]]
+    name = "Standards"
+    identifier = "standards"
+    pre = "<i class='fa fa-desktop'></i>"
+    weight = -85
+[[menu.main]]
+    name = "Updates"
+    identifier = "updates"
+    pre = "<i class='fa fa-columns'></i>"
+    weight = -80

--- a/config.toml
+++ b/config.toml
@@ -22,13 +22,3 @@ title = "docs.cf.18f.us"
     identifier = "ops"
     pre = "<i class='fa fa-wrench'></i>"
     weight = -90
-[[menu.main]]
-    name = "Standards"
-    identifier = "standards"
-    pre = "<i class='fa fa-desktop'></i>"
-    weight = -85
-[[menu.main]]
-    name = "Updates"
-    identifier = "updates"
-    pre = "<i class='fa fa-columns'></i>"
-    weight = -80

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -19,13 +19,6 @@
                     <li{{if $currentNode.IsMenuCurrent "main" . }} class="active"{{end}}><a href="{{.Url}}">{{ .Name }}</a> </li>
                     {{ end }}
                 </ul>
-              {{else}}
-                <li>
-                <a class="" href="{{.Url}}">
-                    {{ .Pre }}
-                    <!--<i class="icon_house_alt"></i>-->
-                    <span>{{ .Name }}</span>
-                </a>
               {{end}}
               </li>
           {{end}}


### PR DESCRIPTION
There are a couple of menu items without child pages:

![basic_deploy_troubleshooting](https://cloud.githubusercontent.com/assets/86842/6747043/a685b506-cea9-11e4-815b-f41d2f4a6299.png)

Nothing happens when you click on them, so better to just get rid of them to eliminate confusion.
