### PR TITLE
clean up recommendations around static site generators

### DIFF
--- a/content/apps/assets.md
+++ b/content/apps/assets.md
@@ -7,7 +7,7 @@ title: Building Static Assets
 
 Applications with non-trivial static assets (javascript and css files) often include a build step to bundle and minify files.
 
-## Build assets on CI
+### Build assets on CI
 
 For applications [deployed from a continuous integration service]({{< relref "continuous-deployment.md" >}}), building assets on CI is a natural fit. Before deploying to cloud.gov, the CI service runs the asset build process. Then the compiled assets are pushed to cloud.gov along with the application code. Here's a minimal example for Travis CI:
 
@@ -33,7 +33,7 @@ Examples in the wild:
 
 * [eRegulations: Notice & comment](https://github.com/eregs/notice-and-comment)
 
-## Build assets on cloud.gov
+### Build assets on cloud.gov
 
 If the application and build process are implemented in the same language, assets can be built directly on cloud.gov on application start. Here's a minimal example for a node.js application:
 

--- a/content/apps/continuous-deployment.md
+++ b/content/apps/continuous-deployment.md
@@ -58,6 +58,7 @@ rvm:
 script: jekyll build ./_site
 deploy:
   skip_cleanup: true
+  # ...
 ```
 
 #### Additional resources

--- a/content/apps/continuous-deployment.md
+++ b/content/apps/continuous-deployment.md
@@ -35,61 +35,32 @@ A common pattern for team workflows is to use separate development and master br
 
 ```yaml
 deploy:
-  - manifest: manifest-staging.yml
-    # ...
-    on:
-      branch: develop
-  - manifest: manifest.yml
-    # ...
-    on:
-      branch: master
+- manifest: manifest-staging.yml
+  # ...
+  on:
+    branch: develop
+- manifest: manifest.yml
+  # ...
+  on:
+    branch: master
 ```
 
 Each manifest should at the very least define an unique `name`, but can also define an unique `host`. Also, it may be necessary to define unique services for each application to use. See [Cloning Applications]({{< relref "cloning.md" >}}) for more information.
 
+#### Jekyll
 
-#### Jekyll Site
-
-Deploying a Jekyll site requires a few changes to your `.travis.yml` and `manifest.yml` as well as the addition of a `Staticfile` and `Gemfile`. Add or update your Gemfile to include the jekyll gem.
-
-**Gemfile**
-
-```
-source "https://rubygems.org"
-
-gem "jekyll"
-```
-
-Add the following lines to the top of your `.travis.yml` to pull Ruby and build the site.
-
-**.travis.yml:**
+To deploy a Jekyll site, add the following to your `.travis.yml`:
 
 ```yaml
 language: ruby
 rvm:
 - 2.1
 script: jekyll build ./_site
+deploy:
+  skip_cleanup: true
 ```
 
-Add a Staticfile pointing to the root of the built site as specified above. The static buildpack will interpret with file.
-
-**Staticfile**
-
-```
-root: _site
-```
-
-Update manifest.yml to use the static buildpack.
-
-**manifest.yml**
-
-```
-buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
-```
-
-See [18F/notalone](https://github.com/18F/notalone) and [18F/18f.gsa.gov](https://github.com/18F/18f.gsa.gov) for working examples.
-
-**Additional Resources:**
+#### Additional resources
 
 - [Jekyll - Continuous Integration](http://jekyllrb.com/docs/continuous-integration/)
 - [Travis - Cloud Foundry Deployment](http://docs.travis-ci.com/user/deployment/cloudfoundry/)

--- a/content/apps/static.md
+++ b/content/apps/static.md
@@ -46,22 +46,19 @@ Deploy:
 $ cf push
 ```
 
+### Builds
+
+If you are using a static site generator (e.g. it uses [Jekyll]({{< relref "#jekyll" >}}) or [Hugo](http://gohugo.io/)) or and/or it requires dependencies to be installed at deploy-time, it's _especially_ recommended that you set up [continuous deployment]({{< relref "continuous-deployment.md" >}}). This way, the build happens in your Continuous Integration (CI) system rather than during the deploy itself within Cloud Foundry. This helps to make your deployments more reliable, have a smaller footprint, and reduce downtime.
+
 ### Jekyll
 
-Deploying a Jekyll site requires a few things:
+Deploying a [Jekyll](http://jekyllrb.com/) site requires a few things:
 
-* Add or update your `Gemfile` to include the jekyll gem.
+* Add or update your `Gemfile` to include the `jekyll` gem.
 
     ```ruby
     source 'https://rubygems.org'
     gem 'jekyll'
-    ```
-
-* Add the following lines to the top of your `.travis.yml` to pull Ruby and build the site.
-
-    ```yaml
-    language: ruby
-    script: jekyll build ./_site
     ```
 
 * Add a `Staticfile` pointing to the root of the built site as specified above. The [static buildpack](https://github.com/cloudfoundry/staticfile-buildpack) will interpret with file.

--- a/content/apps/static.md
+++ b/content/apps/static.md
@@ -5,6 +5,8 @@ menu:
 title: Deploying Static Sites
 ---
 
+### Basics
+
 Create `index.html`:
 
 ```
@@ -44,25 +46,37 @@ Deploy:
 $ cf push
 ```
 
-### Continuous deployment with Travis-CI
+### Jekyll
 
-Add your repo to Travis-CI.
+Deploying a Jekyll site requires a few things:
 
-Create a `.travis.yml` file with `edge` set to `true`:
+* Add or update your `Gemfile` to include the jekyll gem.
 
-```yml
-edge: true
-```
+    ```ruby
+    source 'https://rubygems.org'
+    gem 'jekyll'
+    ```
 
-Run the Cloud Foundry set-up script:
+* Add the following lines to the top of your `.travis.yml` to pull Ruby and build the site.
 
-```
-$ travis setup cloudfoundry
-```
+    ```yaml
+    language: ruby
+    script: jekyll build ./_site
+    ```
 
-Follow the prompts. When you're done, the script will have appended all the necessary markup to the `.travis.yml` file.
+* Add a `Staticfile` pointing to the root of the built site as specified above. The [static buildpack](https://github.com/cloudfoundry/staticfile-buildpack) will interpret with file.
 
-Once you merge a Pull Request, Travis will run and deploy the site.
+    ```yaml
+    root: _site
+    ```
+
+* Update `manifest.yml` to use the [static buildpack](https://github.com/cloudfoundry/staticfile-buildpack).
+
+    ```yaml
+    buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    ```
+
+See [18F/notalone](https://github.com/18F/notalone) and [18F/18f.gsa.gov](https://github.com/18F/18f.gsa.gov) for working examples.
 
 ### Redirect all traffic
 


### PR DESCRIPTION
There was information living on the wrong pages, and some information duplicated, so cleaned that up. Also added a section recommending that static site builds should occur _outside_ of Cloud Foundry.
