### PR TITLE
Link open source policy instead of reproducing it

### DIFF
--- a/content/ops/procedures.md
+++ b/content/ops/procedures.md
@@ -11,11 +11,6 @@ Accounts in the metrics site require GitHub login. Local accounts are not allowe
 
 ### Working in the open
 
-In the cloud.gov project we open everything from start but there are a couple things that are not allowed to be public. Please use your discretion and if you have doubts please ask in #cloud-gov.
-Here is a list of things that are prohibited from being publicly disclosed:
+As part of 18F, the cloud.gov team follows our [18F Open Source Policy](https://github.com/18F/open-source-policy/blob/master/policy.md) and its guide to [practicing our open source policy](https://github.com/18F/open-source-policy/blob/master/practice.md), including [protecting sensitive information](https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information).
 
-- PII (both for employees and users)
-- IP addresses (both internal and external unless required for operational purposes)
-- Passwords, API keys, TLS keys, Oauth secrets or any other "secret"
-
-You can see examples on how to load secrets to a BOSH manifest here: https://github.com/18F/cg-deploy-cf
+You can see examples for how to load secrets to a BOSH manifest here: https://github.com/18F/cg-deploy-cf


### PR DESCRIPTION
Following up on further documenting our policies for responsibly working in the open (https://github.com/18F/cg-compliance/issues/174).
