### PR TITLE
add a page on managing teammates

### DIFF
--- a/content/apps/managing-teammates.md
+++ b/content/apps/managing-teammates.md
@@ -2,7 +2,7 @@
 menu:
   main:
     parent: advanced
-title: Managing teammates
+title: Managing Teammates
 weight: 10
 ---
 

--- a/content/apps/managing-teammates.md
+++ b/content/apps/managing-teammates.md
@@ -9,7 +9,8 @@ weight: 10
 To add a new teammate to your organization:
 
 1. [Send them an invite](https://login.cloud.gov/invitations/new).
-1. Run
+1. Confirm that they received the email.
+1. Once they have accepted the invite, run
 
     ```bash
     cf set-org-role <email> <org> OrgManager

--- a/content/apps/managing-teammates.md
+++ b/content/apps/managing-teammates.md
@@ -9,17 +9,29 @@ weight: 10
 To add a new teammate to your organization:
 
 1. [Send them an invite](https://login.cloud.gov/invitations/new).
-1. Confirm that they received the email.
-1. Once they have accepted the invite, run
+1. Confirm with them that they have received and accepted the invite.
+1. Ensure you are running version >= [6.14.0](https://github.com/cloudfoundry/cli/releases/tag/v6.14.0) of the CLI. If not, you will need to [upgrade](https://docs.cloudfoundry.org/devguide/installcf/install-go-cli.html).
+
+    ```bash
+    cf -v
+    ```
+
+1. To give them read-only permissions to the organization, run
+
+    ```bash
+    cf set-org-role <email> <org> OrgAuditor
+    ```
+
+1. If you want to make them an admin for your organization, run
 
     ```bash
     cf set-org-role <email> <org> OrgManager
     ```
 
-1. Add them to each space:
+1. If you want to give them permission to deploy, add them to each space:
 
     ```bash
     cf set-space-role <email> <org> <space> SpaceDeveloper
     ```
 
-[Learn more](https://docs.cloudfoundry.org/concepts/roles.html).
+[Learn more about Cloud Foundry roles](https://docs.cloudfoundry.org/concepts/roles.html).

--- a/content/apps/managing-teammates.md
+++ b/content/apps/managing-teammates.md
@@ -1,0 +1,24 @@
+---
+menu:
+  main:
+    parent: advanced
+title: Managing teammates
+weight: 10
+---
+
+To add a new teammate to your organization:
+
+1. [Send them an invite](https://login.cloud.gov/invitations/new).
+1. Run
+
+    ```bash
+    cf set-org-role <email> <org> OrgManager
+    ```
+
+1. Add them to each space:
+
+    ```bash
+    cf set-space-role <email> <org> <space> SpaceDeveloper
+    ```
+
+[Learn more](https://docs.cloudfoundry.org/concepts/roles.html).

--- a/content/getting-started/accounts.md
+++ b/content/getting-started/accounts.md
@@ -11,7 +11,7 @@ weight: -100
 You will need a Cloud Foundry account before continuing. To get an account:
 
 * **If you are a member of 18F:** post in #cloud-gov-support.
-* **If your organization/project is registered with cloud.gov:** ask one of your teammates to [send you an invite](https://login.cloud.gov/invitations/new).
+* **If your organization/project is registered with cloud.gov:** ask one of your teammates to follow [these instructions]({{< relref "managing-teammates.md" >}}).
 * **Otherwise:** see [who can use cloud.gov]({{< relref "intro/overview/who-can-use-cloudgov.md" >}}).
 
 ## Resetting your password


### PR DESCRIPTION
Right now, developers at 18F are asking the cloud.gov team to add new people that join teams, but with the invite functionality, I think this can be all self-service. Not positive these instructions are accurate, so please verify!
