### PR TITLE
s/18f.gov/cloud.gov/ in several places

### DIFF
--- a/content/apps/continuous-deployment.md
+++ b/content/apps/continuous-deployment.md
@@ -36,7 +36,7 @@ deploy:
   provider: cloudfoundry
   username: DEPLOYER_USER
   password:
-  api: https://api.18f.gov
+  api: https://api.cloud.gov
   organization: ORG
   space: SPACE
 ```
@@ -111,7 +111,7 @@ dependencies:
 
 test:
   post:
-    - cf login -a https://api.18f.gov -u DEPLOYER_USER -p $CF_PASS -o ORG -s SPACE
+    - cf login -a https://api.cloud.gov -u DEPLOYER_USER -p $CF_PASS -o ORG -s SPACE
 
 deployment:
   production:
@@ -155,7 +155,7 @@ And setup the following environment variables in a "deploy target":
 
 | Name    | Value              |
 |---------|--------------------|
-| CF_API  | `api.18f.gov`      |
+| CF_API  | `api.cloud.gov`      |
 | CF_USER | deployer username  |
 | CF_PASS | deployer password  |
 | CF_ORG  | target organization|

--- a/content/getting-started/setup.md
+++ b/content/getting-started/setup.md
@@ -44,7 +44,7 @@ First, please [create an issue in the DevOps issue tracker](https://github.com/1
 ### Log in
 
 ```bash
-cf api https://api.18f.gov
+cf api https://api.cloud.gov
 cf login
 ```
 

--- a/content/ops/changing-password.md
+++ b/content/ops/changing-password.md
@@ -11,7 +11,7 @@ This document from the admin guide is useful: http://docs.cloudfoundry.org/admin
 In short:
 
 - Install `uaac` CLI: `gem install cf-uaac`
-- Target UAA: `uaac target uaa.18f.gov`
+- Target UAA: `uaac target uaa.cloud.gov`
 - Get token: `uaac token client get admin -s MyAdminPassword`
   - If `uaac contexts` doesn't have scim.write:
   - `uaac client update admin --authorities "OTHER-EXISTING-PERMISSIONS uaa.admin clients.secret scim.read scim.write password.write"`

--- a/content/ops/creating-a-new-admin-user.md
+++ b/content/ops/creating-a-new-admin-user.md
@@ -37,7 +37,7 @@ The [User Account and Authentication server](https://github.com/cloudfoundry/uaa
 
 ##### Specifying the UAA Target:
 
-	uaac target uaa.18f.gov
+	uaac target uaa.cloud.gov
 
 ##### Obtaining A Token:
 
@@ -50,14 +50,14 @@ Note: The client secret can specified on the command line with the `-s` switch, 
 	Client secret:  ********************************
 
 	Successfully fetched token via client credentials grant.
-	Target: https://uaa.18f.gov
+	Target: https://uaa.cloud.gov
 	Context: admin, from client admin
 
 ##### Confirming Authorization:
 
 Use `uaac context` to confirm your current authorization and permissions.
 
-	[1]*[https://uaa.18f.gov]
+	[1]*[https://uaa.cloud.gov]
 	  skip_ssl_validation: true
 
 	  [0]*[admin]


### PR DESCRIPTION
Noticed these when @ertzeid was going through the new user setup. Didn't change references to 18f.gov for app routes, just core components.
