### PR TITLE
Add a little more info about buildpacks

### DIFF
--- a/content/apps/multi-buildpack-deploys.md
+++ b/content/apps/multi-buildpack-deploys.md
@@ -6,7 +6,7 @@ menu:
 title: Multi-Language Projects
 ---
 
-CloudFoundry is capable of deploying, multi-language projects by using a special [buildpack](https://github.com/ddollar/heroku-buildpack-multi). In short, this buildpack applies any buildpacks listed in `.buildpacks` file.
+CloudFoundry is capable of deploying multi-language projects by using a special [buildpack](https://github.com/ddollar/heroku-buildpack-multi). In short, this buildpack applies any buildpacks listed in the `.buildpacks` file.
 
 Instead of using buildpack-multi, consider splitting your application into smaller components. If you are using buildpack-multi to run multiple long-running processes, you should run them as separate cloud.gov applications instead. If you're investigating multi-buildpack deploys to build static assets on cloud.gov, you can avoid this issue by [building assets on CI]({{< relref "assets.md#build-assets-on-ci" >}}).
 

--- a/content/getting-started/concepts.md
+++ b/content/getting-started/concepts.md
@@ -71,7 +71,7 @@ cf target -o ORGNAME -s SPACENAME
 
 ## Buildpacks
 
-All apps need to use a 'buildpack' specific to their language, which sets up dependencies for particular language stacks. There are standard buildpacks for most languages, and they will usually be auto-detected by CF. Using the standard buildpacks is strongly encouraged. In the rare case where the buildpack does not get detected correctly, or to use a custom buildpack, it can be specified in the manifest (as below) or with the `-b` flag. Use either the buildpack name:
+All apps need to use a "buildpack" specific to their language, which sets up dependencies for particular language stacks. There are [standard buildpacks for most languages](https://docs.cloudfoundry.org/buildpacks/), and they will usually be auto-detected by Cloud Foundry. Using the standard buildpacks is strongly encouraged. In the rare case where the buildpack does not get detected correctly, or to use a custom buildpack, it can be specified in the manifest (as below) or with the `-b` flag. Use either the buildpack name:
 
     buildpack: python_buildpack
 
@@ -79,6 +79,7 @@ or a URL to reference it.
 
     buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
 
+If you might need multiple buildpacks for an app, see [Multi-Language Projects]({{< relref "apps/multi-buildpack-deploys.md" >}}).
 
 ### Buildpack Release Schedule
 


### PR DESCRIPTION
Changes:
- Help readers find out what the standard buildpacks are.
- Cross-link a related docs page.
- Remove a stray comma.
