### PR TITLE
remove references to 18f.us

### DIFF
--- a/content/apps/custom-domains.md
+++ b/content/apps/custom-domains.md
@@ -9,7 +9,7 @@ weight: 10
 ### Creating the [Load Balancer (ELB)](http://aws.amazon.com/elasticloadbalancing/)
 There needs to be one ELB pointing to Cloud Foundry per TLS certificate.
 
-* If domains under the cert already point to apps on Cloud Foundry (e.g. `18f.us`), you're all set.
+* If domains under the cert already point to apps on Cloud Foundry (e.g. `18f.us` or `18f.gov`), you're all set.
 * If not, follow the [ELB instructions]({{< relref "ops/elb.md" >}}).
 
 ### Creating the [Hosted Zone](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/AboutHZWorkingWith.html).

--- a/content/apps/django.md
+++ b/content/apps/django.md
@@ -122,7 +122,7 @@ To create and deploy your app:
 cf push APPNAME --no-start
 ```
 
-Normally, you would be able to view the site at `APPNAME.labs.18f.us`, but we gave the command the `--no-start` flag. Before we start the app we need to set up the database.
+Normally, you would be able to view the site at `APPNAME.18f.gov`, but we gave the command the `--no-start` flag. Before we start the app we need to set up the database.
 
 ## Setting Up the Database
 
@@ -147,4 +147,4 @@ Now try running the push command without the `--no-start` flag:
 cf push APPNAME
 ```
 
-It should now be running at `APPNAME.labs.18f.us`!
+It should now be running at `APPNAME.18f.gov`!

--- a/content/ops/changing-password.md
+++ b/content/ops/changing-password.md
@@ -11,7 +11,7 @@ This document from the admin guide is useful: http://docs.cloudfoundry.org/admin
 In short:
 
 - Install `uaac` CLI: `gem install cf-uaac`
-- Target UAA: `uaac target uaa.labs.18f.us`
+- Target UAA: `uaac target uaa.18f.gov`
 - Get token: `uaac token client get admin -s MyAdminPassword`
   - If `uaac contexts` doesn't have scim.write:
   - `uaac client update admin --authorities "OTHER-EXISTING-PERMISSIONS uaa.admin clients.secret scim.read scim.write password.write"`


### PR DESCRIPTION
One thing I wasn't sure about: under [Creating the Record Set](https://docs.18f.gov/apps/custom-domains/#creating-the-record-set-http-docs-aws-amazon-com-route53-latest-developerguide-rrsets-working-with-html:a696116b867437408b4ff35951b9cdb0), which ELB should be used for `*.18f.gov` domains?
