### PR TITLE
Add details about alternate root folders

### DIFF
--- a/content/apps/static.md
+++ b/content/apps/static.md
@@ -37,6 +37,8 @@ applications:
     FORCE_HTTPS: true
 ```
 
+If the static content is included in a different folder, you can add a `path` declaration. E.g., `path: dist` or `path: assets`.
+
 Deploy:
 
 ```


### PR DESCRIPTION
Note that [some documentation on the Internet](https://github.com/cloudfoundry/staticfile-buildpack) describes using `root` instead of `path`, but in practice, this has not worked on our CF. I don't know why.
