### PR TITLE
Remove warning about SSL validation

### DIFF
--- a/content/apps/continuous-deployment.md
+++ b/content/apps/continuous-deployment.md
@@ -22,8 +22,6 @@ Depending on your CI system the setup is going to be a bit different. **For all 
 
 ### Travis
 
-**THIS SOLUTION DOESN'T CURRENTLY WORK SINCE TRAVIS DOES NOT SUPPORT `--skip-ssl-validation` for CF**
-
 Per [http://docs.travis-ci.com/user/deployment/cloudfoundry/](http://docs.travis-ci.com/user/deployment/cloudfoundry/) you need to add this section to your `.travis.yml` file:
 
 ```


### PR DESCRIPTION
This is fixed now that we're on `api.18f.gov` right?
