### PR TITLE
Copyedits for a few newcomer doc pages

### DIFF
--- a/content/apps/troubleshooting.md
+++ b/content/apps/troubleshooting.md
@@ -7,36 +7,36 @@ linktitle: Troubleshooting
 weight: 100
 ---
 
-Below are some common problems and recommended practices for solving them. Make sure to [look at the logs]({{< relref "logs.md" >}}) to help troubleshoot.
+Here are some common problems and recommended practices for solving them. Make sure to [look at the logs]({{< relref "logs.md" >}}) to help troubleshoot.
 
 ## [STG] Staging Phase
 
 ### App dependency specification
 
-Dependencies are resolved during staging. For information beyond what's presented in `cf logs` Use the the verbose logging option for your buildpack if available.
+Dependencies are resolved during staging. For information beyond what's presented in `cf logs`, use the the verbose logging option for your buildpack if available.
 
 For example, `cf set-env APPNAME VERBOSE true` enables verbose logging for the default node.js buildpack.
 
 ### App size and build complexity
 
 - Pushed application files must total less than 1GB. Use `.cfignore` to specify files which should be excluded from the push.
-- The combined size of application files and the specified buildpack must totale less 1.5GB.
+- The combined size of application files and the specified buildpack must total less than 1.5GB.
 - The entire compiled droplet must total less than 4GB.
 - Staging must complete with 15 minutes and application must start within 5 minutes by default.
 
 ### Buildpacks used
 
-Cloud Foundry will attempt to detect the buildpack to use with your app by examining the application files in search Use the `buildpack:` key in your manifest to specify a native buildpack by name or a custom buildpack by providing a URL. Override the buildpack setting and detection with the `-b` commandline switch which takes the same arguments.
+Cloud Foundry will attempt to detect the buildpack to use with your app by examining the application files. Use the `buildpack:` key in your manifest to specify a native buildpack by name or a custom buildpack by providing a URL. Override the buildpack setting and detection with the `-b` command line switch, which takes the same arguments.
 
 ### Python dependency errors
 
-If you're seeing errors installing any Python dependencies, check if you've got a `vendor/` directory in your app's root. The Python buildpack won't use PyPI if you have a `vendor/` directory, so you'll need to rename that directory to something else.
+If you're seeing errors installing any Python dependencies, check whether you have a `vendor/` directory in your app's root. The Python buildpack won't use PyPI if you have a `vendor/` directory, so you'll need to rename that directory to something else.
 
 ## [DEA] Droplet Execution Phase
 
 ### App manifest contents
 
-When starting multiple apps via a single manifest tree apps will start in the order they are encountered. Ensure worker apps running queues or migrations start before the apps which depend on them.
+When starting multiple apps via a single manifest tree, apps will start in the order they are encountered. Ensure worker apps running queues or migrations start before the apps which depend on them.
 
 ### Command line options to cf push
 
@@ -47,13 +47,13 @@ Application start commands are cached during staging. Specifying a start command
 ### Environment variables and service bindings
 
 - Apps must listen on the port specified in the `VCAP_APP_PORT` environment variable.
-- Environment variables are updated when the app is staged and persist between application restarts. Be sure to run `cf restage` after updating an variables.
-- Specify services in the application manifest via the `application:key`, bindings will be created when the application is pushed. Avoid creating creating bindings after the fact with `cf bind-service` as that will create a hidden dependency
-- Service instance credentials and connection parameters are stored the JSON formatted `VCAP_SERVICES`. The format of this variable differs between v1 and v2 services, see [this section](http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES) of the Cloud Foundry docs for more information.
+- Environment variables are updated when the app is staged and persist between application restarts. Be sure to run `cf restage` after updating variables.
+- Specify services in the application manifest via the `application:key`. Bindings will be created when the application is pushed. Avoid creating bindings after the fact with `cf bind-service` as that will create a hidden dependency.
+- Service instance credentials and connection parameters are stored in the JSON-formatted `VCAP_SERVICES`. The format of this variable differs between v1 and v2 services; see [this section](http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES) of the Cloud Foundry docs for more information.
 - Inspect the entire application environment including `VCAP_SERVICES` with `cf env APPNAME`.
 
 ### Application start up time
 
-By default, applications must start with 60 seconds. This timeout can be extend to a maximum of 180 second via the `-t` command line switch or `timeout:` manifest key.
+By default, applications must start with 60 seconds. This timeout can be extended to a maximum of 180 second via the `-t` command line switch or `timeout:` manifest key.
 
-Avoid placing long running or multi-step tasks in the application start command. Consider using worker apps as part of a multi-application manifest instead.
+Avoid placing long-running or multi-step tasks in the application start command. Consider using worker apps as part of a multi-application manifest instead.

--- a/content/apps/troubleshooting.md
+++ b/content/apps/troubleshooting.md
@@ -22,7 +22,7 @@ For example, `cf set-env APPNAME VERBOSE true` enables verbose logging for the d
 - Pushed application files must total less than 1GB. Use `.cfignore` to specify files which should be excluded from the push.
 - The combined size of application files and the specified buildpack must total less than 1.5GB.
 - The entire compiled droplet must total less than 4GB.
-- Staging must complete with 15 minutes and application must start within 5 minutes by default.
+- Staging must complete within 15 minutes and application must start within 5 minutes by default.
 
 ### Buildpacks used
 
@@ -54,6 +54,6 @@ Application start commands are cached during staging. Specifying a start command
 
 ### Application start up time
 
-By default, applications must start with 60 seconds. This timeout can be extended to a maximum of 180 second via the `-t` command line switch or `timeout:` manifest key.
+By default, applications must start within 60 seconds. This timeout can be extended to a maximum of 180 second via the `-t` command line switch or `timeout:` manifest key.
 
 Avoid placing long-running or multi-step tasks in the application start command. Consider using worker apps as part of a multi-application manifest instead.

--- a/content/getting-started/concepts.md
+++ b/content/getting-started/concepts.md
@@ -5,15 +5,15 @@ menu:
 title: Concepts
 ---
 
-You might want to look at the [cloud.gov terminology]({{< relref "intro/terminology/system-terminology.md" >}}) page first, if you haven't already.
+Here's an overview of key cloud.gov terms and concepts. cloud.gov uses Cloud Foundry terms, so the [Cloud Foundry glossary](http://docs.cloudfoundry.org/concepts/glossary.html) is a helpful reference too.
 
 ## Organizations
 
-Cloud Foundry groups its users by [organizations](http://docs.cloudfoundry.org/concepts/roles.html#orgs), or "orgs" for short. Orgs group together users for management and present a shared perimeter for services, domains and quotas. When your account is created, it will be given permissions to an org and a personal space.
+Cloud Foundry groups its users by [organizations](http://docs.cloudfoundry.org/concepts/roles.html#orgs), or "orgs" for short. Orgs group together users for management and present a shared perimeter for services, domains and quotas. When your account is created, it gets permissions to an org and a personal space.
 
 ### Naming convention
 
-Within 18F, the `ORGNAME` will correspond to a project/client, e.g. `cap` for GSA's [Common Acquisition Platform](https://18f.gsa.gov/dashboard/project/C2/), or `devops` for internal apps like [Hubot](https://github.com/18F/18f-bot).
+Within 18F, the `ORGNAME` corresponds to a project/client, e.g. `cap` for GSA's [Common Acquisition Platform](http://www.gsa.gov/portal/category/106839), or `devops` for internal apps such as [Hubot](https://github.com/18F/18f-bot).
 
 ### List available orgs
 
@@ -21,7 +21,7 @@ Within 18F, the `ORGNAME` will correspond to a project/client, e.g. `cap` for GS
 cf orgs
 ```
 
-Only orgs where you've been assigned an org-role or those which contain a space where you've been assigned a space-role will appear.
+This only displays orgs where you've been assigned an org role, or those which contain a space where you've been assigned a space role.
 
 ### See details about a specific org
 
@@ -45,7 +45,7 @@ Every application is scoped to a [space](http://docs.cloudfoundry.org/concepts/r
 
 ### Naming convention
 
-Within 18F, the `SPACENAME` will correspond to an environment, e.g. `dev` or `prod`. If the org is more general (e.g. `devops`), the space may correspond to the name of the project (e.g. `hubot`).
+Within 18F, the `SPACENAME` corresponds to an environment, e.g. `dev` or `prod`. If the org is more general (e.g. `devops`), the space may correspond to the name of the project (e.g. `hubot`).
 
 ### Management
 
@@ -55,7 +55,7 @@ To create a space:
 cf create-space SPACENAME
 ```
 
-**Note:**  To create a space within a given org you must have the `OrgManager` role. You can check to see which users and managers for your org with:
+**Note:**  To create a space within a given org, you must have the `OrgManager` role. You can see which users are managers for your org with:
 
 ```bash
 cf org-users ORGNAME
@@ -63,7 +63,7 @@ cf org-users ORGNAME
 
 ## Target
 
-The Cloud Foundry CLI keeps a global state of whatever [organization]({{< relref "#organizations" >}})+[space]({{< relref "#spaces" >}}) you're interacting with. This is known as the "target", and is set via
+The Cloud Foundry CLI keeps a global state of whatever [organization]({{< relref "#organizations" >}})+[space]({{< relref "#spaces" >}}) you're interacting with. This is known as the "target", and you can set it with:
 
 ```bash
 cf target -o ORGNAME -s SPACENAME
@@ -71,11 +71,11 @@ cf target -o ORGNAME -s SPACENAME
 
 ## Buildpacks
 
-All apps need to use a "buildpack" specific to their language, which sets up dependencies for particular language stacks. There are [standard buildpacks for most languages](https://docs.cloudfoundry.org/buildpacks/), and they will usually be auto-detected by Cloud Foundry. Using the standard buildpacks is strongly encouraged. In the rare case where the buildpack does not get detected correctly, or to use a custom buildpack, it can be specified in the manifest (as below) or with the `-b` flag. Use either the buildpack name:
+All apps need to use a "buildpack" specific to their language, which sets up dependencies for particular language stacks. There are [standard buildpacks for most languages](https://docs.cloudfoundry.org/buildpacks/), and they will usually be auto-detected by Cloud Foundry. We strongly encourage you to use the standard buildpacks. In the rare case where the buildpack does not get detected correctly, or to use a custom buildpack, you can specify it in the manifest (as below) or with the `-b` flag. Use either the buildpack name:
 
     buildpack: python_buildpack
 
-or a URL to reference it.
+Or a URL to reference it:
 
     buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
 
@@ -86,8 +86,8 @@ If you might need multiple buildpacks for an app, see [Multi-Language Projects](
 
 ### Buildpack Release Schedule
 
-18F's selection of buildpacks may occasionally lag behind CF's by a month or more (except for security patches), in which case you may sometimes need to specify the URL in order to get a more up-to-date version. The buildpack release schedule looks like the following:
+18F's selection of buildpacks may occasionally lag behind CF's by a month or more (except for security patches), in which case you may need to specify the URL in order to get a more up-to-date version. The buildpack release schedule looks like the following:
 
 - The CF buildpack team develops on a branch and cuts buildpack releases.
 - The CF release team cuts a release for CF with new buildpacks every ~2 weeks.
-- 18F grabs those releases and deploys them as soon as we can (sometimes it takes a while).
+- 18F grabs those releases and deploys them as soon as we can.

--- a/content/getting-started/your-first-deploy.md
+++ b/content/getting-started/your-first-deploy.md
@@ -6,9 +6,10 @@ title: Your First Deploy
 weight: -30
 ---
 
-To get used to Cloud Foundry, we recommend that you practice by deploying a simple application before moving into deploying something for production. This was originally written as an outline for live training, so will be expanded over time.
+cloud.gov is an instance of Cloud Foundry, so [the Cloud Foundry documentation](http://docs.cloudfoundry.org), Stack Overflow questions, etc. should mostly be applicable.
 
-The first thing to know is that cloud.gov is a stock instance of Cloud Foundry, so [the general Cloud Foundry documentation](http://docs.cloudfoundry.org), Stack Overflow questions, etc. should mostly be applicable.
+To get used to Cloud Foundry, we recommend that you practice by deploying a simple application before moving into deploying something for production.
+
 
 ## Deploying
 
@@ -16,6 +17,6 @@ The first thing to know is that cloud.gov is a stock instance of Cloud Foundry, 
 1. [Deploy a "hello world" application.](https://github.com/18F/cf-hello-worlds#readme)
 1. Tweak the app (without committing) and re-`push`.
 
-Note that the changes will be reflected in Cloud Foundry even without being committed to Git. Cloud Foundry is not Git-aware – it simply deploys whatever is contained in the directory that you `push` from. That being said, you _can_ set up [continuous deployment]({{< relref "apps/continuous-deployment.md" >}}) from a Git repository.
+The changes will be reflected in Cloud Foundry even without being committed to Git. Cloud Foundry is not Git-aware – it simply deploys whatever is contained in the directory that you `push` from. That being said, you _can_ set up [continuous deployment]({{< relref "apps/continuous-deployment.md" >}}) from a Git repository.
 
 Next, take a look at the [Concepts]({{< relref "concepts.md" >}}) page. Once you're ready to deploy your own application, head over to the [general deployment tips]({{< relref "apps/deployment.md" >}}).


### PR DESCRIPTION
Copyedits for Your First Deploy, Concepts, and Troubleshooting, to help first-time readers have a smoother reading experience.
- Fixing typos and adding missing words
- "Concepts" started by referring people to a page that had one external link, so I replaced that with a link.
- Present tense
- Slightly more standard framing for example commands
