### PR TITLE
Updating readme to clarify cloud.gov instead of CF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-# 18F CF Docs [![wercker status](https://app.wercker.com/status/b53005d7e69162205a5c9b63f3d65029/s/master "wercker status")](https://app.wercker.com/project/bykey/b53005d7e69162205a5c9b63f3d65029)
+# 18F cloud.gov documentation
 
-This repository contains the site code for the [18F Cloud Foundry documentation](http://docs.cloudfoundry.org/).
+[![wercker status](https://app.wercker.com/status/b53005d7e69162205a5c9b63f3d65029/s/master "wercker status")](https://app.wercker.com/project/bykey/b53005d7e69162205a5c9b63f3d65029)
+
+This repository contains the site code for [cloud.gov documentation](https://docs.cloud.gov/).
+
+cloud.gov is a Platform as a Service based on the Cloud Foundry project, which provides its own [Cloud Foundry documentation](http://docs.cloudfoundry.org/).
 
 ## Contributing
 
-Hugo uses markdown to build the pages. Just add your page to the section you want inside the content folder.
+Hugo uses Markdown to build the pages. Add your page to the section you want inside the content folder.
 
 ### Running the site locally
 
@@ -23,6 +27,6 @@ This site uses a shared cloud.gov style, [cg-style](https://github.com/18F/cg-st
 5. Run the watching build task in *cg-docs* repository: `npm run watch`
 6. Edit code in the *cg-style* directory and they will propagate down to *cg-docs*
 
-## Acknowledgement
+## Acknowledgment
 
 The theme for the site has been "forked" from the [Hugo documentation](https://gohugo.io/overview/introduction/).


### PR DESCRIPTION
"18F CF Docs" and "This repository contains the site code for the 18F Cloud Foundry documentation" could be confusing since cloud.gov isn't just Cloud Foundry, so I updated those bits. I also copyedited this a tiny bit.
