### PR TITLE
thin down the First Deploy page

### DIFF
--- a/content/apps/deployment.md
+++ b/content/apps/deployment.md
@@ -30,11 +30,18 @@ The command to create a new app and to push a new version of an existing one are
 
 The app should now be live at `APPNAME.18f.gov`.
 
+## Caveats
+
+* Don't write to local storage (it's ephemeral) – use S3 [service]({{< relref "apps/managed-services.md" >}}) instead
+* Instances will be restarted if they exceed [memory limits]({{< relref "apps/limits.md" >}})
+* Proper [logging]({{< relref "apps/logs.md" >}}) might require special libraries/configuration for your app
+
 ## Twelve-Factor Apps
 
 In general, applications will be easiest to deploy to Cloud Foundry if they follow the [Twelve Factor App](http://12factor.net/) guidelines.
 
 ## Setting Environment Variables
+
 See Cloud Foundry's [documentation on environment variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html).
 
 ## Exclude files
@@ -55,3 +62,12 @@ A couple of important points on the `.cfignore`:
 ## Deployment notifications
 
 If you would like to be notified about deployments in your Slack channel, follow [these instructions](https://github.com/18F/hubot-cf-notifications#adding-applications), and add the [configuration](https://github.com/18F/hubot-cf-notifications#configuration) to [Charlie](https://github.com/18F/18f-bot/blob/master/cf_config.json).
+
+## Other stuff you might need to do
+
+* Connecting to a [service]({{< relref "apps/managed-services.md" >}})
+    * [Databases]({{< relref "apps/databases.md" >}})
+* Rollback
+    * Just `checkout` the old version and `cf-push`
+* [Running one-off commands]({{< relref "getting-started/cf-ssh.md" >}})
+* Deleting an application (`cf delete`)

--- a/content/getting-started/setup.md
+++ b/content/getting-started/setup.md
@@ -33,4 +33,4 @@ If you want to practice deploying, run the following before continuing:
 cf target -o sandbox -s <USERNAME>
 ```
 
-Your `USERNAME` is probably the part of your email before the `@`, e.g. `FIRSTNAME.LASTNAME`. When you're done, please `cf delete <APPNAME>`.
+Your `USERNAME` is probably the part of your email before the `@`, e.g. `FIRSTNAME.LASTNAME`. When you're done, please `cf delete <APPNAME>`. See the walkthrough for [your first deploy]({{< relref "your-first-deploy.md" >}}).

--- a/content/getting-started/your-first-deploy.md
+++ b/content/getting-started/your-first-deploy.md
@@ -16,32 +16,25 @@ The first thing to know is that cloud.gov is a stock instance of Cloud Foundry, 
 1. [Deploy a "hello world" application.](https://github.com/18F/cf-hello-worlds#readme)
 1. Tweak the app (without committing) and re-`push`.
 
+Note that the changes will be reflected in Cloud Foundry even without being committed to Git. Cloud Foundry is not Git-aware – it simply deploys whatever is contained in the directory that you `push` from. That being said, you _can_ set up [continuous deployment]({{< relref "apps/continuous-deployment.md" >}}) from a Git repository.
+
+Once you're ready to deploy your own application, head over to the [general deployment tips]({{< relref "apps/deployment.md" >}}).
+
 ## Explanation of the magic
 
-* [Concepts]({{< relref "concepts.md" >}})
-* Routing and what that means in terms of DNS/requests
-    * [Custom domains]({{< relref "apps/custom-domains.md" >}})
-* Packaging up the app (based on what's in that directory, so commit your code!)
+Take a look at the [Concepts]({{< relref "concepts.md" >}}) page.
 
 ## Caveats
 
 * Don't write to local storage (it's ephemeral) – use S3 [service]({{< relref "apps/managed-services.md" >}}) instead
-* Assets must be precompiled
 * Instances will be restarted if they exceed [memory limits]({{< relref "apps/limits.md" >}})
 * Proper [logging]({{< relref "apps/logs.md" >}}) might require special libraries/configuration for your app
-* [`.gitignore`/`.cfignore`]({{< relref "apps/deployment.md#exclude-files" >}})
 
 ## Other stuff you might need to do
 
-* [Continuous deployment]({{< relref "apps/continuous-deployment.md" >}})
 * Connecting to a [service]({{< relref "apps/managed-services.md" >}})
     * [Databases]({{< relref "apps/databases.md" >}})
 * Rollback
     * Just `checkout` the old version and `cf-push`
 * [One-off commands]({{< relref "getting-started/cf-ssh.md" >}})
 * Deleting an application
-
-## Useful links
-
-* [EPA training notes](https://docs.google.com/document/d/1HOWUV_cqwyfOXJ_2ssb_FU7pdHjhQGmvi1OKxxN0aCc/edit)
-* [@mhz's notes from one of the sessions](https://docs.google.com/document/d/10Ql-HrxVOm7KHld48HiZMSdONuy2TTUnB-bYVna8wz4/edit)

--- a/content/getting-started/your-first-deploy.md
+++ b/content/getting-started/your-first-deploy.md
@@ -18,23 +18,4 @@ The first thing to know is that cloud.gov is a stock instance of Cloud Foundry, 
 
 Note that the changes will be reflected in Cloud Foundry even without being committed to Git. Cloud Foundry is not Git-aware – it simply deploys whatever is contained in the directory that you `push` from. That being said, you _can_ set up [continuous deployment]({{< relref "apps/continuous-deployment.md" >}}) from a Git repository.
 
-Once you're ready to deploy your own application, head over to the [general deployment tips]({{< relref "apps/deployment.md" >}}).
-
-## Explanation of the magic
-
-Take a look at the [Concepts]({{< relref "concepts.md" >}}) page.
-
-## Caveats
-
-* Don't write to local storage (it's ephemeral) – use S3 [service]({{< relref "apps/managed-services.md" >}}) instead
-* Instances will be restarted if they exceed [memory limits]({{< relref "apps/limits.md" >}})
-* Proper [logging]({{< relref "apps/logs.md" >}}) might require special libraries/configuration for your app
-
-## Other stuff you might need to do
-
-* Connecting to a [service]({{< relref "apps/managed-services.md" >}})
-    * [Databases]({{< relref "apps/databases.md" >}})
-* Rollback
-    * Just `checkout` the old version and `cf-push`
-* [One-off commands]({{< relref "getting-started/cf-ssh.md" >}})
-* Deleting an application
+Next, take a look at the [Concepts]({{< relref "concepts.md" >}}) page. Once you're ready to deploy your own application, head over to the [general deployment tips]({{< relref "apps/deployment.md" >}}).


### PR DESCRIPTION
Now contains (what is close to) the minimal set of instructions.
