### PR TITLE
Change USERNAME to SPACE in "Getting Started" setup

### DIFF
--- a/content/getting-started/setup.md
+++ b/content/getting-started/setup.md
@@ -30,7 +30,7 @@ If you want to practice deploying, run the following before continuing:
 
 
 ```bash
-cf target -o sandbox -s <USERNAME>
+cf target -o sandbox -s <SPACE>
 ```
 
-Your `USERNAME` is probably the part of your email before the `@`, e.g. `FIRSTNAME.LASTNAME`. When you're done, please `cf delete <APPNAME>`. See the walkthrough for [your first deploy]({{< relref "your-first-deploy.md" >}}).
+Your `SPACE` is probably the part of your email before the `@`, e.g. `FIRSTNAME.LASTNAME`. When you're done, please `cf delete <APPNAME>`. See the walkthrough for [your first deploy]({{< relref "your-first-deploy.md" >}}).


### PR DESCRIPTION
As an experiment, I was trying to set up travis CI integration for an experimental branch of a repository, so that it would deploy to my sandbox.

While following the [Deploying Static Sites](https://docs.cloud.gov/apps/static/) instructions, I was confused when `travis setup cloudfoundry` asked me for information. Specifically:
- When it asked for my `username`, I assumed this was my `FIRSTNAME.LASTNAME` because that is what I typed as my `USERNAME` in the "Getting Started" setup.
- When it asked for my `space`, I had no idea what to write.

It was only when closely examining the output of `cf target` that I realized that my username was actually my email, and my space was actually what I _thought_ my username was (i.e., `FIRSTNAME.LASTNAME`). I think this confusion may have been alleviated if the "Getting Started" section used what appears to be the correct terminology. However, I'm also very new to cloud foundry so I could be wrong.
