### PR TITLE
Use USA disclaimer element above header

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -15,6 +15,16 @@
   </head>
 
   <body>
+
+    <div class="usa-disclaimer">
+      <div class="usa-grid">
+        <span class="usa-disclaimer-official">An official website of the United States Government
+          <img alt="US flag signifying that this is a United States Federal Government website" src="/img/us_flag_small.png">
+        </span>
+        <span class="usa-disclaimer-stage">This site is currently in alpha. <a href="https://18f.gsa.gov/dashboard/stages/#alpha">Learn more.</a></span>
+      </div>
+    </div>
+
     <!-- start header -->
     <header class="header">
       <div class="header-wrap">


### PR DESCRIPTION
In address 18f/cg-deck#187 I noticed that the disclaimer is missing on the docs site. There is also issue in this repo, so this closes #211.

This PR changes the header partial to match the rest of the cloud.gov sites with the `.usa-disclaimer` at the top.
