### PR TITLE
Add a tip on continuously deploying to certain apps

### DIFF
--- a/content/apps/continuous-deployment.md
+++ b/content/apps/continuous-deployment.md
@@ -43,6 +43,8 @@ sudo: required
 
 Replace `DEPLOYER_USER`, `ORG`, and `SPACE` accordingly and run `travis encrypt --add deploy.password --skip-version-check` to enter the deployer's password.
 
+If you want to have continuous deployment on only a specific app or group of apps, the easiest solution is to isolate them in their own space.
+
 #### Jekyll Site
 
 Deploying a Jekyll site requires a few changes to your `.travis.yml` and `manifest.yml` as well as the addition of a `Staticfile` and `Gemfile`.


### PR DESCRIPTION
I just set up continuous deployment for CALC's dev server and, after trying the (http://docs.travis-ci.com/user/deployment/#Conditional-Releases-with-on%3A)[on setting] to accomplish this, I ended up reconfiguring the apps. The one I want to deploy to is in its own space now, making configuration easy.

It took me awhile to get this working properly, so I'm hoping to spare others the effort.
