### PR TITLE
Add `cf files` documentation;

### DIFF
--- a/content/apps/databases.md
+++ b/content/apps/databases.md
@@ -62,3 +62,36 @@ To access a service database, use the [cf-ssh]({{< relref "getting-started/cf-ss
     ./psql/bin/psql $DATABASE_URL
 
 You should now have an open `psql` terminal connected to the service database.
+
+### Accessing files created on the server using cf files
+
+When accessing a database using `cf-ssh`, you may produce a database dump file
+and will very likely need to pull it down from the server. You can easily print
+out any file on your server to your terminal via the `cf files` command. You
+have to make sure you haven't disconnected from your ssh session that you
+created with `cf-ssh`.
+
+```sh
+cf files <APP_NAME> [PATH] [-i INSTANCE]
+```
+
+The `<APP_NAME>` can be found by running `cf apps` in your terminal. You should
+see an app named with a `-ssh` suffix. This is the `<APP_NAME>` you want to use
+to download files created within that instance.
+
+The `[PATH]` on the server begins with `app/` and is mapped to your project's
+working directory. To get the full path to a file you're looking for on the
+server, just run the `cf files` command without a path. This is similar to
+running `ls -log` on your local file system.
+
+```sh
+cf files <APP_NAME>
+```
+
+To save a file to your local machine, you can redirect the output from `stout`
+to a file using the `>` character and then a file path on your local machine.
+Here's an example:
+
+```sh
+cf files my-app-ssh app/path/to/database_dump.sql > ./database_dump.sql
+```

--- a/content/apps/databases.md
+++ b/content/apps/databases.md
@@ -93,5 +93,5 @@ to a file using the `>` character and then a file path on your local machine.
 Here's an example:
 
 ```sh
-cf files my-app-ssh app/path/to/database_dump.sql > ./database_dump.sql
+cf files my-app-ssh app/path/to/database_dump.sql | tail -n +4 > ./database_dump.sql
 ```


### PR DESCRIPTION
This patch adds documentation for `cf files` under Databases as it seems
to be the most useful when paired with accessing `psql` on the server.
