### PR TITLE
most organizations should only need a single space

### DIFF
--- a/content/getting-started/index.md
+++ b/content/getting-started/index.md
@@ -92,13 +92,9 @@ cf target -o ORGNAME
 
 Every application is scoped to a "space". Applications in the same space share a location for app development, deployment, and maintenance.
 
-### Naming convention
-
-For simple organizations where there's only going to be a single application per environment, just use a single space called `general`. If the org is more general (e.g. `devops`), the space may correspond to the name of the project (e.g. `hubot`).
-
 ### Management
 
-To create a space:
+For most organizations, having a single space called `general` will work. To create a space:
 
 ```bash
 cf create-space SPACENAME

--- a/content/getting-started/index.md
+++ b/content/getting-started/index.md
@@ -94,7 +94,7 @@ Every application is scoped to a "space". Applications in the same space share a
 
 ### Naming convention
 
-Within 18F, the `SPACENAME` will correspond to an environment, e.g. `dev` or `prod`. If the org is more general (e.g. `devops`), the space may correspond to the name of the project (e.g. `hubot`).
+For simple organizations where there's only going to be a single application per environment, just use a single space called `general`. If the org is more general (e.g. `devops`), the space may correspond to the name of the project (e.g. `hubot`).
 
 ### Management
 


### PR DESCRIPTION
Switching between spaces is a bit of a hassle, and for our use case, I'm realizing that there's not really any benefit to splitting environments between them. Applications with multiple environments will have the environment name in the CF app name anyway (e.g. `c2-staging`).
