### PR TITLE
clarifying the timeframe for the sandbox resource cap

### DIFF
--- a/content/intro/pricing/rates.md
+++ b/content/intro/pricing/rates.md
@@ -57,7 +57,7 @@ Access package fees are charged yearly and are non-severable.
 
 You will be charged for resources as a factor of the memory your applications consume. 
 
-- Sandbox: Resource usage is capped to 1 GB.
+- Sandbox: Resource usage is capped to 1 GB/month.
 - All other packages: $0.0033 per MB reserved per day (~$99/GB/month)
 
 Resource usage fees are charged per quarter, tallied monthly, and severable.


### PR DESCRIPTION
@mogul, @dlapiduz, or another should confirm if it's correct that the 1 GB resource limit for sandbox accounts is per month, but if it is, this will help clarify the time period of that limit, since I didn't see one when reading it.  .  
