### PR TITLE
Add notes to IR retro section about cg-postmortems

### DIFF
--- a/content/ops/security-ir.md
+++ b/content/ops/security-ir.md
@@ -171,7 +171,7 @@ Once the incident is no longer active — i.e. the breach has been contained, th
 
 The final step in handling a security incident is figuring out what we learned. The IC (or one of the ICs if there were multiple, or a designated other party) should lead a retrospective and develop an incident report. 
 
-Conducting retrospectives is out of the scope of this document, but as a crash course, here's an [introduction to blameless postmortems](https://codeascraft.com/2012/05/22/blameless-postmortems/).
+Conducting retrospectives is out of the scope of this document, but as a crash course, here's an [introduction to blameless postmortems](https://codeascraft.com/2012/05/22/blameless-postmortems/). We follow the [basic steps listed at cg-postmortems](https://github.com/18F/cg-postmortems).
 
 The report should contain a timeline of the incident, details about how the incident progressed, and information about the vulnerabilities that led to the incident. A cause analysis is an important part of this report; the team should use tools such as [Infinite Hows](http://www.kitchensoap.com/2014/11/14/the-infinite-hows-or-the-dangers-of-the-five-whys/) or [Five Whys](https://en.wikipedia.org/wiki/5_Whys) to try to dig into causes, how future incidents could be prevented, how responses could be better in the future, etc.
 
@@ -182,7 +182,7 @@ The report should also contain some basic response metrics:
 - Time to containment (how long did it take from when we became aware until the issue was contained?)
 - Threat actions (which specific actions -- e.g. phishing, password attacks, etc) -- were taken by the actor)?
 
-This report should be posted as a final comment on the GitHub issue, which can then be closed.
+This report should be posted as a final comment on the GitHub issue, which can then be closed. If appropriate, this should also be posted publicly at [cg-postmortems](https://github.com/18F/cg-postmortems) (omitting any sensitive information).
 
 ## Incident Severities
 


### PR DESCRIPTION
The [IR-4 control](https://web.nvd.nist.gov/view/800-53/Rev4/control?controlName=IR-4) requires a couple things:
- "Coordinates incident handling activities with contingency planning activities"
- "Incorporates lessons learned from ongoing incident handling activities into incident response procedures, training, and testing, and implements the resulting changes accordingly"

...and we already have some of that at https://github.com/18F/cg-postmortems ! So this IR guide should at least cross-link to that repo and suggest using it if appropriate. :)

Note that this is a (minor-ish) change to the IR process that we discussed in our training, so we should make sure that the cloud-gov-team on Slack is ok with (and aware of) this change.
