### PR TITLE
add link to forgot_password URL

### DIFF
--- a/content/getting-started/setup.md
+++ b/content/getting-started/setup.md
@@ -54,6 +54,9 @@ Once you log in for the first time, you'll probably want to change your password
 cf passwd
 ```
 
+If for some reason you cannot reset your password with `cf passwd` you can also use the
+[web-based reset feature](https://login.cloud.gov/forgot_password).
+
 ## Playing around
 
 If you want to practice deploying, run the following before continuing:


### PR DESCRIPTION
Sometimes `cf passwd` will not work, like when your old password doesn't meet the new password requirements. Then you need to use the web-based tool.
