### PR TITLE
Add section on running django manage.py commands

### DIFF
--- a/content/apps/django.md
+++ b/content/apps/django.md
@@ -147,3 +147,7 @@ cf push APPNAME
 ```
 
 It should now be running at `APPNAME.18f.gov`!
+
+### Running management commands
+
+You may want to run `manage.py` commands on your app to perform maintenance tasks and such. For more information on doing this, see the guide on [Running One-Off Tasks](/getting-started/one-off-tasks/).


### PR DESCRIPTION
This adds a tiny section to the Django guide on running management commands, which just points the user to the [running one-off tasks](https://docs.cloud.gov/getting-started/one-off-tasks/) guide.
