### PR TITLE
Change `rds` to `aws-rds`

### DIFF
--- a/content/apps/databases.md
+++ b/content/apps/databases.md
@@ -19,10 +19,10 @@ cf bind-service <APP_NAME> <DB_NAME>
 cf restage <APP_NAME>
 ```
 
-If you want to use PostgreSQL, use the `rds` service rather than `postgresql*`. This gives you things like database snapshots automatically. The `shared-psql` plan(s) uses an existing instance, which is preferred for staging environments or simple open data apps. For a production application with sensitive data, use `micro-psql` or `medium-psql`. To use the `rds` service with `myapp` in your staging environment, for example, you would do something like:
+If you want to use PostgreSQL, use the `aws-rds` service rather than `postgresql*`. This gives you things like database snapshots automatically. The `shared-psql` plan(s) uses an existing instance, which is preferred for staging environments or simple open data apps. For a production application with sensitive data, use `micro-psql` or `medium-psql`. To use the `aws-rds` service with `myapp` in your staging environment, for example, you would do something like:
 
 ```bash
-cf create-service rds shared-psql myapp-staging-db
+cf create-service aws-rds shared-psql myapp-staging-db
 cf bind-service myapp myapp-staging-db
 cf restage myapp
 ```


### PR DESCRIPTION
I believe `aws-rds` is the preferred service to use now.
