### PR TITLE
Update max `cloudgov-style` version to be <= 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "anchor-js": "git+https://github.com/msecret/anchorjs.git",
-    "cloudgov-style": "^0.3.4",
+    "cloudgov-style": "^0.x",
     "highlight": "^0.2.4",
     "jquery": "^2.2.0",
     "jquery.scrollto": "^2.1.2"


### PR DESCRIPTION
This patch uses the caret-ranges from the `npmjs` docs to allow for
updates from version `0.0.0` to `1.0.0`. Because the versions are being
updated across minor version numbers, targeting `^0.x` will prevent this
repo from needing to be updated between `0.6.x` as of this writing until
`1.x`.

@see https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004
