### PR TITLE
Adding sentences on the finer points of .cfignore

### DIFF
--- a/content/apps/deployment.md
+++ b/content/apps/deployment.md
@@ -41,4 +41,9 @@ Cloud Foundry isn't version-control-aware, so `cf push` will deploy the working 
 ln -s .gitignore .cfignore
 ```
 
-and commit the `.cfignore` to your repository. Note that more advanced git-ignore syntax, such as the `**` recursive subdirectory wildcard, may not be supported by `.cfignore`.
+and commit the `.cfignore` to your repository. However, read on if you have a more advanced CF setup.
+
+A couple of important points on the `.cfignore`:
+
+1. if you have a more advanced app setup and have apps with a `path` other than the project root (where you run `cf push` from), you will need an additional `.cfignore` file located in each app `path`;
+2. also note that more advanced `.gitignore` syntax, such as the `**` recursive subdirectory wildcard, are _not_ supported by `.cfignore`.


### PR DESCRIPTION
Adding some learnings from today's Screenhero session with @dlapiduz 
- Multiple .cfignore files are necessary for projects with more than one root app path
- cfignore does not support advanced gitignore syntax (depsite the directions advising to symlink .cfignore from .gitignore)
