### PR TITLE
helps better align to CM-1

### DIFF
--- a/content/ops/configuration-management.md
+++ b/content/ops/configuration-management.md
@@ -12,10 +12,11 @@ In short, everything needed to run and operate the platform that is not a _secre
 
 Here are some examples:
 
+- CI Pipelines (Concourse)
 - Infrastructure/Network configuration (Terraform)
 - VM setup and quantity (Bosh)
 - Software configuration (Bosh)
-- CI Pipelines (Concourse)
+
 
 ## Where should all this configuration go?
 All configuration must be stored in GitHub using the following "Change Workflow" unless it is a _secret_.

--- a/content/ops/configuration-management.md
+++ b/content/ops/configuration-management.md
@@ -8,7 +8,7 @@ title: Configuration Management
 This document describes how the 18F cloud.gov team approaches configuration management of the core platform.
 
 ## What goes into configuration management?
-In short, everything needed to run and operate the platform that is not a _secret_.
+In short, everything needed to run and operate the platform that is not a _secret_. 
 
 Here are some examples:
 


### PR DESCRIPTION
Concourse is technically "run" before Terraform, so good to put them in chronological order.
