### PR TITLE
fix references to old repository name

### DIFF
--- a/content/apps/continuous-deployment.md
+++ b/content/apps/continuous-deployment.md
@@ -164,6 +164,6 @@ And setup the following environment variables in a "deploy target":
 
 You can also add the `alt_appname` attribute to do [Blue-Green deploys](http://docs.pivotal.io/pivotalcf/devguide/deploy-apps/blue-green.html).
 
-Example project: https://github.com/18F/cloud-foundry-notes/blob/master/wercker.yml.
+Example project: https://github.com/18F/cg-docs/blob/master/wercker.yml.
 
 ***

--- a/content/ops/repos.md
+++ b/content/ops/repos.md
@@ -28,7 +28,7 @@ We try to keep this page up-to-date, but you may find more repositories [on GitH
 
 ## Public domain
 
-This project is in the worldwide [public domain](https://github.com/18F/cloud-foundry-notes/blob/master/LICENSE.md). As stated in [CONTRIBUTING](https://github.com/18F/cloud-foundry-notes/blob/master/CONTRIBUTING.md):
+This project is in the worldwide [public domain](https://github.com/18F/cg-docs/blob/master/LICENSE.md). As stated in [CONTRIBUTING](https://github.com/18F/cg-docs/blob/master/CONTRIBUTING.md):
 
 > This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 >

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -49,7 +49,7 @@
               <a href="/help/"><i class='fa fa-life-ring'></i> <span>Help</span></a>
             </li>
             {{ if .IsPage }}
-            {{ $File := .File }}  {{with $File.Path }}<li><a href="https://github.com/18f/cloud-foundry-notes/edit/master/content/{{ $File.Dir }}{{ $File.LogicalName }}" target="blank"><i class='fa fa-edit'></i> Refine this Page</a> </li>{{end}}
+            {{ $File := .File }}  {{with $File.Path }}<li><a href="https://github.com/18f/cg-docs/edit/master/content/{{ $File.Dir }}{{ $File.LogicalName }}" target="blank"><i class='fa fa-edit'></i> Refine this Page</a> </li>{{end}}
             {{ end }}
   </ul>
 </aside>


### PR DESCRIPTION
Thankfully the old repository name redirects, but still best to fix it.
