### PR TITLE
Improve 'leveraging auth' section.

### DIFF
--- a/content/apps/leveraging-authentication.md
+++ b/content/apps/leveraging-authentication.md
@@ -29,112 +29,84 @@ There are two important cloud.gov URLs you will need to use:
 - `https://login.cloud.gov/oauth/authorize`, which is where you will direct the user to login with their agency credentials
 - `https://uaa.cloud.gov/oauth/token`, which is where you will exchange auth codes for auth tokens
 
-If you are already familiar with OAuth 2.0, you might know where to go from here. If not, read on for a minimal example of how to do the OAuth dance. Here's the basic gist of it:
+If you are already familiar with OAuth 2.0, you might know where to go from here. If not, read on for a minimal example of how to do the OAuth dance. Below is the basic gist of it.
 
-`1.` Generate a link (or redirect the user) to the authorize URL with these query parameters:
+#### Send your user to login.cloud.gov
+
+First, generate a link (or redirect the user) to the authorize URL with these
+query parameters:
 
 * `client_id=<YOUR APP'S REGISTERED NAME>`
 * `response_type=code`
 * (optional) `state=<ANYTHING>`
 
 You can optionally set a `state` parameter with any value you'd like.
-It will be returned to you in a later step. An example of something you might
-want to set in state is the URL in your application that the user was attempting
-to access.
+It will be returned to you in a later step. While optional, it's highly
+recommended that you use it for [security reasons](http://www.twobotechnologies.com/blog/2014/02/importance-of-state-in-oauth2.html).
 
 Here is an example:
 
-  ```html
-  <a href="https://login.cloud.gov/oauth/authorize?client_id=NAME&response_type=code">
-    Log in
-  </a>
-  ```
+```html
+<a href="https://login.cloud.gov/oauth/authorize?client_id=NAME&response_type=code">
+  Log in
+</a>
+```
 
-`2.` Once the user visits the authorize URL and successfully logs in with their
-credentials, your app will receive a `GET` request to the callback URL
-associated with the registered app. The `GET` request will include query parameters:
+Once the user clicks on this link, they will be sent to cloud.gov to login.
+
+#### The user is returned to your site
+
+Once the user successfully logs in with their credentials, your app will
+receive a `GET` request to the callback URL associated with the registered
+app. The `GET` request will include query parameters:
 
 * `code=<A UNIQUE ACCESS CODE>`
 * (optional) `state=<VALUE FROM STATE PARAM IN AUTHORIZE LINK>`
 
-Here is where things get fun. A snippet of example NodeJS code is shown
-[below](#token-exchange-example-code) to help illustrate this part of the process.
+Now your site's backend will need to exchange the access code for an
+access token. Here is where things get fun.
 
-  `1)` First, exchange the `code` for an authorization token by sending a `POST`
-  request to the token endpoint (`https://uaa.cloud.gov/oauth/token`)
-  with the following form-encoded parameters:
+1.  First, exchange the `code` for an authorization token by sending a
+    `POST` request to the token endpoint
+    (`https://uaa.cloud.gov/oauth/token`) with the following form-encoded
+    parameters:
 
-  - `code=<CODE FROM QUERY PARAM IN CALLBACK REQUEST>`
-  - `grant_type='authorization_code'`
-  - `response_type='token'`
-  - `client_id=<YOUR APP'S REGISTERED NAME>`
-  - `client_secret=<THE SECRET KEY YOU RECEIVED WHEN REGISTERING YOUR APP>`
+    - `code=<CODE FROM QUERY PARAM IN CALLBACK REQUEST>`
+    - `grant_type='authorization_code'`
+    - `response_type='token'`
+    - `client_id=<YOUR APP'S REGISTERED NAME>`
+    - `client_secret=<THE SECRET KEY YOU RECEIVED WHEN REGISTERING YOUR APP>`
 
-  `2)` If everything works and UAA is able to verify your request, the response
-  from that `POST` request will be JSON encoded and will contain these important
-  members:
+2.  If everything works and UAA is able to verify your request, the response
+    from that `POST` request will be JSON encoded and will contain these
+    important members:
 
-  - `access_token` - a [JSON Web Token](https://jwt.io/)
-  - `expires_in` - time in seconds until the `access_token` expires
-  - `refresh_token` - a refresh token that can be exchanged for another
-  `access_token` when the current one expires
+    - `access_token` - a [JSON Web Token](https://jwt.io/)
+    - `expires_in` - time in seconds until the `access_token` expires
+    - `refresh_token` - a refresh token that can be exchanged for another
+      `access_token` when the current one expires
 
-  `3)` The `access_token` is a JSON Web Token that can be decoded using a
-  library such as [node-jsonwebtoken](https://github.com/auth0/node-jsonwebtoken).
-  See https://jwt.io/ for a list of libraries for various languages. Decode it
-  to get the authenticated user's `email`, which you can then use within
-  your application to identify and/or authorize the user.
+3.  The `access_token` is a JSON Web Token that can be decoded using a
+    library such as [node-jsonwebtoken](https://github.com/auth0/node-jsonwebtoken).
+    See https://jwt.io/ for a list of libraries for various languages. Decode it
+    to get the authenticated user's `email`, which you can then use within
+    your application to identify and/or authorize the user.
 
-  If you get an expired token error at some point in the future, you can
-  exchange the `refresh_token` from the previous step to get a new `access_token`,
-  so you might want to securely save the `refresh_token` associated with the
-  authenticated user.
+    If you get an expired token error at some point in the future, you can
+    exchange the `refresh_token` from the previous step to get a new `access_token`,
+    so you might want to securely save the `refresh_token` associated with the
+    authenticated user.
 
+For an example of this entire process in under 100 lines of node JS, see the
+[example client](https://github.com/18F/cg-fake-uaa/tree/master/example-client).
 
-#### Token Exchange Example Code
+## Using the fake UAA server
 
-```javascript
-const UAA_TOKEN_URL = 'https://uaa.cloud.gov/oauth/token';
-
-// Exchanges an authorization code for an authorization token
-function exchangeCodeForAuthToken(code, callback) {
-  request.post(UAA_TOKEN_URL, {
-    form: {
-      code,
-      grant_type: 'authorization_code',
-      response_type: 'token',
-      client_id: CLIENT_ID,
-      client_secret: CLIENT_SECRET,
-    },
-  }, callback);
-}
-
-// Handler for the registered callback URL
-app.get('/auth/callback', (req, res) => {
-  if (!req.query.code) {
-    res.status(400).send('Missing "code" query parameter');
-    return;
-  }
-
-  exchangeCodeForAuthToken(req.query.code, (err, response, body) => {
-    if (err) {
-      res.status(400).send(err);
-      return;
-    }
-
-    const responseBody = JSON.parse(body);
-
-    // The access token is a JSON Web Token, which can be decoded
-    // to retrieve encoded information.
-    // ref: https://jwt.io/
-    // The module used here is https://github.com/auth0/node-jsonwebtoken
-    const decodedToken = jwt.decode(responseBody.access_token);
-    const userEmail = decodedToken.email;
-
-    res.send(`Hello, ${userEmail}! You have successfully authenticated.`);
-  });
-});
-```
+During development, you may want to authenticate against a local server
+running [cg-fake-uaa](https://github.com/18F/cg-fake-uaa), a minimal
+"fake" version of the cloud.gov UAA server. Aside from making login easier
+and allowing for offline development, it also makes the OAuth handshake
+easier to debug.
 
 ## Resources
 


### PR DESCRIPTION
This fixes #321:
- Converts some of the workarounds to https://github.com/18F/web-design-standards/issues/1328 into nested lists, as that USWDS issue has been resolved.
- Links to [The Importance of the state parameter in OAuth2](http://www.twobotechnologies.com/blog/2014/02/importance-of-state-in-oauth2.html).
- Mentions [cg-fake-uaa](https://github.com/18F/cg-fake-uaa).
- Replaces the incomplete code snippet with a link to [cg-fake-uaa's example client](https://github.com/18F/cg-fake-uaa/tree/master/example-client).
