### PR TITLE
rearrange menu sections

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -56,3 +56,15 @@ title = "docs.cloud.gov"
 [[menu.main]]
     name = "Contributing"
     identifier = "ops"
+[[menu.main]]
+    name = "Deployment"
+    identifier = "deployment"
+    parent = "ops"
+[[menu.main]]
+    name = "Users"
+    identifier = "users"
+    parent = "ops"
+[[menu.main]]
+    name = "Operations"
+    identifier = "operations"
+    parent = "ops"

--- a/config.toml
+++ b/config.toml
@@ -52,12 +52,6 @@ title = "docs.cloud.gov"
     identifier = "apps"
     pre = "<i class='fa fa-file-text'></i>"
     weight = -110
-[[menu.main]]
-    name = "Standards"
-    parent = "usage"
-    identifier = "standards"
-    pre = "<i class='fa fa-desktop'></i>"
-    weight = -85
 
 [[menu.main]]
     name = "Contributing"

--- a/config.toml
+++ b/config.toml
@@ -7,35 +7,6 @@ title = "docs.cloud.gov"
   author = "18f"
 
 [[menu.main]]
-    name = "Usage"
-    identifier = "usage"
-    weight = -10
-[[menu.main]]
-    name = "Getting Started"
-    parent = "usage"
-    identifier = "getting-started"
-    pre = "<i class='fa fa-road'></i>"
-    weight = -120
-[[menu.main]]
-    name = "Deploying Apps"
-    parent = "usage"
-    identifier = "apps"
-    pre = "<i class='fa fa-file-text'></i>"
-    weight = -110
-[[menu.main]]
-    name = "Operations"
-    parent = "usage"
-    identifier = "ops"
-    pre = "<i class='fa fa-wrench'></i>"
-    weight = -90
-[[menu.main]]
-    name = "Standards"
-    parent = "usage"
-    identifier = "standards"
-    pre = "<i class='fa fa-desktop'></i>"
-    weight = -85
-
-[[menu.main]]
     name = "Introduction"
     identifier = "intro"
     weight = -20
@@ -64,3 +35,32 @@ title = "docs.cloud.gov"
     parent = "intro"
     identifier = "terminology"
     weight = -100
+
+[[menu.main]]
+    name = "Usage"
+    identifier = "usage"
+    weight = -10
+[[menu.main]]
+    name = "Getting Started"
+    parent = "usage"
+    identifier = "getting-started"
+    pre = "<i class='fa fa-road'></i>"
+    weight = -120
+[[menu.main]]
+    name = "Deploying Apps"
+    parent = "usage"
+    identifier = "apps"
+    pre = "<i class='fa fa-file-text'></i>"
+    weight = -110
+[[menu.main]]
+    name = "Operations"
+    parent = "usage"
+    identifier = "ops"
+    pre = "<i class='fa fa-wrench'></i>"
+    weight = -90
+[[menu.main]]
+    name = "Standards"
+    parent = "usage"
+    identifier = "standards"
+    pre = "<i class='fa fa-desktop'></i>"
+    weight = -85

--- a/config.toml
+++ b/config.toml
@@ -52,6 +52,12 @@ title = "docs.cloud.gov"
     identifier = "apps"
     pre = "<i class='fa fa-file-text'></i>"
     weight = -110
+[[menu.main]]
+    name = "Advanced"
+    parent = "usage"
+    identifier = "advanced"
+    pre = "<i class='fa fa-rocket'></i>"
+    weight = -100
 
 [[menu.main]]
     name = "Contributing"

--- a/config.toml
+++ b/config.toml
@@ -7,30 +7,30 @@ title = "docs.cloud.gov"
   author = "18f"
 
 [[menu.main]]
-    name = "Docs"
-    identifier = "docs"
+    name = "Usage"
+    identifier = "usage"
     weight = -10
 [[menu.main]]
     name = "Getting Started"
-    parent = "docs"
+    parent = "usage"
     identifier = "getting-started"
     pre = "<i class='fa fa-road'></i>"
     weight = -120
 [[menu.main]]
     name = "Deploying Apps"
-    parent = "docs"
+    parent = "usage"
     identifier = "apps"
     pre = "<i class='fa fa-file-text'></i>"
     weight = -110
 [[menu.main]]
     name = "Operations"
-    parent = "docs"
+    parent = "usage"
     identifier = "ops"
     pre = "<i class='fa fa-wrench'></i>"
     weight = -90
 [[menu.main]]
     name = "Standards"
-    parent = "docs"
+    parent = "usage"
     identifier = "standards"
     pre = "<i class='fa fa-desktop'></i>"
     weight = -85

--- a/config.toml
+++ b/config.toml
@@ -53,14 +53,12 @@ title = "docs.cloud.gov"
     pre = "<i class='fa fa-file-text'></i>"
     weight = -110
 [[menu.main]]
-    name = "Operations"
-    parent = "usage"
-    identifier = "ops"
-    pre = "<i class='fa fa-wrench'></i>"
-    weight = -90
-[[menu.main]]
     name = "Standards"
     parent = "usage"
     identifier = "standards"
     pre = "<i class='fa fa-desktop'></i>"
     weight = -85
+
+[[menu.main]]
+    name = "Contributing"
+    identifier = "ops"

--- a/content/apps/cloning.md
+++ b/content/apps/cloning.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: apps
+    parent: advanced
 title: Cloning Applications
 weight: 10
 ---

--- a/content/apps/continuous-deployment.md
+++ b/content/apps/continuous-deployment.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: apps
+    parent: advanced
 title: Continuous Deployment
 weight: 10
 ---

--- a/content/apps/custom-domains.md
+++ b/content/apps/custom-domains.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: apps
+    parent: advanced
 title: Custom Domains
 weight: 10
 ---

--- a/content/apps/durable-logging.md
+++ b/content/apps/durable-logging.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: apps
+    parent: advanced
 title: Durable Logging with the ELK Service
 weight: 10
 ---
@@ -77,7 +77,7 @@ Bind the ELK instance to your applications.
 cf bs APPNAME MY_ELK
 ```
 
-Application logs will begin draining to the ELK instance shortly, you do not need to restage the newly bound applications. 
+Application logs will begin draining to the ELK instance shortly, you do not need to restage the newly bound applications.
 
 #### Make it permanent
 
@@ -98,7 +98,7 @@ Add the ELK binding to your application manifest as shown below to ensure ELK is
 #### Create a Kibana proxy
 
 
-Access to Kibana requires the creation of a service proxy. Use [make-proxy](https://github.com/18F/cf-service-proxy/blob/master/make-proxy.sh) to do this. 
+Access to Kibana requires the creation of a service proxy. Use [make-proxy](https://github.com/18F/cf-service-proxy/blob/master/make-proxy.sh) to do this.
 
 Clone the [cf-service-proxy](https://github.com/18F/cf-service-proxy/) repo.
 
@@ -127,7 +127,7 @@ Now you can create the proxy using the `nginx-auth/Staticfile.auth` file you jus
 ```
 
 Note: `DOMAIN` should only include the domain portion of your Kibana proxy route without the hostname. You can list available domains with `cf domains`.
-	
+
 **output**
 
 	Looking for jq.
@@ -138,11 +138,11 @@ Note: `DOMAIN` should only include the domain portion of your Kibana proxy route
 	    - Found bindings.
 	Checking status for MY_ELK-proxy.
 	Creating MY_ELK-proxy...
-	
+
 	Getting service credentials for MY_ELK.
 	  Port: 12345
 	  IP: 10.10.10.1
-	
+
 	Getting app environment for MY_ELK-proxy.
 	! Proxy vars don't match.
 	+ Injecting service credentials into MY_ELK-proxy.
@@ -152,9 +152,9 @@ Note: `DOMAIN` should only include the domain portion of your Kibana proxy route
 	- Finishing start of MY_ELK-proxy.
 	  - Getting credentials for MY_ELK-proxy.
 	Checking status for MY_ELK-proxy.
-	
+
 	Access the the proxied service here:
-	
+
 	https://user:pass@proxy.domain
 	Done.
 
@@ -173,7 +173,7 @@ Kibana requires a few moments to load.
 
 Proceed with the default index name and pattern. This can always be changed later via the 'Settings' link at the top of each Kibana view.
 
-For more information on these settings see [Getting Kibana Up and Running](https://www.elastic.co/guide/en/kibana/current/setup.html) in the official docs. 
+For more information on these settings see [Getting Kibana Up and Running](https://www.elastic.co/guide/en/kibana/current/setup.html) in the official docs.
 
 ![Selecting an index pattern is the first step in accessing a new Kibana instance.](/img/configure_index_pattern-450.png)
 
@@ -209,7 +209,7 @@ Creating the Elasticsearch / Marvel proxy follows much the same process as the K
   -z "9200/tcp" \
   -p
 ```
-	
+
 **output**
 
 	Looking for jq.
@@ -223,11 +223,11 @@ Creating the Elasticsearch / Marvel proxy follows much the same process as the K
 	Cleaning up: /tmp/placeholder-7D45FC20-2A19-48C8-BCC6-3DECA5530DFB
 	Checking status for MY_ELK-proxy.
 	Creating MY_ELK-proxy...
-	
+
 	Getting service credentials for MY_ELK.
 	  Port: 12345
 	  IP: 10.10.10.1
-	
+
 	Getting app environment for MY_ELK-proxy.
 	! Proxy vars don't match.
 	+ Injecting service credentials into MY_ELK-proxy.
@@ -237,8 +237,8 @@ Creating the Elasticsearch / Marvel proxy follows much the same process as the K
 	- Finishing start of MY_ELK-proxy.
 	  - Getting credentials for MY_ELK-proxy.
 	Checking status for MY_ELK-proxy.
-	
+
 	Access the the proxied service here:
-	
+
 	https://user:password@proxy.domain
 	Done.

--- a/content/apps/moving-apps.md
+++ b/content/apps/moving-apps.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: apps
+    parent: advanced
 title: Moving apps between spaces
 weight: 10
 ---

--- a/content/apps/multi-buildpack-deploys.md
+++ b/content/apps/multi-buildpack-deploys.md
@@ -2,7 +2,7 @@
 date: 2015-07-10T14:32:59-04:00
 menu:
   main:
-    parent: apps
+    parent: advanced
 title: Deploying Multi-language Projects
 weight: 10
 ---
@@ -33,5 +33,3 @@ https://github.com/cloudfoundry/nodejs-buildpack
 
 ## Debugging
 Multi-buildpacks deploys can be difficult to debug because [heroku-buildpack-multi](https://github.com/ddollar/heroku-buildpack-multi.git) hides the error logs. For more verbose output use [ozzyjohnson/heroku-buildpack-multi](https://github.com/ozzyjohnson/heroku-buildpack-multi).
-
-

--- a/content/apps/multiple-instances.md
+++ b/content/apps/multiple-instances.md
@@ -2,7 +2,7 @@
 date: 2015-05-27T13:32:00-04:00
 menu:
   main:
-    parent: ops
+    parent: apps
 title: Running Multiple Instances
 weight: 10
 ---

--- a/content/apps/multiple-instances.md
+++ b/content/apps/multiple-instances.md
@@ -2,7 +2,7 @@
 date: 2015-05-27T13:32:00-04:00
 menu:
   main:
-    parent: apps
+    parent: advanced
 title: Running Multiple Instances
 weight: 10
 ---

--- a/content/apps/plugins.md
+++ b/content/apps/plugins.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: ops
+    parent: advanced
 title: Plugins
 weight: 10
 ---

--- a/content/apps/production-ready.md
+++ b/content/apps/production-ready.md
@@ -2,7 +2,7 @@
 date: 2015-08-28T10:32:59-04:00
 menu:
   main:
-    parent: apps
+    parent: advanced
 title: Production Ready Checklist
 weight: 10
 ---

--- a/content/getting-started/cf-ssh.md
+++ b/content/getting-started/cf-ssh.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: getting-started
+    parent: advanced
 title: Running one off tasks
 weight: 100
 ---
@@ -18,7 +18,7 @@ Our `cf-ssh` is customized to our Cloud Foundry installation so please **do not 
 
 ### Install `cf-ssh`
 
-1. Download `cf-ssh` for your environment https://github.com/18F/cloud-foundry-scripts/releases/
+1. [Download `cf-ssh` for your environment](https://github.com/18F/cloud-foundry-scripts/releases/)
 1. Run
 
     ```bash

--- a/content/ops/accessing-v1-managed-services.md
+++ b/content/ops/accessing-v1-managed-services.md
@@ -1,14 +1,14 @@
 ---
 menu:
   main:
-    parent: ops
+    parent: operations
 title: Accessing v1 Managed Services
 weight: 10
 ---
 
 #### Background:
 
-Cloud Foundry Managed Services provide applications with on-demand access to services outside of the stateless application environment. Typical managed services include databases, queues and key-value stores. 
+Cloud Foundry Managed Services provide applications with on-demand access to services outside of the stateless application environment. Typical managed services include databases, queues and key-value stores.
 
 The v1 services in [cf-services-contrib-release](https://github.com/cloudfoundry-community/cf-services-contrib-release) are a straightforward way to get started quickly with a suite of useful service bindings. Services included are elasticsearch, memcached, mongodb, postgresql, rabbitmq, redis, vblob and swift.
 
@@ -24,7 +24,7 @@ The v1 services in [cf-services-contrib-release](https://github.com/cloudfoundry
 2.) The utility [jq](http://stedolan.github.io/jq/) JSON parsing utility is not strictly necessary, but comes into play in of one of the examples below.
 
 	brew install jq
-	
+
 3.) An fully deployed and authorized v1 Cloud Foundry service such as the contrib services mentioned above.
 
 #### Procedure:
@@ -39,7 +39,7 @@ In order to create a service instance and binding for use with an application we
 
 	Getting service auth tokens as USERNAME...
 	OK
-	
+
 	label           provider   
 	postgresql      core   
 	elasticsearch   core   
@@ -51,13 +51,13 @@ Unfortunately, the `cf` cli lacks a command to query for v1 service plans direct
 Identify the `service_plan_url` for the service `entity` (service label) you're interested in.
 
 	cf curl /v2/services
-	
+
 Access the entity `service_plan_url` with `cf curl` to see available plans.
 
 	cf curl SERVICE_PLAN_URL
 
 We can do this as a one-liner with some help from jq.
-	
+
 	cf curl `cf curl /v2/services | jq -r '(.resources[] | select(.entity.label == SERVICE_LABEL) | .entity.service_plans_url)'`
 
 ##### Create a Service Instance:
@@ -73,10 +73,10 @@ Create a new service instance by specifying a service label, plan and a name of 
 For example, the create an instance of the elasticsearch service using the free plan with name 'es'.
 
 	cf create-service elasticsearch free es
-	
+
 ##### Bind the Service Instance:
 
-A service instance must be bound to the application which will access it. This can be done in a single step by adding a binding to the application's `manifest.yml`. 
+A service instance must be bound to the application which will access it. This can be done in a single step by adding a binding to the application's `manifest.yml`.
 
 **manifest.yml**
 
@@ -122,7 +122,7 @@ Use `cf env APPLICATION` to to display the application environment variables inc
 	...
 
 In this case, `url` alone could be sufficient for establishing a connection from the running application.
-	
+
 ##### Access the Service Configuration:
 
 Configuration and credentials for the bound service can be accessed in several ways.
@@ -152,12 +152,10 @@ To access the elasticsearch service described above with a node app.
 	...
 	var cfenv = require("cfenv")
 	var appEnv = cfenv.getAppEnv()
-	
+
 	url = appEnv.getServiceURL("es")
-	
+
 	var client = new elasticsearch.Client({
 		host: url,
 	});
 	...
-
-

--- a/content/ops/aws-onboarding.md
+++ b/content/ops/aws-onboarding.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: ops
+    parent: users
 title: AWS Onboarding
 weight: 10
 ---

--- a/content/ops/changing-password.md
+++ b/content/ops/changing-password.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: ops
+    parent: users
 title: Changing a password
 weight: 10
 ---

--- a/content/ops/create-user.md
+++ b/content/ops/create-user.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: ops
+    parent: users
 title: Creating a user
 weight: 10
 ---

--- a/content/ops/creating-a-development-environment-with-bosh-lite.md
+++ b/content/ops/creating-a-development-environment-with-bosh-lite.md
@@ -1,8 +1,9 @@
 ---
 menu:
   main:
-    parent: ops
-title: Creating a dev environment
+    parent: deployment
+title: Creating a dev environment on AWS
+linktitle: AWS
 weight: 10
 ---
 
@@ -185,7 +186,7 @@ When complete, use bosh vms to have a look at the resulting environment.
 
 	ubuntu@agent-id-bosh-0:~/workspace/bosh-lite$ bosh vms
 
-	Deployment `cf-warden'
+	Deployment 'cf-warden'
 
 	Director task 4
 

--- a/content/ops/creating-a-local-dev-environment-in-Virtual-Box.md
+++ b/content/ops/creating-a-local-dev-environment-in-Virtual-Box.md
@@ -1,9 +1,9 @@
 ---
 menu:
   main:
-    parent: ops
-title: Creating a local dev environment with Virtual Box
-weight: 10
+    parent: deployment
+title: Creating a local dev environment with VirtualBox
+linktitle: Local
 ---
 
 BOSH Lite is designed to provide a local development environment for BOSH and by extension Cloud Foundry. BOSH Lite will be used run locally via Virtualbox. This guide is primarily concerned with bringing up a single-instance environment VB.
@@ -32,7 +32,7 @@ Note: If that fails goto http://www.vagrantup.com/downloads and install from web
 While not strictly necessary, but this guide assumes a recent version is installed. Install or update it from:
 
 	brew cask install virtualbox
-	
+
 Additional info can be found here: https://www.virtualbox.org/wiki/Downloads
 
 ##### Docker
@@ -40,7 +40,7 @@ Additional info can be found here: https://www.virtualbox.org/wiki/Downloads
 We need to install Docker. It will be used to build the cflinuxfs2.tar.gz. Install from here:
 
 	brew cask install dockertoolbox
-	
+
 Additional info can be found here: https://docs.docker.com/mac/step_one/
 
 ##### Git
@@ -145,7 +145,7 @@ When complete, use bosh vms to have a look at the resulting environment.
 
 	ubuntu@agent-id-bosh-0:~/workspace/bosh-lite$ bosh vms
 
-	Deployment `cf-warden'
+	Deployment 'cf-warden'
 
 	Director task #
 
@@ -182,12 +182,12 @@ We're done provisioning, now we'll disconnect and access the environment via the
 	vagrant plugin install vagrant-scp
 	cd ~/host_working_folder/
 
-Now Docker must be installed and running on your Mac for the next procedure to work. Launch into a docker terminal to create the cflinuxfs2 container. 
+Now Docker must be installed and running on your Mac for the next procedure to work. Launch into a docker terminal to create the cflinuxfs2 container.
 
 	git clone https://github.com/cloudfoundry/stacks.git
 	cd stacks
 	make
-	
+
 Secure copy the cflinuxfs2 container to the CF VM.
 
 	cd ../bosh-lite

--- a/content/ops/creating-a-new-admin-user.md
+++ b/content/ops/creating-a-new-admin-user.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: ops
+    parent: users
 title: Creating an admin user
 weight: 10
 ---

--- a/content/ops/creating-a-stemcell-building-vm.md
+++ b/content/ops/creating-a-stemcell-building-vm.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: ops
+    parent: deployment
 title: Creating a Stemcell Building VM
 weight: 10
 ---
@@ -11,18 +11,18 @@ How to create a vagrant machine on AWS for building new bosh stemcells.
 #### Prerequisites
 
 Vagrant with the vagrant-aws, vagrant-berkshelf and vagrant-omnibus plugins.
- 
+
 	brew install vagrant
 	vagrant plugin install vagrant-berkshelf
 	vagrant plugin install vagrant-omnibus
 	vagrant plugin install vagrant-aws
-		
+
 The AWS CLI (Amazon Web Services Command Line Interface) is not strictly necessary, but this guide assumes a recent version it. Install or update it with:
- 
+
 	sudo pip install awscli -U
 
 Git.
- 
+
  	brew install git
 
 #### Procedure
@@ -34,7 +34,7 @@ You'll need a recent version of the AWS CLI for some of these commands. The curr
 Create the bosh user.
 
 	aws iam create-user --user-name bosh
-	
+
 Apply a policy that will allow bosh to perform actions in the AWS environment.
 
 	aws iam attach-user-policy --user-name bosh --policy-arn 'arn:aws:iam::aws:policy/AmazonEC2FullAccess'
@@ -46,7 +46,7 @@ Create the bosh keypair.
 Create the bosh access key and secret key.
 
 	aws iam create-access-key --user-name bosh
-	
+
 Export the required environment variables using key file and credentials create above.
 
 This is the path to the private portion of the bosh keypair (bosh.pem).
@@ -57,7 +57,7 @@ This is AWS access key to be used by bosh.
 
 
 	export BOSH_AWS_ACCESS_KEY_ID=ABCDEFGHIJKLMNOPQRST
-	
+
 This is AWS secret key to be used by bosh.
 
 	export BOSH_AWS_SECRET_ACCESS_KEY=abcdefghijklmnopqrstuvwxyz0123456789abcd
@@ -69,7 +69,7 @@ Again the AWS CLI is nice to have here.
 Create the security group.
 
 	aws ec2 create-security-group --group-name bosh-stemcell --description 'SSH access to the bosh stemcell creation VM.'
-	
+
 Add your own public IP at minimum.
 
 	aws ec2 authorize-security-group-ingress --group-name bosh-stemcells --protocol tcp --port 22 --cidr $(curl icanhazip.com)/32

--- a/content/ops/deploying-the-admin-ui.md
+++ b/content/ops/deploying-the-admin-ui.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: ops
+    parent: deployment
 title: Deploying the admin UI
 weight: 10
 ---
@@ -61,7 +61,7 @@ As of this writing, instructions for deploying the Admin UI bosh release default
 
 1. Initiate the deployment.
 
-		bosh deploy 
+		bosh deploy
 
 1. Run the registration errand.
 
@@ -72,11 +72,11 @@ As of this writing, instructions for deploying the Admin UI bosh release default
 Admin UI users and administrators must be part of the groups `admin_ui.users` or `admin_ui.admins` respectively.  Add new members with the uaac cli:
 
 	uaac member add admin_ui.user USERNAME
-	
+
 Or...
 
 	uaac member add admin_ui.admins USERNAME
-	
+
 
 #### Operation
 

--- a/content/ops/deploying-the-docker-broker.md
+++ b/content/ops/deploying-the-docker-broker.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: ops
+    parent: deployment
 title: Deploying the Docker Broker
 weight: 10
 ---
@@ -39,7 +39,7 @@ This guide covers the high level steps required to configure, deploy and enable 
 1. Provision an elastic IP for use by the broker.
 
 		aws ec2 allocate-address --domain vpc
-	
+
 	Note the provided `PublicIp` for use as the `elastic_ip` variable below.
 
 1. Choose an appropriate template from the `./examples` directory replacing the variables which describe your environment and secrets. For the purpose of this guide we're working with `docker-broker-aws.yml` where we'll need to provide the following variables.
@@ -48,19 +48,19 @@ This guide covers the high level steps required to configure, deploy and enable 
 		director_uuid
 		elastic_ip
 		root_domain
-		
+
 		properties.nats.user
 		properties.nats.password
 		properties.nats.machines
-		
+
 		properties.cf.admin_username
 		properties.cf.admin_password
-		
+
 		properties.broker.username
 		properties.broker.password
-		
+
 	Save the complete manifest to a new file. For example, `docker-broker-aws-deploy.yml`.
-	
+
 	**Note:** The manifest describes each Docker image to be downloaded and made available as a service in the `properties.broker.services` section. Service configuration is covered in greater detail in [Configuration]({{< relref "#configuration" >}}).
 
 1. Generate a deployment from the manifest.
@@ -69,13 +69,13 @@ This guide covers the high level steps required to configure, deploy and enable 
 
 1. Initiate the deployment.
 
-		bosh deploy 
+		bosh deploy
 
 #### Configuration
 
 Docker images are configured in the `properties.broker.services` key which contains a list of images, each with its own respective metadata, credential configuration and plans.
 
-For more information about each field in a service description see: 
+For more information about each field in a service description see:
 
 * [Services Metadata Fields](http://docs.cloudfoundry.org/services/catalog-metadata.html#services-metadata-fields)
 * [Plan Metadata Fields](http://docs.cloudfoundry.org/services/catalog-metadata.html#plan-metadata-fields)
@@ -105,26 +105,26 @@ A few critical things to note when adding a service.
 1. Enable the broker.
 
 		cf create-service-broker BROKER_NAME BROKER_USER BROKER_PASS https://BROKER_HOST
-		
+
 	Where each variable correlates to a section of the manifest used to create the deployment.
-	
+
 	- `BROKER_NAME` = properties.broker.name
 	- `BROKER_USER` = properties.broker.username
 	- `BROKER_PASS` = properties.broker.password
 	- `BROKER_HOST` = properties.broker.host
-	
+
 1. Enable services.
 
 	To enable all plans of a service for all orgs.
 
 		cf enable-service-access SERVICE
-		
+
 	To enable a specific service plan or enable plans in a specific org use the `-p` and/or `-o` option.
-		
+
 		cf enable-service-access SERVICE -p PLAN -o ORG
 
 1. Create service instances.
 
 		cf create-service SERVICE PLAN SERVICE_INSTANCE_NAME
-	
+
 1. Bind those services to your apps using `cf bind-service` or the `services` key in your application `manifest.yml`.

--- a/content/ops/elb.md
+++ b/content/ops/elb.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: ops
+    parent: operations
 title: ELB termination
 weight: 10
 ---
@@ -27,6 +27,7 @@ Use [this CloudFormation JSON template](https://github.com/18F/cloud-foundry-man
 * **HostedZoneName**: Type in the name of the hosted zone, e.g. `open.foia.gov`.
 * **ZoneName**: Type in the name of the subdomain in front of the hosted zone domain, if one applies.
 t
+
 ### Creating the ELB by hand
 
 The CloudFormation JSON above is built to represent the following workflow:

--- a/content/ops/making-announcements.md
+++ b/content/ops/making-announcements.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: ops
+    parent: operations
 title: Making announcements
 weight: 10
 ---
@@ -21,8 +21,8 @@ To announce maintenance on the status page:
   * Describe the change briefly.
   * Indicate whether you expect any disruption in service as a result.
   * Direct users to support channels if they have questions or are worried about the timing of the maintenance.
-  * Use an appropriate time window. 
-      * Pay attention to the timezone, which is specified in Eastern Time (EDT)! 
+  * Use an appropriate time window.
+      * Pay attention to the timezone, which is specified in Eastern Time (EDT)!
       * Be sure to leave a little more time than you expect will be needed. Better to be done earlier than announced than run later than expected!
   * If disruption *is* expected, *check the box that says "Automatically remind subscribers"* so they are proactively warned in advance of the window.
 1. Extend the window if you're not done in time. End it early if you're done sooner than announced.
@@ -33,14 +33,14 @@ As soon as we are aware of a problem, [the cloud.gov status page](https://cloudg
 To announce an incident on the status page:
 
 1. Log into the [status page management console](https://manage.statuspage.io/pages/swcbylb1c30f).
-1. Create an incident. 
+1. Create an incident.
   * If there are user-visible problems, set the status of appropriate components.
-  * Summarise the observable symptoms and the state of the incident; don't try to explain the detailed internal state/cause in detail! 
+  * Summarise the observable symptoms and the state of the incident; don't try to explain the detailed internal state/cause in detail!
   * Remind users of established support channels in case they have questions or are urgently affected.
 1. Investigate and fix the problem.
 1. Update the incident to reflect that it's resolved, and that a postmortem is pending. Ensure that the component status is set appropriately.
 1. Enter a postmortem for the incident. In the postmortem, include these sections:
   1. **What Happened** - Describe in plain language what happened, referring to user-observable symptoms
-  1. **Remediation Performed** - Specific steps taken to resolve the situation, eg "Restarted UAA and observed that authentication returned to normal". 
-  1. **Regression Prevention** - Indicate any improvements that we've added to the backlog which would prevent similar incidents in future, with a link to [the cloud.gov roadmap](https://18f.storiesonboard.com/m/gov-dev) so that interested users can follow our progress. 
+  1. **Remediation Performed** - Specific steps taken to resolve the situation, eg "Restarted UAA and observed that authentication returned to normal".
+  1. **Regression Prevention** - Indicate any improvements that we've added to the backlog which would prevent similar incidents in future, with a link to [the cloud.gov roadmap](https://18f.storiesonboard.com/m/gov-dev) so that interested users can follow our progress.
      * *Ideally this portion gets filled in after a "[5 Whys](https://en.wikipedia.org/wiki/5_Whys)" or "[Ishikawa](https://en.wikipedia.org/wiki/Ishikawa_diagram)" root-cause meeting has occurred.*

--- a/content/ops/metrics.md
+++ b/content/ops/metrics.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: ops
+    parent: operations
 title: Metrics
 weight: 10
 ---
@@ -45,4 +45,3 @@ In order to export a dashboard:
   * Make a ticket in the `DevOps` repository with the title `[JumpBox Access Req]` to be given access.
 1. Go into the metrics folder `cd ~/workspace/deployments/monitoring-services/cf-metrics-18f`
 1. Run `for f in grafana/dashboards/*.json; do curl --user <insert username>:<insert password> 'http://<internal AWS IP For Docker Host>:3000/api/dashboards/db' -X POST -H 'Content-Type: application/json;charset=UTF-8' --data-binary @$f; done`
-

--- a/content/ops/plugins.md
+++ b/content/ops/plugins.md
@@ -6,7 +6,7 @@ title: Plugins
 weight: 10
 ---
 
-CloudFoundry includes a framework for plugins. Since CloudFoundry is written for performance in Go, these plugins do not function exactly the same as plugins do in other dynamically-compiled frameworks like Capistrano or Fab. Still, they provide a basic framework for extending the base functionality of the CloudFoundry CLI
+CloudFoundry includes a framework for plugins. Since CloudFoundry is written for performance in Go, these plugins do not function exactly the same as plugins do in other dynamically-compiled frameworks like Capistrano or Fab. Still, they provide a basic framework for extending the base functionality of the CloudFoundry CLI.
 
 ### Using Plugins
 
@@ -32,9 +32,8 @@ Then you can compile your own plugin and install it. Plugins are able to call an
 
 ### What Plugins Can't Do
 
-Plugins are only invoked when they are explicitly called within the CLI. In this sense, they resemble [Slack's outgoing webhooks](https://api.slack.com/outgoing-webhooks). There currently isn’t any support for plugins to register themselves to be called at specific points in the deployment cycle, as there is in other deployment mechanisms. The CloudFoundry team has [prioritized such features at the bottom of their list](https://github.com/cloudfoundry/cli/issues/123), and [this situation remains unchanged a year later](https://github.com/cloudfoundry/cli/issues/404). 
+Plugins are only invoked when they are explicitly called within the CLI. In this sense, they resemble [Slack's outgoing webhooks](https://api.slack.com/outgoing-webhooks). There currently isn’t any support for plugins to register themselves to be called at specific points in the deployment cycle, as there is in other deployment mechanisms. The CloudFoundry team has [prioritized such features at the bottom of their list](https://github.com/cloudfoundry/cli/issues/123), and [this situation remains unchanged a year later](https://github.com/cloudfoundry/cli/issues/404).
 
 For cases where we want to wrap an event like `cf push` with optional before and after actions, the CF team recommends that we should define our own separately named plugin. For example, we might want to have cf push using .gitignore if there is no .cfignore file. To do this with plugins, we’d have to define out our `18fpush` plugin that copies the .gitignore to .cfignore if not there, calls the regular push action and then undoes the copy. Every person deploying code would have to remember to call `cf 18fpush` instead of `cf push` for this to be effective.
 
 Alternatively, we can just edit the CLI code itself so that it’ll contain the new behavior for all pushes. But this means we are adding some code for our specific needs that aren’t necessarily useful for the cloudfoundry CLI code. And it requires us to make sure our fork tracks changes to the main CLI repository. Neither of these cases are ideal, but they are the only options we have.
-

--- a/content/ops/policies.md
+++ b/content/ops/policies.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: ops
+    parent: users
 title: Policies
 weight: 10
 ---

--- a/content/ops/ports.md
+++ b/content/ops/ports.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: ops
+    parent: operations
 title: Port Descriptions
 weight: 10
 ---

--- a/content/ops/updating-cf.md
+++ b/content/ops/updating-cf.md
@@ -1,7 +1,7 @@
 ---
 menu:
   main:
-    parent: ops
+    parent: deployment
 title: Updating Cloud Foundry
 weight: 10
 ---

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -17,10 +17,12 @@
                   <ul class="sub nested-menu {{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }} open {{end}}" style="{{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }} display: block; {{else}}display: none; {{end}}">
                       {{ range .Children }}
 		      <li class="sub-menu {{if $currentNode.IsMenuCurrent "main" . }} active {{end}}" >
-                          <a href="javascript:;" class="">
+                          <a {{ if .HasChildren }}href="javascript:;"{{ else }}href="{{.URL}}"{{end}} class="">
                               {{ .Pre }}
                               <span>{{ .Name }}</span>
+                              {{ if .HasChildren }}
                               <span class="menu-arrow fa {{if $currentNode.HasMenuCurrent "main" . }}fa-angle-down{{else}}fa-angle-right{{end}}"></span>
+                              {{ end }}
                           </a>
                           {{ if .HasChildren }}
 			  <ul class="sub {{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }} open {{end}}" style="{{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }}display: block; {{else}}display: none; {{end}}">


### PR DESCRIPTION
The biggest change in this pull request moves all the navigation items previously under Docs -> Operations to a Contributing section of the menu. The Contributing section is really intended for cloud.gov staff, but @mogul suggested the word "Contributing", which I think makes it more welcoming than something like "Internal Docs". Totally open to other ideas for the menu/sub-menu titles.

There are no content changes – just navigational. See commits for more specifics.

**Before**

<img width="209" alt="screen shot 2015-12-27 at 9 55 17 am" src="https://cloud.githubusercontent.com/assets/86842/12010924/08185620-ac80-11e5-90c4-67ef6aee2977.png">

**After**

<img width="219" alt="screen shot 2015-12-24 at 11 27 50 am" src="https://cloud.githubusercontent.com/assets/86842/11996461/693ab2aa-aa31-11e5-9584-884ffcccd3c9.png">

/cc @jameshupp 
