### PR TITLE
add a guide around cloning apps

### DIFF
--- a/content/apps/cloning.md
+++ b/content/apps/cloning.md
@@ -17,6 +17,7 @@ Say you have an existing deployment on Cloud Foundry, and you want to make a new
 
 1. Use [manifest inheritance](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#multi-manifests) to do any necessary configuration.
 1. Run `cf push <NEW_APP_NAME> -f <PATH_TO_MANIFEST>`.
+1. Make sure to run any necessary database setup commands, etc.
 
 ## If you don't have a manifest
 
@@ -36,3 +37,5 @@ Say you have an existing deployment on Cloud Foundry, and you want to make a new
     ```bash
     cf push <NEW_APP_NAME> -f <NEW_APP_NAME>_manifest.yml
     ```
+
+1. Make sure to run any necessary database setup commands, etc. for the new application.

--- a/content/apps/cloning.md
+++ b/content/apps/cloning.md
@@ -1,0 +1,38 @@
+---
+menu:
+  main:
+    parent: apps
+title: Cloning Applications
+weight: 10
+---
+
+Say you have an existing deployment on Cloud Foundry, and you want to make a new staging environment. Below are the different scenarios around [application manifests](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html).
+
+## If you have a single manifest
+
+1. Run `cf push <NEW_APP_NAME>`.
+1. Use the CLI to do any other necessary configuration.
+
+## If you have environment-specific manifests
+
+1. Use [manifest inheritance](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#multi-manifests) to do any necessary configuration.
+1. Run `cf push <NEW_APP_NAME> -f <PATH_TO_MANIFEST>`.
+
+## If you don't have a manifest
+
+1. Generate a manifest from an existing application:
+
+    ```bash
+    cf create-app-manifest <EXISTING_APP_NAME>
+    cp <EXISTING_APP_NAME>_manifest.yml <NEW_APP_NAME>_manifest.yml
+    ```
+
+1. Clean up `<NEW_APP_NAME>_manifest.yml`. You probably only need the following properties:
+    * `name` (required) – make sure to change it to the new app name
+    * `env` – change any environment-specific variables, e.g. the `DATABASE_URL`
+    * `services`
+1. Deploy the new environment:
+
+    ```bash
+    cf push <NEW_APP_NAME> -f <NEW_APP_NAME>_manifest.yml
+    ```


### PR DESCRIPTION
See https://trello.com/c/DCJmzNB3/24-allow-environments-to-be-cloned.

This guide explains the various ways to clone applications (short of anything fancy like copying the database), but is a start. I imagine this will also change as we figure out best practices for manifests and configuration, and get more of our environment variables set up by services.
