### PR TITLE
Update govcloud.md (typos, grammar, outdated info).

### DIFF
--- a/content/apps/govcloud.md
+++ b/content/apps/govcloud.md
@@ -2,13 +2,13 @@
 menu:
   main:
     parent: apps
-title: What Is New in Govcloud?
+title: What's New in Cloud.gov?
 ---
 
-The new environment is a bit different and full of shiny new things here is some and how use them:
+The new environment is a bit different and full of shiny new things.  Here are some and how to use them:
 
-The new API endpoint (for now) is api.fr.cloud.gov. To use it: `cf login -a api.fr.cloud.gov --sso`. Your GSA/EPA credentials should still work there, no other credentials work at this time.
+The new API endpoint (for now) is `api.cloud.gov`. To use it: `cf login -a api.cloud.gov --sso` for GSA/EPA accounts and `cf login -a api.cloud.gov` for non-GSA/EPA accounts. See [Setting Up Your Account]({{< relref "../getting-started/accounts.md" >}}) for more information.
 
-`cf-ssh` is gone, long live `cf ssh`. With the current cli you have in your environment you should be able to run `cf ssh` in the new environment. `cf-ssh` is not supported in the govcloud environment.
+`cf-ssh` is gone, long live `cf ssh`. With the [current cli](https://docs.cloudfoundry.org/devguide/installcf/install-go-cli.html), you should be able to run `cf ssh` for access to your apps. The `cf-ssh` command is no longer supported on cloud.gov.
 
-If you are going to be working in both east-west and govcloud environments, this plugin might be helpful: https://github.com/guidowb/cf-targets-plugin.
+If you are going to be working in both AWS east-west and govcloud environments, [this CloudFoundry plugin](https://github.com/guidowb/cf-targets-plugin) might be helpful.


### PR DESCRIPTION
This page seems a little odd to me, like it was left over from a very, very old iteration of cloud.gov documentation. So I'm submitting the pull request to clean up the language and make it consistent, but I'd suggest that perhaps this page could go away in lieu of a proper "updates" section or something to that effect. Do with it what you will.  😃 
