### PR TITLE
Update url for CF-SSH

### DIFF
--- a/content/getting-started/one-off-tasks.md
+++ b/content/getting-started/one-off-tasks.md
@@ -65,7 +65,7 @@ Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not
 
 ### Installation
 
-1. [Download `cf-ssh` for your environment](https://github.com/18F/cloud-foundry-scripts/releases/).
+1. [Download `cf-ssh` for your environment](https://github.com/18F/cf-ssh/releases/).
 1. Run
 
     ```bash

--- a/content/getting-started/one-off-tasks.md
+++ b/content/getting-started/one-off-tasks.md
@@ -65,7 +65,7 @@ Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not
 
 ### Installation
 
-1. [Download `cf-ssh` for your environment](https://github.com/18F/cf-ssh/releases/).
+1. [Download `cf-ssh` for your environment](https://github.com/18F/cf-ssh/releases/) ([source](https://github.com/18F/cf-ssh/tree/18f)).
 1. Run
 
     ```bash


### PR DESCRIPTION
Moving the releases to the cf-ssh repo in the 18F org
