### PR TITLE
Adding mention of the HTTPS-Only Standard and HSTS

### DIFF
--- a/content/apps/custom-domains.md
+++ b/content/apps/custom-domains.md
@@ -13,7 +13,7 @@ The [Manual Method](#manual-method) is available to all users. We've also develo
 
 The Manual Method supports user access to your application over IPv6 if your DNS supports IPv6.
 
-For all custom domains, we recommend incorporating [HTTPS-Only Standard guidance](https://https.cio.gov/), including [HSTS preloading](https://https.cio.gov/hsts/).
+For all custom domains, we recommend incorporating [HTTPS-Only Standard guidance](https://https.cio.gov/), including [HSTS](https://https.cio.gov/hsts/) and [preloading](https://https.cio.gov/guide/#options-for-hsts-compliance).
 
 If you need to set up an app on a domain managed by GSA TTS, you may also be interested in [18F/dns](https://github.com/18F/dns).
 

--- a/content/apps/custom-domains.md
+++ b/content/apps/custom-domains.md
@@ -13,6 +13,8 @@ The [Manual Method](#manual-method) is available to all users. We've also develo
 
 The Manual Method supports user access to your application over IPv6 if your DNS supports IPv6.
 
+For all custom domains, we recommend incorporating [HTTPS-Only Standard guidance](https://https.cio.gov/), including [HSTS preloading](https://https.cio.gov/hsts/).
+
 If you need to set up an app on a domain managed by GSA TTS, you may also be interested in [18F/dns](https://github.com/18F/dns).
 
 ## Manual Method


### PR DESCRIPTION
A while back I asked @konklone if we should include anything here to support good HTTPS practices, and he suggested mentioning this.

https://18f.slack.com/archives/cloud-gov-support/p1470696022000946

https://18f.slack.com/archives/cloud-gov-support/p1470748039000956

Phrased gently as a recommendation, since handling this is a customer responsibility.
