### PR TITLE
`cf --version` = `cf -v`

### DIFF
--- a/content/getting-started/setup.md
+++ b/content/getting-started/setup.md
@@ -30,10 +30,10 @@ sudo mv cf /usr/local/bin
 ### Confirm the installation
 
 ```bash
-cf --version
+cf -v
 ```
 
-As of this writing the current cf CLI version is `6.10.0-b78bf10`.
+As of this writing the current cf CLI version is `6.12.3-c0c9a03`.
 
 ## Setting up your account
 


### PR DESCRIPTION
- `--version` is not a registered command

![screen shot 2015-09-10 at 11 23 25 am](https://cloud.githubusercontent.com/assets/601515/9803539/44977e98-57d8-11e5-8aae-68f226750f4b.png)
