### PR TITLE
Change "Deck" to "Dashboard" in header partial

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -55,7 +55,7 @@
               <a href="https://cloudgov.statuspage.io/">Status</a>
             </li>
             <li class="nav-link">
-              <a href="https://console.cloud.gov/">Deck</a>
+              <a href="https://console.cloud.gov/">Dashboard</a>
             </li>
             <li class="nav-link">
               <a href="https://cloud.gov/#contact">Contact</a>


### PR DESCRIPTION
Per content guidelines outlined here, "Deck" should be changed to "Dashboard" throughout various applications under cloud.gov

Refs https://github.com/18F/cg-deck/issues/333#issuecomment-229223814
