### PR TITLE
explain how to use short-lived apps to run one-off tasks

### DIFF
--- a/content/apps/databases.md
+++ b/content/apps/databases.md
@@ -55,7 +55,7 @@ The [dj_database_url](https://github.com/kennethreitz/dj-database-url#url-schema
 
 ## Access a postgres database using cf-ssh
 
-To access a service database, use the [cf-ssh]({{< relref "getting-started/cf-ssh.md" >}}) CLI to start an instance that is bound to the service and download the `psql` binary to that instance:
+To access a service database, use the [cf-ssh]({{< relref "getting-started/one-off-tasks.md" >}}) CLI to start an instance that is bound to the service and download the `psql` binary to that instance:
 
     cf-ssh APP_NAME
     curl https://s3.amazonaws.com/18f-cf-cli/psql-9.4.4-ubuntu-14.04.tar.gz | tar xvz

--- a/content/apps/databases.md
+++ b/content/apps/databases.md
@@ -55,7 +55,7 @@ The [dj_database_url](https://github.com/kennethreitz/dj-database-url#url-schema
 
 ## Access a postgres database using cf-ssh
 
-To access a service database, use the [cf-ssh]({{< relref "getting-started/one-off-tasks.md" >}}) CLI to start an instance that is bound to the service and download the `psql` binary to that instance:
+To access a service database, use the [cf-ssh]({{< relref "getting-started/one-off-tasks.md#cf-ssh" >}}) CLI to start an instance that is bound to the service and download the `psql` binary to that instance:
 
     cf-ssh APP_NAME
     curl https://s3.amazonaws.com/18f-cf-cli/psql-9.4.4-ubuntu-14.04.tar.gz | tar xvz

--- a/content/apps/deployment.md
+++ b/content/apps/deployment.md
@@ -69,5 +69,5 @@ If you would like to be notified about deployments in your Slack channel, follow
     * [Databases]({{< relref "apps/databases.md" >}})
 * Rollback
     * Just `checkout` the old version and `cf-push`
-* [Running one-off commands]({{< relref "getting-started/cf-ssh.md" >}})
+* [Running one-off commands]({{< relref "getting-started/one-off-tasks.md" >}})
 * Deleting an application (`cf delete`)

--- a/content/apps/rails.md
+++ b/content/apps/rails.md
@@ -29,7 +29,7 @@ See the official CF guide: [Getting Started Deploying Ruby on Rails Apps](http:/
     # etc.
     ```
 
-1. [SSH into the application]({{< relref "getting-started/cf-ssh.md" >}}), then run `rake db:setup`.
+1. [SSH into the application]({{< relref "getting-started/one-off-tasks.md" >}}), then run `rake db:setup`.
 
 Your app should now be live at `APP_NAME.18f.gov`!
 

--- a/content/apps/rails.md
+++ b/content/apps/rails.md
@@ -29,7 +29,7 @@ See the official CF guide: [Getting Started Deploying Ruby on Rails Apps](http:/
     # etc.
     ```
 
-1. [SSH into the application]({{< relref "getting-started/one-off-tasks.md" >}}), then run `rake db:setup`.
+1. Run `rake db:setup` as a [one-off task]({{< relref "getting-started/one-off-tasks.md" >}}).
 
 Your app should now be live at `APP_NAME.18f.gov`!
 

--- a/content/getting-started/one-off-tasks.md
+++ b/content/getting-started/one-off-tasks.md
@@ -3,6 +3,8 @@ menu:
   main:
     parent: advanced
 title: Running One Off Tasks
+aliases:
+- /getting-started/cf-ssh/
 ---
 
 There are a couple ways to run one off tasks in Cloud Foundry. The easiest one is running CF SSH.
@@ -17,7 +19,7 @@ Our `cf-ssh` is customized to our Cloud Foundry installation so please **do not 
 
 ### Install `cf-ssh`
 
-1. [Download `cf-ssh` for your environment](https://github.com/18F/cloud-foundry-scripts/releases/)
+1. [Download `cf-ssh` for your environment](https://github.com/18F/cloud-foundry-scripts/releases/).
 1. Run
 
     ```bash

--- a/content/getting-started/one-off-tasks.md
+++ b/content/getting-started/one-off-tasks.md
@@ -2,7 +2,7 @@
 menu:
   main:
     parent: advanced
-title: Running One Off Tasks
+title: Running One-Off Tasks
 aliases:
 - /getting-started/cf-ssh/
 ---
@@ -38,17 +38,24 @@ The idea here is that we are going to deploy a new application, but running the 
         * `domains`
         * `host`
         * `hosts`
+        * `instances`
         * `random-route`
     * Add [`no-route: true`](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#no-route).
-    * Set [`command`](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#start-commands) to be whatever you want to execute.
-1. Deploy the one-off app:
+    * Set the [`command`](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#start-commands) attribute to be the following:
+
+        ```yaml
+        command: (<your command> && echo SUCCESS || echo FAIL) && sleep infinity
+        ```
+
+1. Deploy the one-off app, and view the output:
 
     ```bash
     cf push -f task_manifest.yml
+    cf logs --recent task-runner
     ```
 
 1. If needed, use [`cf files`](http://cli.cloudfoundry.org/en-US/cf/files.html) to collect any artifacts.
-1. Run `cf delete task-runner` (or whatever you named the one-off app) to clean it up.
+1. Run `cf delete task-runner` to clean it up.
 
 ## CF SSH
 

--- a/content/getting-started/one-off-tasks.md
+++ b/content/getting-started/one-off-tasks.md
@@ -7,17 +7,56 @@ aliases:
 - /getting-started/cf-ssh/
 ---
 
-There are a couple ways to run one off tasks in Cloud Foundry. The easiest one is running CF SSH.
+There are a couple of ways to run one off tasks in Cloud Foundry. The most reliable way to do one-off tasks is by deploying a short-lived app.
+
+## Disclaimers
+
+* Both require a "complete" [application manifest](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) (which needs to include all of your service bindings, etc.) &mdash; if you don't have one yet, generate one from an existing app:
+
+    ```bash
+    cf create-app-manifest <APP_NAME> -p manifest.yml
+    ```
+
+* Both will spin up an instance of your environment uploading your **local** code.
+    * Note that this may not be in sync with your live app.
+    * You can leverage this fact to include files that your one-off task might need, such as a data file for importing.
+
+## Short-lived app
+
+The idea here is that we are going to deploy a new application, but running the one-off task, rather than starting a server or whatever it would normally do. Note that this will not work for any command that is interactive.
+
+1. Make a copy of your application manifest:
+
+    ```bash
+    cp manifest.yml task_manifest.yml
+    ```
+
+1. Modify the `task_manifest.yml`:
+    * Change the `name` value to be `task-runner` (or something descriptive).
+    * Remove the following attributes, if present:
+        * `domain`
+        * `domains`
+        * `host`
+        * `hosts`
+        * `random-route`
+    * Add [`no-route: true`](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#no-route).
+    * Set [`command`](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#start-commands) to be whatever you want to execute.
+1. Deploy the one-off app:
+
+    ```bash
+    cf push -f task_manifest.yml
+    ```
+
+1. If needed, use [`cf files`](http://cli.cloudfoundry.org/en-US/cf/files.html) to collect any artifacts.
+1. Run `cf delete task-runner` (or whatever you named the one-off app) to clean it up.
 
 ## CF SSH
 
-`cf-ssh` is a shared ssh session with an application container that you can connect to. This allows you to debug the environment and your application without disturbing a running container.
+Another way to run one-off commands is via `cf-ssh`. `cf-ssh` is a shared ssh session with an application container that you can connect to. This allows you to debug the environment and your application without disturbing a running container.
 
-`cf-ssh` will spin up an instance of your environment uploading your **local** code. Note that this may not be in sync with your running container.
+Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not use the community version or [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html)**.
 
-Our `cf-ssh` is customized to our Cloud Foundry installation so please **do not use the community version**.
-
-### Install `cf-ssh`
+### Installation
 
 1. [Download `cf-ssh` for your environment](https://github.com/18F/cloud-foundry-scripts/releases/).
 1. Run
@@ -30,8 +69,11 @@ Our `cf-ssh` is customized to our Cloud Foundry installation so please **do not 
 
 ### Usage
 
-1. If you don't have an [application manifest](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) yet, generate one from an existing app with `cf create-app-manifest <APP_NAME>`.
-1. In your project folder, run `cf-ssh -f <PATH_TO_MANIFEST>` (`-f` option only needed if the file isn't named `manifest.yml`).
-    * If you want to receive more feedback about what `cf-ssh` is doing please run it with the `--verbose` flag.
+1. In your project folder, run
+
+    ```bash
+    cf-ssh --verbose -f manifest.yml
+    ```
+
 1. The process takes between 2 to 10 minutes to start the session since it is compiling your application in the background. When it completes, you will see a command prompt.
 1. When done, run `exit`.

--- a/content/getting-started/one-off-tasks.md
+++ b/content/getting-started/one-off-tasks.md
@@ -61,7 +61,7 @@ The idea here is that we are going to deploy a new application, but running the 
 
 Another way to run one-off commands is via `cf-ssh`. `cf-ssh` is a shared ssh session with an application container that you can connect to. This allows you to debug the environment and your application without disturbing a running container.
 
-Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not use the community version or [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html)**.
+Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not use the community version or [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html)**. Also note that only one person can use `cf-ssh` for any particular app at any particular time.
 
 ### Installation
 


### PR DESCRIPTION
`cf-ssh` has been consistently unrelaible, so wanted to add information about a better way to run non-interactive tasks.

/cc @pkarman 
