### PR TITLE
Mention "cf files" in cf-ssh instructions

### DIFF
--- a/content/getting-started/one-off-tasks.md
+++ b/content/getting-started/one-off-tasks.md
@@ -54,7 +54,7 @@ The idea here is that we are going to deploy a new application, but running the 
     cf logs --recent task-runner
     ```
 
-1. If needed, use [`cf files`](http://cli.cloudfoundry.org/en-US/cf/files.html) to collect any artifacts.
+1. If needed, use [`cf files`][] to collect any artifacts.
 1. Run `cf delete task-runner` to clean it up.
 
 ## CF SSH
@@ -83,4 +83,9 @@ Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not
     ```
 
 1. The process takes between 2 to 10 minutes to start the session since it is compiling your application in the background. When it completes, you will see a command prompt.
+
+1. If you need to collect any files on the remote machine, you can use [`cf files`][] from a separate terminal window (do *not* close your SSH session, as the machine will be destroyed upon exit). For example, if your project's name in your `manifest.yml` is `foo`, then `cf files foo-ssh app/` should list all the files in your SSH session's default working directory.
+
 1. When done, run `exit`.
+
+[`cf files`]: http://cli.cloudfoundry.org/en-US/cf/files.html


### PR DESCRIPTION
I had to transfer some files from a `cf-ssh` session today and it took a little while to figure out, so I thought that mentioning `cf files` with example usage might help future passers-by.
