### PR TITLE
Update assets to use new navigation style

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -8,7 +8,7 @@
         <a href="javascript:;" class="">
           {{ .Pre }}
           <span>{{ .Name }}</span>
-          <span class="menu-arrow sidenav-arrow fa {{if $currentNode.HasMenuCurrent "main" . }}fa-angle-down{{else}}fa-angle-right{{end}}"></span>
+          <span class="sidenav-arrow {{if $currentNode.HasMenuCurrent "main" . }}sidenav-arrow-down{{else}}sidenav-arrow-right{{end}}"></span>
         </a>
         <ul class="usa-sidenav-sub_list sidenav-list sidenav-level-two nested-menu {{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }} open {{end}}" style="{{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }} display: block; {{else}}display: none; {{end}}">
           {{ range .Children }}
@@ -17,7 +17,7 @@
               {{ .Pre }}
               <span>{{ .Name }}</span>
               {{ if .HasChildren }}
-                <span class="menu-arrow sidenav-arrow fa {{if $currentNode.HasMenuCurrent "main" . }}fa-angle-down{{else}}fa-angle-right{{end}}"></span>
+                <span class="sidenav-arrow {{if $currentNode.HasMenuCurrent "main" . }}sidenav-arrow-down{{else}}sidenav-arrow-right{{end}}"></span>
               {{ end }}
             </a>
               {{ if .HasChildren }}

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "clean": "rm -rf ./public",
     "copy": "npm run copy-img && npm run copy-font",
     "copy-img": "cp -r node_modules/cloudgov-style/img/* ./public/img/",
-    "copy-font": "cp node_modules/cloudgov-style/font/* ./public/fonts/",
-    "make-dirs": "mkdir -p ./public/css && mkdir -p ./public/js && mkdir -p ./public/img && mkdir -p ./public/fonts",
+    "copy-font": "cp node_modules/cloudgov-style/font/* ./public/font/",
+    "make-dirs": "mkdir -p ./public/css && mkdir -p ./public/js && mkdir -p ./public/img && mkdir -p ./public/font",
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "onchange './node_modules/cloudgov-style/css/*.scss' './node_modules/cloudgov-style/img/*' './static_src/**/*.scss' -v -- npm run build",
     "start": "npm run build && hugo server --renderToDisk"


### PR DESCRIPTION
A recent upgrade to `cloudgov-style` resulted in the docs site breaking in two ways:
1. The fonts were not found
2. The side navbar had wonky icons

This changes the path for fonts used in the build process and uses different icon classes.

It would also be great to see if we can work this repo and the cg-landing repo into the automated visual regression testing so we can maybe pick up on these breaking changes earlier.
