### PR TITLE
switch to simple heading IDs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,8 @@ publishdir = "public"
 [params]
   description = "Cloud.gov documentation"
   author = "18f"
+[blackfriday]
+  plainIDAnchors = true
 
 [[menu.main]]
     name = "Introduction"


### PR DESCRIPTION
Before and after:

<img width="733" alt="screen shot 2016-05-13 at 4 02 28 pm" src="https://cloud.githubusercontent.com/assets/86842/15260311/2c9d2050-1924-11e6-99fd-21f9007c4fa2.png">

No real benefit to the longer ones, from what I can tell. Not sure why that's the default.

http://gohugo.io/overview/configuration/#configure-blackfriday-rendering
