### PR TITLE
Another way to add info about SSH in E/W and GovCloud

### DIFF
--- a/content/getting-started/one-off-tasks.md
+++ b/content/getting-started/one-off-tasks.md
@@ -7,7 +7,7 @@ aliases:
 - /getting-started/cf-ssh/
 ---
 
-There are a couple of ways to run one off tasks in Cloud Foundry. The most reliable way to do one-off tasks is by deploying a short-lived app.
+There are a couple of ways to run one-off tasks in cloud.gov's version of Cloud Foundry. The most reliable way to do one-off tasks is by deploying a short-lived app.
 
 ## Disclaimers
 
@@ -57,13 +57,17 @@ The idea here is that we are going to deploy a new application, but running the 
 1. If needed, use [`cf files`][] to collect any artifacts.
 1. Run `cf delete task-runner` to clean it up.
 
-## CF SSH
+## CF-SSH or CF SSH
+
+*These instructions are different depending on the "environment" your application lives in. If you're not sure, pick East/West. (GovCloud is our new environment.)*
+
+### *East/West environment:* CF-SSH
 
 Another way to run one-off commands is via `cf-ssh`. `cf-ssh` is a shared ssh session with an application container that you can connect to. This allows you to debug the environment and your application without disturbing a running container.
 
 Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not use the community version of [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html)**. Also note that only one person can use `cf-ssh` for any particular app at any particular time.
 
-### Installation
+#### Installation
 
 1. [Download cloud.gov's `cf-ssh` for your environment](https://github.com/18F/cf-ssh/releases/) ([source](https://github.com/18F/cf-ssh/tree/18f)).
 1. Run
@@ -74,7 +78,7 @@ Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not
     if [ -w /usr/local/bin ]; then mv cf-ssh /usr/local/bin; else sudo mv cf-ssh /usr/local/bin; fi
     ```
 
-### Usage
+#### Usage
 
 1. In your project folder, run
 
@@ -89,3 +93,10 @@ Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not
 1. When done, run `exit`.
 
 [`cf files`]: http://cli.cloudfoundry.org/en-US/cf/files.html
+
+
+### *GovCloud environment:* CF SSH
+
+Another way to run one-off commands is via `cf ssh`, which lets you securely login to an application instance where you can perform debugging, environment inspection, and other tasks.
+
+[`cf ssh`]: https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html

--- a/content/getting-started/one-off-tasks.md
+++ b/content/getting-started/one-off-tasks.md
@@ -97,6 +97,4 @@ Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not
 
 ### *GovCloud environment:* CF SSH
 
-Another way to run one-off commands is via `cf ssh`, which lets you securely login to an application instance where you can perform debugging, environment inspection, and other tasks.
-
-[`cf ssh`]: https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html
+Another way to run one-off commands is via [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-command), which lets you securely login to an application instance where you can perform debugging, environment inspection, and other tasks.

--- a/content/getting-started/one-off-tasks.md
+++ b/content/getting-started/one-off-tasks.md
@@ -57,7 +57,7 @@ The idea here is that we are going to deploy a new application, but running the 
 1. If needed, use [`cf files`][] to collect any artifacts.
 1. Run `cf delete task-runner` to clean it up.
 
-## CF-SSH or CF SSH
+## CF SSH
 
 *These instructions are different depending on the "environment" your application lives in. If you're not sure, pick East/West. (GovCloud is our new environment.)*
 


### PR DESCRIPTION
This is an experiment based on the info at https://github.com/18F/cg-docs/pull/379 and https://github.com/18F/cg-docs/pull/380. Instead of removing the E/W info (like 379) or fully duplicating the sections (like 380), I tried just duplicating the sections that changed, since I suspect this might be easier for readers to understand (and for us to maintain).

cc @sushiandbeer - I'm curious if this makes sense to you.
