### PR TITLE
split up pages around troubleshooting deployments

### DIFF
--- a/content/apps/basic-deploy-troubleshooting.md
+++ b/content/apps/basic-deploy-troubleshooting.md
@@ -3,7 +3,8 @@ menu:
   main:
     parent: apps
 title: Basic Deploy Troubleshooting
-weight: 10
+linktitle: Troubleshooting
+weight: 100
 ---
 
 The most direct way to view events related to your application through the deploy process is `cf logs APPNAME`. Used alone, `cf logs` will tail the combined stream of logs from each Cloud Foundry service involved in your application deploy. Running with the recent flag as in `cf logs APPNAME --recent` will stream the entire loggregator buffer for your app.
@@ -23,72 +24,62 @@ Responses to clients requests made to the application route.
 **STG:**
 Buildpack activity.
 
-##### Log Format:
+## Log Format
 
-Each line of log output has the following format: A timestamp, the source service / instance the type of output (OUT/ERR) and finally the output detail. 
+Each line of log output has the following format: A timestamp, the source service / instance the type of output (OUT/ERR) and finally the output detail.
 
 	Timestamp                   Svc/Ins      Type      Detail
 	2015-01-01T00:00:00.00-0400 [XXX/N]      OUT/ERR   ...
 
 **Example Log:**
-	       
+
 	2015-03-16T17:37:47.82-0400 [DEA/1]      OUT Starting app instance (index 0) with guid GUID
 	2015-03-16T17:37:50.85-0400 [DEA/1]      ERR Instance (index 0) failed to start accepting connections
 	2015-03-16T17:37:53.54-0400 [API/0]      OUT App instance exited with guid GUID0 payload: {"cc_partition"=>"default", "droplet"=>"GUID0", "version"=>"GUID1", "instance"=>"GUID2", "index"=>0, "reason"=>"CRASHED", "exit_status"=>127, "exit_description"=>"failed to accept connections within health check timeout", "crash_timestamp"=>1426541870}
 
-##### Common Problems and Recommended Practices:
+## Common Problems and Recommended Practices
 
-###### [STG] Staging Phase:
- 
-**Influences:**
- 
-App dependency specification.
+### [STG] Staging Phase
 
-- Dependencies are resolved during staging. For information beyond what's presented in `cf logs` Use the the verbose logging option for your buildpack if availble.
+#### App dependency specification
 
-	For example, `cf set-env APPNAME VERBOSE true` enables verbose logging for the default node.js buildpack.
+Dependencies are resolved during staging. For information beyond what's presented in `cf logs` Use the the verbose logging option for your buildpack if available.
 
-App size and build complexity.
+For example, `cf set-env APPNAME VERBOSE true` enables verbose logging for the default node.js buildpack.
 
-- Pushed application files must total less than 1GB. Use `.cfignore` to specify files which should be excluded from the push. 
-- The combined size of application files and the specified buildpack must totale less 1.5GB. 
+#### App size and build complexity
+
+- Pushed application files must total less than 1GB. Use `.cfignore` to specify files which should be excluded from the push.
+- The combined size of application files and the specified buildpack must totale less 1.5GB.
 - The entire compiled droplet must total less than 4GB.
 - Staging must complete with 15 minutes and application must start within 5 minutes by default.
 
-Buildpacks used.
+#### Buildpacks used.
 
-- Cloud Foundry will attempt to detect the buildpack to use with your app by examining the application files in search Use the `buildpack:` key in your manifest to specify a native buildpack by name or a custom buildpack by providing a URL. Override the buildpack setting and detection with the `-b` commandline switch which takes the same arguments.
+Cloud Foundry will attempt to detect the buildpack to use with your app by examining the application files in search Use the `buildpack:` key in your manifest to specify a native buildpack by name or a custom buildpack by providing a URL. Override the buildpack setting and detection with the `-b` commandline switch which takes the same arguments.
 
-###### [DEA] Droplet Execution Phase:
+### [DEA] Droplet Execution Phase
 
-**Influences:**
+#### App manifest contents
 
-App manifest contents.
+When starting multiple apps via a single manifest tree apps will start in the order they are encountered. Ensure worker apps running queues or migrations start before the apps which depend on them.
 
-- When starting multiple apps via a single manifest tree apps will start in the order they are encountered. Ensure worker apps running queues or migrations start before the apps which depend on them.
+#### Command line options to cf push
 
-Command line options to cf push. 
+By default, an application will start with a command specified by its buildpack. The `command:` in an application manifest will override the buildpack start command. The `-c` switch used with `cf push` overrides both the buildpack and manifest start commands.
 
-- By default, an application will start with a command specified by its buildpack. The `command:` in an application manifest will override the buildpack start command. The `-c` switch used with `cf push` overrides both the buildpack and manifest start commands. 
+Application start commands are cached during staging. Specifying a start command via `-c` does not update the staged command. Check the staged command with `cf files APPNAME app_staging.yml`. Specifying `-c 'null'` forces the buildpack start command to be used.
 
-	Application start commands are cached during staging. Specifying a start command via `-c` does not update the staged command. Check the staged command with `cf files APPNAME app_staging.yml`. Specifying `-c 'null'` forces the buildpack start command to be used. 
-
-Environment variables and service bindings.
+#### Environment variables and service bindings
 
 - Apps must listen on the port specified in the `VCAP_APP_PORT` environment variable.
 - Environment variables are updated when the app is staged and persist between application restarts. Be sure to run `cf restage` after updating an variables.
-- Specify services in the application manifest via the `application:key`, bindings will be created when the application is pushed. Avoid creating creating bindings after the fact with `cf bind-service` as that will create a hidden dependency 
+- Specify services in the application manifest via the `application:key`, bindings will be created when the application is pushed. Avoid creating creating bindings after the fact with `cf bind-service` as that will create a hidden dependency
 - Service instance credentials and connection parameters are stored the JSON formatted `VCAP_SERVICES`. The format of this variable differs between v1 and v2 services, see [this section](http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES) of the Cloud Foundry docs for more information.
 - Inspect the entire application environment including `VCAP_SERVICES` with `cf env APPNAME`.
 
-Application start up time.
+#### Application start up time
 
-- By default, applications must start with 60 seconds. This timeout can be extend to a maximum of 180 second via the `-t` command line switch or `timeout:` manifest key.
+By default, applications must start with 60 seconds. This timeout can be extend to a maximum of 180 second via the `-t` command line switch or `timeout:` manifest key.
 
-	Avoid placing long running or multi-step tasks in the application start command. Consider using worker apps as part of a multi-application manifest instead.
-
-
-
-
-
-
+Avoid placing long running or multi-step tasks in the application start command. Consider using worker apps as part of a multi-application manifest instead.

--- a/content/apps/deployment.md
+++ b/content/apps/deployment.md
@@ -3,6 +3,7 @@ menu:
   main:
     parent: apps
 title: General Deployment Tips
+linktitle: General Tips
 weight: -10
 ---
 

--- a/content/apps/durable-logging.md
+++ b/content/apps/durable-logging.md
@@ -2,7 +2,7 @@
 menu:
   main:
     parent: advanced
-title: Durable Logging with the ELK Service
+title: Durable Logging
 weight: 10
 ---
 

--- a/content/apps/logs.md
+++ b/content/apps/logs.md
@@ -1,0 +1,39 @@
+---
+menu:
+  main:
+    parent: apps
+title: Logs
+weight: 80
+---
+
+The most direct way to view events related to your application through the deploy process is `cf logs APPNAME`. Used alone, `cf logs` will tail the combined stream of logs from each Cloud Foundry service involved in your application deploy. Running with the recent flag as in `cf logs APPNAME --recent` will stream the entire loggregator buffer for your app.
+
+## Log types
+
+**API:**
+Calls to stop, start and update the application. Exit status of errors reported by the DEA.
+
+**App:**
+Stdout and stderr of the application start command.
+
+**DEA:**
+Responses to API stop, start and update calls.
+
+**RTR:**
+Responses to clients requests made to the application route.
+
+**STG:**
+Buildpack activity.
+
+## Log format
+
+Each line of log output has the following format: A timestamp, the source service / instance the type of output (OUT/ERR) and finally the output detail.
+
+  	Timestamp                   Svc/Ins      Type      Detail
+  	2015-01-01T00:00:00.00-0400 [XXX/N]      OUT/ERR   ...
+
+## Example log
+
+  	2015-03-16T17:37:47.82-0400 [DEA/1]      OUT Starting app instance (index 0) with guid GUID
+  	2015-03-16T17:37:50.85-0400 [DEA/1]      ERR Instance (index 0) failed to start accepting connections
+  	2015-03-16T17:37:53.54-0400 [API/0]      OUT App instance exited with guid GUID0 payload: {"cc_partition"=>"default", "droplet"=>"GUID0", "version"=>"GUID1", "instance"=>"GUID2", "index"=>0, "reason"=>"CRASHED", "exit_status"=>127, "exit_description"=>"failed to accept connections within health check timeout", "crash_timestamp"=>1426541870}

--- a/content/apps/logs.md
+++ b/content/apps/logs.md
@@ -6,34 +6,27 @@ title: Logs
 weight: 80
 ---
 
-The most direct way to view events related to your application through the deploy process is `cf logs APPNAME`. Used alone, `cf logs` will tail the combined stream of logs from each Cloud Foundry service involved in your application deploy. Running with the recent flag as in `cf logs APPNAME --recent` will stream the entire loggregator buffer for your app.
+The most direct way to view events related to your application through the deploy process is
 
-## Log types
+```bash
+cf logs APPNAME
+```
 
-**API:**
-Calls to stop, start and update the application. Exit status of errors reported by the DEA.
+Used alone, `cf logs` will tail the combined stream of logs from each Cloud Foundry service involved in your application deploy. Running with the `--recent` flag will stream the entire loggregator buffer for your app.
 
-**App:**
-Stdout and stderr of the application start command.
-
-**DEA:**
-Responses to API stop, start and update calls.
-
-**RTR:**
-Responses to clients requests made to the application route.
-
-**STG:**
-Buildpack activity.
-
-## Log format
-
-Each line of log output has the following format: A timestamp, the source service / instance the type of output (OUT/ERR) and finally the output detail.
-
-  	Timestamp                   Svc/Ins      Type      Detail
-  	2015-01-01T00:00:00.00-0400 [XXX/N]      OUT/ERR   ...
+```bash
+cf logs APPNAME --recent
+```
 
 ## Example log
 
   	2015-03-16T17:37:47.82-0400 [DEA/1]      OUT Starting app instance (index 0) with guid GUID
   	2015-03-16T17:37:50.85-0400 [DEA/1]      ERR Instance (index 0) failed to start accepting connections
   	2015-03-16T17:37:53.54-0400 [API/0]      OUT App instance exited with guid GUID0 payload: {"cc_partition"=>"default", "droplet"=>"GUID0", "version"=>"GUID1", "instance"=>"GUID2", "index"=>0, "reason"=>"CRASHED", "exit_status"=>127, "exit_description"=>"failed to accept connections within health check timeout", "crash_timestamp"=>1426541870}
+
+
+## See also
+
+* [Information about the log format](https://docs.cloudfoundry.org/devguide/deploy-apps/streaming-logs.html)
+* [Viewing your application's logs](https://docs.cloudfoundry.org/devguide/deploy-apps/streaming-logs.html#view)
+* [Setting up durable logging]({{< relref "apps/durable-logging.md" >}})

--- a/content/apps/multi-buildpack-deploys.md
+++ b/content/apps/multi-buildpack-deploys.md
@@ -3,7 +3,7 @@ date: 2015-07-10T14:32:59-04:00
 menu:
   main:
     parent: advanced
-title: Deploying Multi-language Projects
+title: Multi-language Projects
 weight: 10
 ---
 

--- a/content/apps/production-ready.md
+++ b/content/apps/production-ready.md
@@ -18,18 +18,17 @@ sample script.
 It is critical that your production application has more than one instance so if
 there any issue with one of the runners your app is on your app continues to work.
 
-### How:
+### How
 
-- Use a setting of `instances: 2` or more in your application `manifest.yml` to ensure your application is resilient when deployed.
-- Use `cf scale` to scale your running application instance count up and down.
+See the [multiple instances]({{< relref "multiple-instances.md" >}}) page.
 
 ## Prefer User Provided Services
 
 Prefer user provided services over environment variables for a secure centralized way to store application credentials and variables.
 
-### How:
+### How
 
-- Create user provided services with `cf cups` bind them with `cf bs`.
+Create user provided services with `cf cups` bind them with `cf bs`.
 
 ## NewRelic (or similar)
 

--- a/content/apps/troubleshooting.md
+++ b/content/apps/troubleshooting.md
@@ -2,7 +2,7 @@
 menu:
   main:
     parent: apps
-title: Basic Deploy Troubleshooting
+title: Deployment Troubleshooting
 linktitle: Troubleshooting
 weight: 100
 ---

--- a/content/apps/troubleshooting.md
+++ b/content/apps/troubleshooting.md
@@ -7,70 +7,40 @@ linktitle: Troubleshooting
 weight: 100
 ---
 
-The most direct way to view events related to your application through the deploy process is `cf logs APPNAME`. Used alone, `cf logs` will tail the combined stream of logs from each Cloud Foundry service involved in your application deploy. Running with the recent flag as in `cf logs APPNAME --recent` will stream the entire loggregator buffer for your app.
+Below are some common problems and recommended practices for solving them. Make sure to [look at the logs]({{< relref "logs.md" >}}) to help troubleshoot.
 
-**API:**
-Calls to stop, start and update the application. Exit status of errors reported by the DEA.
+## [STG] Staging Phase
 
-**App:**
-Stdout and stderr of the application start command.
-
-**DEA:**
-Responses to API stop, start and update calls.
-
-**RTR:**
-Responses to clients requests made to the application route.
-
-**STG:**
-Buildpack activity.
-
-## Log Format
-
-Each line of log output has the following format: A timestamp, the source service / instance the type of output (OUT/ERR) and finally the output detail.
-
-	Timestamp                   Svc/Ins      Type      Detail
-	2015-01-01T00:00:00.00-0400 [XXX/N]      OUT/ERR   ...
-
-**Example Log:**
-
-	2015-03-16T17:37:47.82-0400 [DEA/1]      OUT Starting app instance (index 0) with guid GUID
-	2015-03-16T17:37:50.85-0400 [DEA/1]      ERR Instance (index 0) failed to start accepting connections
-	2015-03-16T17:37:53.54-0400 [API/0]      OUT App instance exited with guid GUID0 payload: {"cc_partition"=>"default", "droplet"=>"GUID0", "version"=>"GUID1", "instance"=>"GUID2", "index"=>0, "reason"=>"CRASHED", "exit_status"=>127, "exit_description"=>"failed to accept connections within health check timeout", "crash_timestamp"=>1426541870}
-
-## Common Problems and Recommended Practices
-
-### [STG] Staging Phase
-
-#### App dependency specification
+### App dependency specification
 
 Dependencies are resolved during staging. For information beyond what's presented in `cf logs` Use the the verbose logging option for your buildpack if available.
 
 For example, `cf set-env APPNAME VERBOSE true` enables verbose logging for the default node.js buildpack.
 
-#### App size and build complexity
+### App size and build complexity
 
 - Pushed application files must total less than 1GB. Use `.cfignore` to specify files which should be excluded from the push.
 - The combined size of application files and the specified buildpack must totale less 1.5GB.
 - The entire compiled droplet must total less than 4GB.
 - Staging must complete with 15 minutes and application must start within 5 minutes by default.
 
-#### Buildpacks used.
+### Buildpacks used
 
 Cloud Foundry will attempt to detect the buildpack to use with your app by examining the application files in search Use the `buildpack:` key in your manifest to specify a native buildpack by name or a custom buildpack by providing a URL. Override the buildpack setting and detection with the `-b` commandline switch which takes the same arguments.
 
-### [DEA] Droplet Execution Phase
+## [DEA] Droplet Execution Phase
 
-#### App manifest contents
+### App manifest contents
 
 When starting multiple apps via a single manifest tree apps will start in the order they are encountered. Ensure worker apps running queues or migrations start before the apps which depend on them.
 
-#### Command line options to cf push
+### Command line options to cf push
 
 By default, an application will start with a command specified by its buildpack. The `command:` in an application manifest will override the buildpack start command. The `-c` switch used with `cf push` overrides both the buildpack and manifest start commands.
 
 Application start commands are cached during staging. Specifying a start command via `-c` does not update the staged command. Check the staged command with `cf files APPNAME app_staging.yml`. Specifying `-c 'null'` forces the buildpack start command to be used.
 
-#### Environment variables and service bindings
+### Environment variables and service bindings
 
 - Apps must listen on the port specified in the `VCAP_APP_PORT` environment variable.
 - Environment variables are updated when the app is staged and persist between application restarts. Be sure to run `cf restage` after updating an variables.
@@ -78,7 +48,7 @@ Application start commands are cached during staging. Specifying a start command
 - Service instance credentials and connection parameters are stored the JSON formatted `VCAP_SERVICES`. The format of this variable differs between v1 and v2 services, see [this section](http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES) of the Cloud Foundry docs for more information.
 - Inspect the entire application environment including `VCAP_SERVICES` with `cf env APPNAME`.
 
-#### Application start up time
+### Application start up time
 
 By default, applications must start with 60 seconds. This timeout can be extend to a maximum of 180 second via the `-t` command line switch or `timeout:` manifest key.
 


### PR DESCRIPTION
Some various changes:
- Cleaned up formatting on various pages
- Shortened some page titles so they fit in the sidebar better
- Split a page about logging out from the troubleshooting page
- Removed information that's explained (well) in the community docs
