### PR TITLE
Link to staticfile buildpack docs.

### DIFF
--- a/content/apps/static.md
+++ b/content/apps/static.md
@@ -88,4 +88,4 @@ http {
 Deploy your application to `NEW_DOMAIN_NAME` and then `cf push` a simple static site with that `nginx.conf`
 configuration to the old domain name. You can see a [full working example](https://github.com/18F/c2-redirect).
 
-You can read more about [nginx customization](https://github.com/cloudfoundry/staticfile-buildpack#advanced-nginx-configuration).
+You can read more about nginx customization at the [Staticfile Buildpack documentation](http://docs.cloudfoundry.org/buildpacks/staticfile/).


### PR DESCRIPTION
In https://github.com/cloudfoundry/staticfile-buildpack/commit/2082dafa5c37468e706bb777aa109ac1de2c9601 the cloudfoundry folks moved all the static buildpack docs to a centralized place at http://docs.cloudfoundry.org/buildpacks/staticfile, so this PR fixes the link.
