### PR TITLE
add more explicit installation instructions for cf-ssh

### DIFF
--- a/content/getting-started/cf-ssh.md
+++ b/content/getting-started/cf-ssh.md
@@ -17,7 +17,13 @@ Our `cf-ssh` is customized to our Cloud Foundry installation so please **do not 
 ### Install `cf-ssh`
 
 1. Download `cf-ssh` for your environment https://github.com/18F/cloud-foundry-scripts/releases/
-1. Move it somewhere in your `$PATH`
+1. Run
+
+    ```bash
+    cd ~/Downloads
+    chmod a+x cf-ssh
+    mv cf-ssh /usr/local/bin
+    ```
 
 ### Usage
 


### PR DESCRIPTION
Following up from https://github.com/18F/cloud-foundry-notes/pull/27#discussion_r26889659.
