### PR TITLE
Update name of Slack channel in docs

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -8,7 +8,7 @@ Welcome! Cloud Foundry is an open source Platform-as-a-Service (PaaS) system for
 
 ## Help!
 
-Find the section you need on the left. Reach out in [#g-devops](https://18f.slack.com/messages/g-devops/) or [open an issue](https://github.com/18F/cloud-foundry-notes/issues/new) if you need anything. If you're not part of 18F but want to talk with us about fun DevOps stuff, [join our #devops-public Slack channel](https://chat.18f.gov/).
+Find the section you need on the left. Reach out in [#devops](https://18f.slack.com/messages/devops/) or [open an issue](https://github.com/18F/cloud-foundry-notes/issues/new) if you need anything. If you're not part of 18F but want to talk with us about fun DevOps stuff, [join our #devops-public Slack channel](https://chat.18f.gov/).
 
 ## Public domain
 

--- a/content/index.md
+++ b/content/index.md
@@ -8,7 +8,7 @@ Welcome! Cloud Foundry is an open source Platform-as-a-Service (PaaS) system for
 
 ## Help!
 
-Find the section you need on the left. Reach out in [#devops](https://18f.slack.com/messages/devops/) or [open an issue](https://github.com/18F/cloud-foundry-notes/issues/new) if you need anything. If you're not part of 18F but want to talk with us about fun DevOps stuff, [join our #devops-public Slack channel](https://chat.18f.gov/).
+Find the section you need on the left. Reach out in [#cloud-gov-support](https://18f.slack.com/messages/cloud-gov-support/) or [open an issue](https://github.com/18F/cloud-foundry-notes/issues/new) if you need anything. If you're not part of 18F but want to talk with us about fun DevOps stuff, [join our #devops-public Slack channel](https://chat.18f.gov/).
 
 ## Public domain
 


### PR DESCRIPTION
- #g-devops is archived
- New channel is just called "devops"
