### PR TITLE
Add `npm start` command;

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ Hugo uses markdown to build the pages. Just add your page to the section you wan
 ### Running the site locally
 
 1. This project uses [Hugo](https://gohugo.io) to build the site. Once Hugo is installed, run `hugo` to build the site.
-2. Run `npm install` to download all the dependencies.
-3. Run `npm run build` to build all the assets.
-4. Run `hugo server --renderToDisk` and browse to [http://localhost:1313](http://localhost:1313).
+1. Run `npm install` to download all the dependencies.
+1. Run `npm run start` and browse to [http://localhost:1313](http://localhost:1313).
 
 ### Style development
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "copy-font": "cp node_modules/cloudgov-style/font/* ./public/fonts/",
     "make-dirs": "mkdir -p ./public/css && mkdir -p ./public/js && mkdir -p ./public/img && mkdir -p ./public/fonts",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "watch": "onchange './node_modules/cloudgov-style/css/*.scss' './node_modules/cloudgov-style/img/*' './static_src/**/*.scss' -v -- npm run build"
+    "watch": "onchange './node_modules/cloudgov-style/css/*.scss' './node_modules/cloudgov-style/img/*' './static_src/**/*.scss' -v -- npm run build",
+    "start": "npm run build && hugo server --renderToDisk"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This patch adds the `npm start` command to help avoid ambiguous commands
around working with this site locally. It also shortens the documentation
instructions as well.
