### PR TITLE
Consolidate apt statements

### DIFF
--- a/content/ops/creating-a-local-dev-environment-in-Virtual-Box.md
+++ b/content/ops/creating-a-local-dev-environment-in-Virtual-Box.md
@@ -124,9 +124,8 @@ With VirtualBox the domain will be tied to the localhost and will always be:
 
 Add some dependency packages for the provisioning tool
 
-	sudo apt-get install ruby
+	sudo apt-get install ruby curl
 	sudo gem install bundle
-	sudo apt-get install curl
 
 Run the automated provisioning script.
 

--- a/content/ops/creating-a-local-dev-environment-in-Virtual-Box.md
+++ b/content/ops/creating-a-local-dev-environment-in-Virtual-Box.md
@@ -2,7 +2,7 @@
 menu:
   main:
     parent: deployment
-title: Creating a local dev environment with VirtualBox
+title: Creating a Local Dev Environment with VirtualBox
 linktitle: Local
 ---
 


### PR DESCRIPTION
I couldn't find a reason to install 'curl' after running 'gem install bundler', these can go on the same line when installing Cloud Foundry dependencies
