### PR TITLE
Expand zero-downtime deploy options.

### DIFF
--- a/content/apps/continuous-deployment.md
+++ b/content/apps/continuous-deployment.md
@@ -11,7 +11,7 @@ changes to your desired environment.
 
 ## Zero-downtime deployment
 
-Use the [`cf-blue-green`](https://github.com/18F/cf-blue-green) tool – see instructions in that repository.
+Use the [autopilot](https://github.com/concourse/autopilot) Cloud Foundry CLI plugin or the [`cf-blue-green`](https://github.com/18F/cf-blue-green) tool; see instructions in the respective repositories.
 
 ## Continuous integration services
 


### PR DESCRIPTION
Link to autopilot, an alternative zero-downtime plugin that relies on manifests rather than live application state for configuration. As I've been arguing [elsewhere](https://github.com/18F/cf-blue-green/issues/17), I think this is the way to go, but am happy to be convinced otherwise.
