### PR TITLE
Copyediting IR Checklist and Guide for consistency and clarity

### DIFF
--- a/content/ops/security-ir-checklist.md
+++ b/content/ops/security-ir-checklist.md
@@ -7,29 +7,29 @@ title: Security IR Checklist
 
 # Security Incident Response Checklist
 
-*This is a short, actionable checklist for the IC to follow during incident response. It's a companion to the detailed [IR guide]({{< relref "security-ir.md" >}}), where you can find the full messy details of each step.*
+*This is a short, actionable checklist for the Incident Commander (IC) to follow during incident response. It's a companion to the [IR guide]({{< relref "security-ir.md" >}}), where you can find the full details of each step.*
 
 ## Initiate
 
 You've just responded to a possible security incident. Congratulations, you're now the Incident Commander (IC)! Follow these steps:
 
-- Create an issue in the [security-incidents](https://github.com/18f/security-incidents) github repo ([use this template]({{< relref "security-ir.md#initiate" >}}))
-- Move incident discussion to `#incident-response`
-- If needed, create a Google Doc to track sensitive information that can't be shared in Slack/Github
-- If needed, start a Google Hangout for responders
+- Create an issue ([using this template]({{< relref "security-ir.md#initiate" >}})) in the [security-incidents](https://github.com/18f/security-incidents) GitHub repository.
+- Move incident discussion to [`#incident-response`](https://18f.slack.com/messages/incident-response/).
+- If needed, create a Google Doc to track sensitive information that can't be shared in Slack/GitHub.
+- If needed, start a Google Hangout for responders.
 - Notify `gsa-ir@gsa.gov` and `devops@gsa.gov` of the investigation. **This needs to happen within one hour.**
 
 ## Assess
 
-- Confirm the incident - Is it a real incident?
-    - If it's not a real incident, go to [false alarm](#false-alarm)
-- Assess the severity, using [the rubric in the IR guide]({{< relref "security-ir.md#incident-severities" >}})
-- Update the github issue:
-    - Status -> "confirmed"
-    - Severity -> high/medium/low
+- Confirm the incident — is it a real incident?
+    - If it's not a real incident, go to [False Alarm](#false-alarm).
+- Assess the severity, using [the rubric in the IR guide]({{< relref "security-ir.md#incident-severities" >}}).
+- Update the GitHub issue:
+    - Status → "confirmed"
+    - Severity → high/medium/low
     - List of responders
-- Send an initial sitrep ([example]({{< relref "security-ir.md#assess" >}})) to: 
-    - Post in `#incident-response`
+- Send an initial situation report (“sitrep”) ([example sitrep]({{< relref "security-ir.md#assess" >}})) to: 
+    - Post in [`#incident-response`](https://18f.slack.com/messages/incident-response/)
     - Email to `gsa-ir@gsa.gov` and `devops@gsa.gov`
     - Email/Slack other stakeholders, if applicable
 
@@ -38,36 +38,36 @@ You've just responded to a possible security incident. Congratulations, you're n
 - Keep the ticket/docs updated as people work, tracking:
     - Leads, and who's following them
     - Remediation items, and who's working on them
-- Send out sitreps on a regular cadence (high: hourly; medium: 2x daily; low: daily)
-- Go into work shifts if the incident lasts longer then 3 hours
-- [hand off IC](#handing-off-ic) if the incident lasts longer than 3 hours
+- Send out sitreps on a regular cadence (high: hourly; medium: 2x daily; low: daily).
+- Go into work shifts if the incident lasts longer then 3 hours.
+- [Hand off IC](#handing-off-ic) if the incident lasts longer than 3 hours.
 
 Once the incident is resolved:
 
-- Update the ticket, set status -> "resolved"
-- Send a final sitrep to stakeholders
-- Schedule a retrospective
+- Update the ticket, set status → "resolved".
+- Send a final sitrep to stakeholders.
+- Schedule a retrospective.
 - Thank everyone involved for their service!
 
 ## Special situations
 
-Some extra checklists for special situations that don't always occur during incidents:
+Extra checklists for special situations that don't always occur during incidents:
 
 ### False Alarm
 
 Follow this checklist if an event turns out not to be a security incident:
 
-- Update the Github issue, setting status to `false alarm`
-- Close the Github issue
-- Notify `gsa-ir@gsa.gov` of the false alarm
+- Update the GitHub issue, setting status to `false alarm`.
+- Close the GitHub issue.
+- Notify `gsa-ir@gsa.gov` of the false alarm.
 - If any sitreps have been sent out, send a final sitrep to all previous recipients, noting the false alarm.
 
 ### Handing off IC
 
-Follow this checklist of you need to hand over IC duties
+Follow this checklist if you need to hand over IC duties:
 
-- Old IC: brief New IC on the situation
-- New IC: confirm that you're taking over
-- New IC: update github issue, noting that you're now the IC
-- New IC: send out a sitrep, noting that you're taking over IC
-- Old IC: stick around for 15-20 minutes to ensure a smooth handoff, then logoff!
+- Old IC: brief New IC on the situation.
+- New IC: confirm that you're taking over.
+- New IC: update GitHub issue, noting that you're now the IC.
+- New IC: send out a sitrep, noting that you're taking over IC.
+- Old IC: stick around for 15-20 minutes to ensure a smooth handoff, then log off!

--- a/content/ops/security-ir.md
+++ b/content/ops/security-ir.md
@@ -5,9 +5,9 @@ menu:
 title: Security IR Guide
 ---
 
-# cloud.gov Incident Response process
+# Security Incident Response Guide
 
-This document outlines cloud.gov's process for responding to security incidents. It outlines roles and responsibilities during and after incidents, and lays out the steps we'll take to resolve them.
+This document outlines cloud.gov's process for responding to security incidents. It outlines roles and responsibilities during and after incidents, and it lays out the steps we'll take to resolve them. *If you're responding to an incident, [here's our IR checklist]({{< relref "security-ir-checklist.md" >}}) as a short, actionable companion to this guide.*
 
 ## Overview
 
@@ -15,8 +15,8 @@ At a high level, incident response follows this process:
 
 [Initiate](#initiate):
 
-- Someone - the *reporter* - reports an incident to the cloud.gov team in `#cloud-gov`. The first responder on the cloud.gov team becomes the initial *Incident Commander* (IC).
-- The IC creates an issue in the [security-incidents](https://github.com/18f/security-incidents) github repo to track the event and notifies GSA IT.
+- Someone (the *reporter*) reports an incident to the cloud.gov team in [`#cloud-gov`](https://18f.slack.com/messages/cloud-gov/). The first responder on the cloud.gov team becomes the initial *Incident Commander* (IC).
+- The IC creates an issue in the [security-incidents](https://github.com/18f/security-incidents) GitHub repository to track the event and notifies GSA IT.
 
 [Assess](#assess):
 
@@ -30,13 +30,13 @@ At a high level, incident response follows this process:
 
 [Retrospective](#retrospective):
 
-- The responding team holds a retrospective to analyize the incident, capture follow-ups and lessons-learned, and writes a formal report.
+- The responding team holds a retrospective to analyze the incident, capture follow-ups and lessons-learned, and write a formal report.
 
 During this process, the team communicates in the following places:
 
-- Situation updates, investigation notes, and other relevent information gets captured in the Github issue created to track this event.
-- Real-time communication happens in Slack, in the `#incident-response` channel.
-- If needed, the team can use a Google Hangout and/or Google Docs to share information that's not appropriate for Slack or Github (PII, etc.).
+- Situation updates, investigation notes, and other relevant information gets captured in the GitHub issue created to track this event.
+- Real-time communication happens in Slack, in the [`#incident-response`](https://18f.slack.com/messages/incident-response/) channel.
+- If needed, the team can use a Google Hangout and/or Google Docs to share information that's not appropriate for Slack or GitHub (PII, etc.).
 
 For full details, read on.
 
@@ -46,11 +46,11 @@ For full details, read on.
 
 An incident begins when someone (the *reporter*) becomes aware of a potential incident. We define "incident" broadly, following [NIST SP 800-61](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf), as "a violation or imminent threat of violation of computer security policies, acceptable use policies, or standard security practices" (6). This is a deliberately broad definition, designed to encompass any scenario that might threaten the security of cloud.gov.
 
-The reporter should contact the cloud.gov team in `#cloud-gov` to begin the response process. They should escalate by contacting the cloud.gov leads directly until they receive acknowledgment of their report. The final escalation point is to page the infrastructure lead, whose contact info is in the channel details of `#incident-response`.
+The reporter should contact the cloud.gov team in [`#cloud-gov`](https://18f.slack.com/messages/cloud-gov/) to begin the response process. They should escalate by contacting the cloud.gov leads directly until they receive acknowledgment of their report. The final escalation point is to page the infrastructure lead, whose contact info is in the channel details of [`#incident-response`](https://18f.slack.com/messages/incident-response/).
 
-The first responder at this point becomes *Incident Commander* (IC), and carries out the next steps in the response. The IC's responsibility is coordination, not necessarily investigation. The IC's primary role is to guide the process. The first responder may remain IC throughout the process, or they may hand off IC duties later in the process.
+The first responder at this point becomes *Incident Commander* (IC) and carries out the next steps in the response. The IC's responsibility is coordination, not necessarily investigation. The IC's primary role is to guide the process. The first responder may remain IC throughout the process, or they may hand off IC duties later in the process.
 
-The first step for the IC is to create an issue in the [`security-incidents`](https://github.com/18f/security-incidents) github repo. Copy the following template to create the issue:
+The first step for the IC is to create an issue in the [`security-incidents`](https://github.com/18f/security-incidents) GitHub repository. Copy the following template to create the issue:
 
 ```
 Short description of what's going on
@@ -68,14 +68,14 @@ The IC is responsible for keeping this issue up-to-date as investigation and rem
 
 #### Comms at the Initiate phase
 
-Note that at this point the issue's status is "investigating" - we haven't confirmed that it's really an issue yet. So, we should actually refer to this as just an "event" at this point; it doesn't become an "incident" until we've confirmed it. 
+Note that at this point the issue's status is "investigating" — we haven't confirmed that it's really an issue yet. So, we should actually refer to this as just an "event" at this point; it doesn't become an "incident" until we've confirmed it. 
 
 At this phase, communications should follow these guidelines: 
 
 - The IC should inform GSA IT and our devops teams of the investigation by emailing `gsa-ir@gsa.gov` and `devops@gsa.gov`. **This needs to happen within 1 hour.**
-- Updates should be posted to the Github issue.
-- Real-time chat should happen in `#incident-response`
-- The IC may start a Google Hangout and/or create Google Docs so that responders can share sensitive information not suitable for sharing in Github or Slack.
+- Updates should be posted to the GitHub issue.
+- Real-time chat should happen in [`#incident-response`](https://18f.slack.com/messages/incident-response/).
+- The IC may start a Google Hangout and/or create Google Docs so that responders can share sensitive information not suitable for sharing in GitHub or Slack.
 
 ### Assess
 
@@ -111,13 +111,14 @@ We've confirmed reports of escaped chickens. Looks like a fox may have tunneled 
 ```
 
 This sitrep should be:
-- posted in `#incident-response`
-- emailed to `gsa-ir@gsa.gov` and `devops@gsa.gov`
-- sent (email or Slack) to external stakeholders, if applicable and relevent
+
+- Posted in [`#incident-response`](https://18f.slack.com/messages/incident-response/)
+- Emailed to `gsa-ir@gsa.gov` and `devops@gsa.gov`
+- Sent (email or Slack) to external stakeholders, if applicable and relevant
 
 #### Comms at the Assess phase
 
-Updates and real-time chat should continue as above (updates on the issue, chat in Slack or Google Hangouts). 
+Updates and real-time chat should continue as above (updates on the GitHub issue, chat in Slack or Google Hangouts). 
 
 ### Remediate
 
@@ -125,9 +126,9 @@ At this point, we're trying to fix the issue! Remediation will be very situation
 
 - The IC's responsibility is coordination, communication, and information-collection. The remediation team will be focused on resolving the issue, so it's up to the IC to make sure that we properly track what happened, how we're fixing it, who's doing what, etc. Ideally, the notes kept by the IC should be sufficient for an outside investigator to independently follow the work of the response team and validate the team's work.
 
-- The team will develop a list of **leads** -- actionable information about breaches, stolen data, etc. The IC should track these leads, maintain information about which are being investigated (and by whom), and what information that investigation leads. These can be tracked as checklists in the Github issue.
+- The team will develop a list of **leads** — actionable information about breaches, stolen data, etc. The IC should track these leads, maintain information about which are being investigated (and by whom), and what information that investigation leads. These can be tracked as checklists in the GitHub issue.
 
-- Similarly, the team will develop a list of **remediation steps**. The IC is likewise responsible for tracking those, making sure they're assigned and followed-up, and verifying them as they're completed. These may be tracked in the central Github issue as well. The IC should distinguish between immediate concerns which should be completed before the incident is considered resolved and long-term improvements/hardening which can be deferred to the Retrospective.
+- Similarly, the team will develop a list of **remediation steps**. The IC is likewise responsible for tracking those, making sure they're assigned and followed-up, and verifying them as they're completed. These may be tracked in the central GitHub issue as well. The IC should distinguish between immediate concerns which should be completed before the incident is considered resolved and long-term improvements/hardening which can be deferred to the Retrospective.
 
 - The response team should aim to adopt a *containment* strategy: if machines are compromised, they should avoid destroying or shutting them down if possible (this can hamper forensics). For AWS instances, you can leave the instance running and instead reconfigure the Security Group for the instance to drop all ingress and egress traffic until forensics can be performed.
 
@@ -135,7 +136,7 @@ At this point, we're trying to fix the issue! Remediation will be very situation
 
     - For High-severity incidents, the team should take action immediately, even if this causes disruption. A notification about the disruption should be sent out as soon as possible, but the team needs no permission to take action at this level.
 
-    - For Medium-severity incidents, the team should notify the cloud.gov leads (Diego & Bret) of the planned action, and help them assess the relative risk of disruption vs security. If the leads are unavailable via Slack, they should be contacted using phone info from their Slack profiles. The team should reach a collaborative decision on action, with a bias towards disruption. If they can't be reached within 1 hour, the team may take action without them.
+    - For Medium-severity incidents, the team should notify the cloud.gov leads (Diego and Bret) of the planned action, and help them assess the relative risk of disruption vs. security. If the leads are unavailable via Slack, they should be contacted using the phone numbers in their Slack profiles. The team should reach a collaborative decision on action, with a bias towards disruption. If they can't be reached within 1 hour, the team may take action without them.
 
     - For Low-severity issues, the team should notify as above, and not take action until a mutually-agreed-on course of action has been determined.
 
@@ -145,27 +146,27 @@ At this point, we're trying to fix the issue! Remediation will be very situation
 
     - For 24/7 responses, the IC should begin shift-planning. Generally, responders should only work 3 hour shifts, so the IC should begin scheduling shifts and sending people "home" to preserve their ability to function.
 
-    - The IC also needs to get into rotation -- again, 3 hour shifts are about the maximum suggested. So, the IC should likely hand off duties at this point.
+    - The IC also needs to get into rotation — again, 3 hour shifts are about the maximum suggested. So, the IC should likely hand off duties at this point.
 
-Once the incident is no longer active -- i.e. the breach has been contained, the issue has been fixed, etc. -- the IC should spin down the incident. There may still be longer-term remediation needed, and possibly more investigation, but as long as the incident is no longer active these activities can proceed at the regular pace of business. To close out an incident, the IC should:
+Once the incident is no longer active — i.e. the breach has been contained, the issue has been fixed, etc. — the IC should spin down the incident. There may still be longer-term remediation needed, and possibly more investigation, but as long as the incident is no longer active these activities can proceed at the regular pace of business. To close out an incident, the IC should:
 
-- Set the status of the incident to "resolved"
-- Send a final sitrep to stakeholders
+- Set the status of the incident to "resolved".
+- Send a final sitrep to stakeholders.
 - Thank everyone involved for their service!
 
 #### Comms at the Remediate phase
 
-- Updates and real-time chat should continue as above (updates on the issue, chat in Slack or Google Hangouts). 
+- Updates and real-time chat should continue as above (updates on the GitHub issue, chat in Slack or Google Hangouts). 
 
-- The IC should continue to post updated sitreps on a regular cadence (the section on severities, below, suggests should cadences for each level). These sitreps should be sent to Slack, to GSA-IT and US-CERT via email, and to any other stakeholders identified throughout the process (e.g. clients).
+- The IC should continue to post updated sitreps on a regular cadence (the section on severities, below, suggests cadences for each level). These sitreps should be sent to Slack, to GSA-IT and US-CERT via email, and to any other stakeholders identified throughout the process (e.g. clients).
 
 ### Retrospective
 
-The final step in handling a security incident is figuring out what we learned. The IC (or one of the ICs, if there were multiple, or a designated other party) should lead a retrospective and develop an incident report. 
+The final step in handling a security incident is figuring out what we learned. The IC (or one of the ICs if there were multiple, or a designated other party) should lead a retrospective and develop an incident report. 
 
 Conducting retrospectives is out of the scope of this document, but as a crash course, here's an [introduction to blameless postmortems](https://codeascraft.com/2012/05/22/blameless-postmortems/).
 
-The report should contain a timelines of the incident, details about how the incident progressed, and information about the vulnerabilities that led to the incident. A cause analysis is an important part of this report; the team should use tools like [Infinite Hows](http://www.kitchensoap.com/2014/11/14/the-infinite-hows-or-the-dangers-of-the-five-whys/) or [Five Whys](https://en.wikipedia.org/wiki/5_Whys) to try to dig into causes, how future incidents could be prevented, how responses could be better in the future, etc.
+The report should contain a timeline of the incident, details about how the incident progressed, and information about the vulnerabilities that led to the incident. A cause analysis is an important part of this report; the team should use tools such as [Infinite Hows](http://www.kitchensoap.com/2014/11/14/the-infinite-hows-or-the-dangers-of-the-five-whys/) or [Five Whys](https://en.wikipedia.org/wiki/5_Whys) to try to dig into causes, how future incidents could be prevented, how responses could be better in the future, etc.
 
 The report should also contain some basic response metrics:
 
@@ -174,7 +175,7 @@ The report should also contain some basic response metrics:
 - Time to containment (how long did it take from when we became aware until the issue was contained?)
 - Threat actions (which specific actions -- e.g. phishing, password attacks, etc) -- were taken by the actor)?
 
-This report should be posted as a final comment on the Github issue, which can then be closed.
+This report should be posted as a final comment on the GitHub issue, which can then be closed.
 
 ## Incident Severities
 
@@ -184,7 +185,7 @@ Note the severities may (and often will) change during the lifecycle of the inci
 
 ### 1 - High Severity
 
-High-sev incidents successfully compromise the confidentiality/integrity of Personally Identifiable Information (PII), impacts the availability of services for a large number of customers, or has significant financial impact. Examples include:
+High-sev incidents successfully compromise the confidentiality/integrity of Personally Identifiable Information (PII), impact the availability of services for a large number of customers, or have significant financial impact. Examples include:
 
 - Confirmed breach of PII
 - Successful root-level compromise of production systems
@@ -193,7 +194,7 @@ High-sev incidents successfully compromise the confidentiality/integrity of Pers
 
 Guidelines for addressing High-sev issues:
 
-- Work will likely be 24/7 (e.g. work until the issue is contained)
+- Work will likely be 24/7 (e.g. work until the issue is contained).
 - Responders are empowered to take any step needed to contain the issue, up to and including complete service degradation.
 - Sitreps should be sent every hour, or more.
 
@@ -208,21 +209,21 @@ Medium-sev incidents represent attempts (possibly un- or not-yet-successful) at 
 
 Guidelines for addressing Medium-sev issues:
 
-- Response should be business-hours
+- Response should be business-hours.
 - Responders should attempt to consult stakeholders before causing downtime, but may proceed without them if they can't be contacted in a reasonable time-frame.
-- Sitreps should be sent approximately twice a day
+- Sitreps should be sent approximately twice a day.
 
 ### 3 - Low Severity
 
 Low-sev incidents don't affect PII, and have no availability or financial impact. Examples include:
 
-- Attempted compromise of non-important systems (staging/testing instances, etc)
+- Attempted compromise of non-important systems (staging/testing instances, etc.)
 - Incidents involving specific employees
 - DoS attacks with no noticeable customer impact
 
 Guidelines for addressing Low-sev issues:
 
-- Response should be business-hours
-- Responders should avoid service degradation unless stakeholders agree
+- Response should be business-hours.
+- Responders should avoid service degradation unless stakeholders agree.
 - Sitreps should be sent approximately daily.
 


### PR DESCRIPTION
I decided that these are docs where we especially want to minimize any superficial distractions, so here are some suggestions. Changes I made include:
- Link to the IR Checklist at the top of the IR Guide for extra-fast clicking if you're in the middle of responding to an incident.
- Retitle "cloud.gov Incident Response process" to "Security Incident Response Guide" for consistency with the name in the sidebar, how we named the checklist, and what we call the IR Guide in the compliance documentation.
- Give each mention of an 18F Slack channel a link to that channel, for fast clicking during responses.
- Minor visual consistency things: capitalizing GitHub as GitHub, using em dashes (—), using arrows (→).
- Fixing a few small spelling, grammar, and word order things to minimize distractions.

cc @jacobian for checking to make sure I didn't mess anything up!
