### PR TITLE
Clarify managing teammates page

### DIFF
--- a/content/apps/managing-teammates.md
+++ b/content/apps/managing-teammates.md
@@ -7,15 +7,19 @@ title: Managing Teammates
 
 ## Invite a teammate
 
-If you're part of an agency team using cloud.gov, you can invite other people at your agency to get cloud.gov accounts:
+If you're part of a team using cloud.gov, you can invite teammates to get cloud.gov accounts. You can invite anyone you need to work with, including federal employees and federal contractors.
 
 1. [Send them an invite](https://login.cloud.gov/invitations/new) (this may prompt you to log into your cloud.gov account first).
 
 1. Confirm with them that they have received and accepted the invite.
 
+Now they have a cloud.gov account. If you invited them with an agency email address and they're part of an agency that has automatic sandbox spaces, they'll automatically get a sandbox space in their agency's cloud.gov org.
+
 ## Give roles to a teammate
 
-If you're an Org Manager or Space Manager, here's how to give roles to your teammates to give them permissions. For details about how cloud.gov org and space roles and permissions work, see [Cloud Foundry roles and permissions](http://docs.cloudfoundry.org/concepts/roles.html#roles).
+After a teammate gets a cloud.gov account, an Org Manager or Space Manager will need to give them roles in your orgs and spaces so they can collaborate with you.
+
+If you're an Org Manager or Space Manager, here's how to give roles to your teammates to give them permissions for your orgs and spaces. For details about how cloud.gov org and space roles and permissions work, see [Cloud Foundry roles and permissions](http://docs.cloudfoundry.org/concepts/roles.html#roles).
 
 First check whether you're running version >= [6.14.0](https://github.com/cloudfoundry/cli/releases/tag/v6.14.0) of the CLI. (If not, you'll need to [upgrade](https://docs.cloudfoundry.org/devguide/installcf/install-go-cli.html).)
 

--- a/content/apps/managing-teammates.md
+++ b/content/apps/managing-teammates.md
@@ -5,32 +5,33 @@ menu:
 title: Managing Teammates
 ---
 
-To add a new teammate to your organization:
+If you have OrgManager permissions for your organization, here's how to add new teammates to your organization. (For details about how cloud.gov org and space permissions work, see [Cloud Foundry roles and permissions](http://docs.cloudfoundry.org/concepts/roles.html#roles).)
 
-1. [Send them an invite](https://login.cloud.gov/invitations/new).
+1. [Send them an invite](https://login.cloud.gov/invitations/new) (this may prompt you to log into your cloud.gov account first).
+
 1. Confirm with them that they have received and accepted the invite.
-1. Ensure you are running version >= [6.14.0](https://github.com/cloudfoundry/cli/releases/tag/v6.14.0) of the CLI. If not, you will need to [upgrade](https://docs.cloudfoundry.org/devguide/installcf/install-go-cli.html).
+
+1. Check whether you're running version >= [6.14.0](https://github.com/cloudfoundry/cli/releases/tag/v6.14.0) of the CLI. (If not, you'll need to [upgrade](https://docs.cloudfoundry.org/devguide/installcf/install-go-cli.html).)
 
     ```bash
     cf -v
     ```
 
-1. To give them read-only permissions to the organization, run
+Then decide which permissions to give them:
+
+* To give them read-only permissions to the organization, run
 
     ```bash
     cf set-org-role <email> <org> OrgAuditor
     ```
 
-1. If you want to make them an admin for your organization, run
+* If you want to make them an admin for your organization, run
 
     ```bash
     cf set-org-role <email> <org> OrgManager
     ```
-
-1. If you want to give them permission to deploy, add them to each space:
+* If you want to give them permission to deploy, add them to each space:
 
     ```bash
     cf set-space-role <email> <org> <space> SpaceDeveloper
     ```
-
-[Learn more about Cloud Foundry roles](https://docs.cloudfoundry.org/concepts/roles.html).

--- a/content/apps/managing-teammates.md
+++ b/content/apps/managing-teammates.md
@@ -5,19 +5,25 @@ menu:
 title: Managing Teammates
 ---
 
-If you have OrgManager permissions for your organization, here's how to add new teammates to your organization. (For details about how cloud.gov org and space permissions work, see [Cloud Foundry roles and permissions](http://docs.cloudfoundry.org/concepts/roles.html#roles).)
+## Invite a teammate
+
+If you're part of an agency team using cloud.gov, you can invite other people at your agency to get cloud.gov accounts:
 
 1. [Send them an invite](https://login.cloud.gov/invitations/new) (this may prompt you to log into your cloud.gov account first).
 
 1. Confirm with them that they have received and accepted the invite.
 
-1. Check whether you're running version >= [6.14.0](https://github.com/cloudfoundry/cli/releases/tag/v6.14.0) of the CLI. (If not, you'll need to [upgrade](https://docs.cloudfoundry.org/devguide/installcf/install-go-cli.html).)
+## Give permissions to a teammate
+
+If you're an Org Manager or Space Manager, here's how to give permissions to your teammates. For details about how cloud.gov org and space permissions work, see [Cloud Foundry roles and permissions](http://docs.cloudfoundry.org/concepts/roles.html#roles).
+
+First check whether you're running version >= [6.14.0](https://github.com/cloudfoundry/cli/releases/tag/v6.14.0) of the CLI. (If not, you'll need to [upgrade](https://docs.cloudfoundry.org/devguide/installcf/install-go-cli.html).)
 
     ```bash
     cf -v
     ```
 
-Then decide which permissions to give them:
+Then decide which permissions to give them, such as:
 
 * To give them read-only permissions to the organization, run
 
@@ -35,3 +41,5 @@ Then decide which permissions to give them:
     ```bash
     cf set-space-role <email> <org> <space> SpaceDeveloper
     ```
+    
+For a complete list of cloud.gov permissions that Org and Space Managers can give and remove, see [the Cloud Foundry guide to Org and Space Roles](https://docs.cloudfoundry.org/adminguide/cli-user-management.html#orgs-spaces).

--- a/content/apps/managing-teammates.md
+++ b/content/apps/managing-teammates.md
@@ -13,9 +13,9 @@ If you're part of an agency team using cloud.gov, you can invite other people at
 
 1. Confirm with them that they have received and accepted the invite.
 
-## Give permissions to a teammate
+## Give roles to a teammate
 
-If you're an Org Manager or Space Manager, here's how to give permissions to your teammates. For details about how cloud.gov org and space permissions work, see [Cloud Foundry roles and permissions](http://docs.cloudfoundry.org/concepts/roles.html#roles).
+If you're an Org Manager or Space Manager, here's how to give roles to your teammates to give them permissions. For details about how cloud.gov org and space roles and permissions work, see [Cloud Foundry roles and permissions](http://docs.cloudfoundry.org/concepts/roles.html#roles).
 
 First check whether you're running version >= [6.14.0](https://github.com/cloudfoundry/cli/releases/tag/v6.14.0) of the CLI. (If not, you'll need to [upgrade](https://docs.cloudfoundry.org/devguide/installcf/install-go-cli.html).)
 
@@ -23,7 +23,7 @@ First check whether you're running version >= [6.14.0](https://github.com/cloudf
     cf -v
     ```
 
-Then decide which permissions to give them, such as:
+Then decide which roles to give them, such as:
 
 * To give them read-only permissions to the organization, run
 
@@ -42,4 +42,4 @@ Then decide which permissions to give them, such as:
     cf set-space-role <email> <org> <space> SpaceDeveloper
     ```
     
-For a complete list of cloud.gov permissions that Org and Space Managers can give and remove, see [the Cloud Foundry guide to Org and Space Roles](https://docs.cloudfoundry.org/adminguide/cli-user-management.html#orgs-spaces).
+For a complete list of cloud.gov roles and permissions that Org and Space Managers can give and remove, see [the Cloud Foundry guide to Org and Space Roles](https://docs.cloudfoundry.org/adminguide/cli-user-management.html#orgs-spaces).


### PR DESCRIPTION
Updated this to explain:
- You can only give permissions if you have appropriate permissions.
- The permissions options are choices (bulleted list) rather than a sequence of steps (numbered list).
- Why you might want to learn more about Cloud Foundry roles.
