### PR TITLE
A few grammar/wording tweaks, and remove a paragraph

### DIFF
--- a/content/intro/pricing/pricing-model.md
+++ b/content/intro/pricing/pricing-model.md
@@ -8,11 +8,11 @@ weight: 10
 
 ## Pricing model
 
-18F provides its services to other agencies on a _full_ cost-recovery model. This holds not only for cloud.gov, but also for our consulting, delivery, and other work.
+18F provides its services to other agencies on a _full_ cost-recovery model. This is true not only for cloud.gov, but also for our consulting, delivery, and other work.
 
 ---
 
-The current cloud.gov pricing model has four components:
+The current cloud.gov pricing model has three components:
 
 - Access package
 - Resource usage
@@ -21,12 +21,10 @@ The current cloud.gov pricing model has four components:
 Find out more about each component via our [pricing terminology page]({{< relref "intro/terminology/pricing-terminology.md" >}}) or see the [dedicated page with our rates]({{< relref "intro/pricing/rates.md" >}}).
 
 ---
-Our mission is to catapult government agencies past mere cloud 'adoption', to the point where they routinely deliver services to the public as fast as they can be developed, all while applying the best practices in security and compliance with minimal effort.
+Our mission is to catapult government agencies past mere cloud 'adoption', to the point where they routinely deliver services to the public as fast as they can develop them, all while applying best practices in security and compliance with minimal effort.
 
-Comparing cloud.gov's pricing model to those private Platform as a Service (PaaS) providers is extremely difficult, as it is not an apples to apples comparison. If you attempt to do a price comparison, be sure to include the up-front and opportunity costs of your procurement, operations, security, and compliance teams in obtaining a solution from scratch. It may be difficult to obtain these costs, especially if they are hidden within various working capital funds in your agency. Consider the labor and time to be saved by having a proven, ready-to-ATO infrastructure in your teams' hands from Day One, via a relatively simple Inter-agency Agreement (IAA). Cloud.gov's resource usage is already priced competitive with the private market, and is the superior option in reducing compliance friction to access the cloud.
-
-It is critical to obtain all this data in order to perform a true cost of ownership comparison. 18F stands ready to help you build an accurate cost model.
+Comparing cloud.gov's pricing model to private Platform as a Service (PaaS) providers is extremely difficult, as it is not an apples to apples comparison. If you attempt to do a price comparison, be sure to include the up-front and opportunity costs of your procurement, operations, security, and compliance teams in obtaining a solution from scratch. It may be difficult to obtain these costs, especially if they are hidden within various working capital funds in your agency. Consider the labor and time to be saved by having a proven, ready-to-ATO infrastructure in your teams' hands from Day One, via a relatively simple Inter-agency Agreement (IAA). Cloud.gov's resource usage is already priced competitively with the private market, and is the superior option in reducing compliance friction to access the cloud.
 
 We are validating whether our pricing model fits the needs of federal agencies, and will continue to experiment with the model. Our promise to our partners is that prices will not be changed on them mid-fiscal year, and the price of any particular part of the platform will *not go up*.
 
-It is important to note that the model _itself_ may change between fiscal years. We will honor the pricing model for access _during_ the period of performance and will not change the model for any particular partner until their period of performance is over.
+It is important to note that the model _itself_ may change between fiscal years. We will honor the pricing model for access _during_ the IAA's period of performance, and will not change the model for any particular partner until their IAA's period of performance is over.


### PR DESCRIPTION
This fixes up some wording issues on the [pricing model page](https://docs.cloud.gov/intro/pricing/pricing-model/), and corrects a numbering error. 

I also removed a small paragraph:

> It is critical to obtain all this data in order to perform a true cost of ownership comparison. 18F stands ready to help you build an accurate cost model.

The first sentence was already communicated in the previous paragraph, and the second sentence isn't very credible given how heavily oriented this page is towards selling a product.
