### PR TITLE
re-format the Rates table

### DIFF
--- a/content/intro/pricing/rates.md
+++ b/content/intro/pricing/rates.md
@@ -18,36 +18,14 @@ Find out [more about this pricing model]({{< relref "intro/pricing/pricing-model
 
 Packages are selected based on the kinds of applications to be hosted.
 
-<table class="responsive_table">
-  <tr>
-    <th width="25%"><span>Sandbox</span></th>
-    <th width="25%"><span>Prototyping</span></th>
-    <th width="25%"><span>FISMA Low</span></th>
-    <th width="25%"><span>FISMA Moderate</span></th>
-  </tr>
-  <tr>
-    <td valign="top">
-      For any .gov or .mil account to try out cloud.gov, no paperwork required. All managed services are available.
-    </td>
-    <td valign="top">
-      Sandbox usage caps can be raised. Suitable for many teams to deploy apps, though limited to the apps.cloud.gov domain. Low ability to delegate access control to teams. No production data allowed. Usually purchased per agency/department. 
-    </td>
-    <td valign="top">
-      One public-facing FISMA Low system, including all the spaces needed and DNS support.
-    </td>
-    <td valign="top">
-      One public-facing FISMA Moderate system, including all the spaces needed and DNS support. Additional support for FISMA Moderate data requirements.
-    </td>
-  </tr>
-  <tr>
-    <td>Free</th>
-    <td>$15K / year plus usage charges</th>
-    <td>$20K / year plus usage charges</th>
-    <td>$90K / year plus usage charges</th>
-  </tr>
-</table>
+| Package | What's included? | Base annual fee | Usage charges? |
+| --- | --- | --- | --- |
+| **Sandbox** | Any user with a `.gov` or `.mil` email address can try out cloud.gov, no paperwork required. All managed services are available. | Free | No |
+| **Prototyping** | Sandbox usage caps can be raised. Suitable for many teams to deploy apps, though limited to the apps.cloud.gov domain. Low ability to delegate access control to teams. No production data allowed. Usually purchased per agency/department. | $15K | Yes |
+| **FISMA Low** | One public-facing FISMA Low system, including all the spaces needed and DNS support. | $20K | Yes |
+| **FISMA Moderate** | One public-facing FISMA Moderate system, including all the spaces needed and DNS support. Additional support for FISMA Moderate data requirements. | $90K | Yes |
 
-Access package fees are charged yearly and are non-severable. 
+Access package fees are charged yearly and are non-severable.
 
 [Find more about what's included in the access package.]({{< relref "intro/pricing/whats-included.md" >}})
 
@@ -55,7 +33,7 @@ Access package fees are charged yearly and are non-severable.
 
 ### Resource usage
 
-You will be charged for resource usage as a factor of the memory, in MB of RAM, your applications consume. 
+You will be charged for resource usage as a factor of the memory, in MB of RAM, your applications consume.
 
 - Sandbox: Resource usage is capped to 1 GB of RAM per month.
 - All other packages: $0.0033 per MB reserved per day (usually this results in $99/GB/month)
@@ -72,7 +50,7 @@ We require your resource usage quota to **be set in advance**. This helps you co
 
 Managed services are those which cloud.gov will spin up instantly and run on your behalf. You pay for the resources they consume and our efforts to provide them as a service.
 
-The pricing for each service is different and they are billed by the service instance. You can see the rate for each type of service instance offered by running `cf marketplace`. (We'll include this information directly here in future.) 
+The pricing for each service is different and they are billed by the service instance. You can see the rate for each type of service instance offered by running `cf marketplace`. (We'll include this information directly here in future.)
 
 **Note:** *We are still determining the rates for some services. We will ensure users of those services are aware of the rates when they are set, and they will not be charged before then.*
 
@@ -82,7 +60,7 @@ Managed services are billed per quarter, tallied monthly, and severable.
 
 This pricing includes _only_ services created through cloud.gov. If you are using additional public or private services offered by 18F Infrastructure, they are priced and billed separately - speak with your 18F Finance point of contact for more information.
 
-<!-- 
+<!--
 TODO
 ---
 

--- a/content/intro/pricing/rates.md
+++ b/content/intro/pricing/rates.md
@@ -16,18 +16,18 @@ Find out [more about this pricing model]({{< relref "intro/pricing/pricing-model
 
 ### Access Package
 
-Packages are selected based on the kinds of applications to be hosted.
+Packages are selected based on the kinds of applications to be hosted. [Find more about what's included in all access packages.]({{< relref "intro/pricing/whats-included.md" >}})
 
-| Package | What's included? | Base annual fee | Usage charges? |
+| Package | What's included? | Base annual fee\* | Usage charges? |
 | --- | --- | --- | --- |
 | **Sandbox** | Any user with a `.gov` or `.mil` email address can try out cloud.gov, no paperwork required. All managed services are available. Resource usage is capped, though it can be raised. | Free | No |
-| **Prototyping** | Suitable for many teams to deploy apps, though limited to the `*.apps.cloud.gov` domain. Access control can be delegated to teams. No production data allowed. Usually purchased per agency/department. | $15K | Yes |
-| **FISMA Low** | One public-facing FISMA Low system, including all the spaces needed and DNS support. | $20K | Yes |
-| **FISMA Moderate** | One public-facing FISMA Moderate system, including all the spaces needed and DNS support. Additional support for FISMA Moderate data requirements. | $90K | Yes |
+| **Prototyping** | Suitable for many teams to deploy apps, though limited to the `*.apps.cloud.gov` domain. Access control can be delegated to teams. No production data allowed. Usually purchased per agency/department. | $15K | No\** |
+| **FISMA Low** | One public-facing FISMA Low system, including all the spaces needed and DNS support. | $20K | No\** |
+| **FISMA Moderate** | One public-facing FISMA Moderate system, including all the spaces needed and DNS support. Additional support for FISMA Moderate data requirements. | $90K | No\** |
 
-Access package fees are charged yearly and are non-severable.
+\*Access package fees are charged yearly and are non-severable.
 
-[Find more about what's included in the access package.]({{< relref "intro/pricing/whats-included.md" >}})
+\*\*See the [managed services](#managed-services) section for details.
 
 ---
 
@@ -48,17 +48,11 @@ We require your resource usage quota to **be set in advance**. This helps you co
 
 ### Managed services
 
-Managed services are those which cloud.gov will spin up instantly and run on your behalf. You pay for the resources they consume and our efforts to provide them as a service.
+[Managed services]({{< relref "apps/managed-services.md" >}}) are those which cloud.gov will spin up instantly and run on your behalf (databases, storage, caching, etc.). You can see the services and plans offered for each by [running `cf marketplace`]({{< relref "apps/managed-services.md#list-services" >}}). *We'll include more details on this page in the future.*
 
-The pricing for each service is different and they are billed by the service instance. You can see the rate for each type of service instance offered by running `cf marketplace`. (We'll include this information directly here in future.)
+While we aren't currently charging for these, we plan to charge for them in the future, to account for the resources they consume and our efforts to provide them as a service. The pricing for each service will be different and will be billed by the service instance, billed per quarter, tallied monthly, and severable. We will ensure users of those services are aware of the rates when they are set, and they will not be charged before then.
 
-**Note:** *We are still determining the rates for some services. We will ensure users of those services are aware of the rates when they are set, and they will not be charged before then.*
-
-Managed services are billed per quarter, tallied monthly, and severable.
-
----
-
-This pricing includes _only_ services created through cloud.gov. If you are using additional public or private services offered by 18F Infrastructure, they are priced and billed separately - speak with your 18F Finance point of contact for more information.
+This pricing will _only_ be for services created through cloud.gov. If you are using additional public or private services offered by 18F Infrastructure, they are priced and billed separately - speak with your 18F Finance point of contact for more information. External databases, SMTP servers, etc. that are _not_ managed by 18F/cloud.gov can also be used, with no additional fee.
 
 <!--
 TODO

--- a/content/intro/pricing/rates.md
+++ b/content/intro/pricing/rates.md
@@ -20,8 +20,8 @@ Packages are selected based on the kinds of applications to be hosted.
 
 | Package | What's included? | Base annual fee | Usage charges? |
 | --- | --- | --- | --- |
-| **Sandbox** | Any user with a `.gov` or `.mil` email address can try out cloud.gov, no paperwork required. All managed services are available. | Free | No |
-| **Prototyping** | Sandbox usage caps can be raised. Suitable for many teams to deploy apps, though limited to the apps.cloud.gov domain. Low ability to delegate access control to teams. No production data allowed. Usually purchased per agency/department. | $15K | Yes |
+| **Sandbox** | Any user with a `.gov` or `.mil` email address can try out cloud.gov, no paperwork required. All managed services are available. Resource usage is capped, though it can be raised. | Free | No |
+| **Prototyping** | Suitable for many teams to deploy apps, though limited to the `*.apps.cloud.gov` domain. Access control can be delegated to teams. No production data allowed. Usually purchased per agency/department. | $15K | Yes |
 | **FISMA Low** | One public-facing FISMA Low system, including all the spaces needed and DNS support. | $20K | Yes |
 | **FISMA Moderate** | One public-facing FISMA Moderate system, including all the spaces needed and DNS support. Additional support for FISMA Moderate data requirements. | $90K | Yes |
 


### PR DESCRIPTION
This pull request does a few things to the Access Package section of the Rates page:
- Flips the axes of the table
  - It feels more natural to me this way, though I recognize that pricing options (especially with checkboxes for features) are sometimes laid out horizontally.
- Adds a `Usage fee?` column, to split that from the base price
- Converts it from an HTML table to a Markdown one
  - Since I wasn't able to keep the `class` on the `<table>`, this inadvertently caused a styling change. This wasn't my intention, though it does it make it consistent with the other tables on the site.
- Minor tweaks to the verbiage

**Before**

<img width="709" alt="Rates table screenshot before the change" src="https://cloud.githubusercontent.com/assets/86842/17523978/936c0396-5e2a-11e6-8165-ffcb63fb9798.png">

**After**

<img width="709" alt="Rates table screenshot after the change" src="https://cloud.githubusercontent.com/assets/86842/17524010/aea11098-5e2a-11e6-8d58-10bd5410395d.png">
