### PR TITLE
make the manifest used by the deployment pipeline configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out
 tmp
 node_modules
 credentials.yml
+credentials.fr.yml

--- a/ci/credentials.example.yml
+++ b/ci/credentials.example.yml
@@ -6,6 +6,7 @@ cf-space: docs
 
 cg-docs-git-url: https://github.com/18F/cg-docs.git
 cg-docs-branch: master
+cg-docs-manifest: cg-docs-compiled/manifest.yml
 
 slack-webhook-url: URL
 slack-channel: '#cloud-gov-liberator'

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -48,7 +48,7 @@ jobs:
           cp -R . ../cg-docs-compiled
   - put: cloud-gov-production
     params:
-      manifest: cg-docs-compiled/ci/manifest.fr.yml
+      manifest: {{cg-docs-manifest}}
       path: cg-docs-compiled
       current_app_name: docs
     on_failure:


### PR DESCRIPTION
This helps since the pipeline is now being used for deploying docs.cloud.gov _and_ docs.fr.cloud.gov.
