### PR TITLE
update link to staticfile buildpack

### DIFF
--- a/content/apps/static.md
+++ b/content/apps/static.md
@@ -32,7 +32,7 @@ Create a `manifest.yml` that uses the [`staticfile-buildpack`](https://github.co
 applications:
 - name: my-static-site
   memory: 64M
-  buildpack: https://github.com/cloudfoundry-incubator/staticfile-buildpack.git
+  buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
   env:
     FORCE_HTTPS: true
 ```


### PR DESCRIPTION
This updates the link in the manifest.yml example to the new static buildpack link (note that it has graduated from the incubator).
