### PR TITLE
Moving custom buildpack info to experiments section

### DIFF
--- a/content/apps/apt-get.md
+++ b/content/apps/apt-get.md
@@ -1,10 +1,14 @@
 ---
 menu:
   main:
-    parent: apps
+    parent: experimental
 title: Using apt-get
 ---
 
-18F Cloud Foundry does not allow the use of `sudo` inside of buildpacks. If your app depends on a library that is `apt-get` installable, use the CF-flavor of the [`apt-buildpack`](https://github.com/pivotal-cf-experimental/apt-buildpack). This works great with [`buildpack-multi`]({{< relref "multi-buildpack-deploys.md" >}}).
+[**This uses an experimental feature.**]({{< relref "apps/experimental/experimental.md" >}})
+
+cloud.gov does not allow the use of `sudo` inside of buildpacks. If your app depends on a library that is `apt-get` installable, use the CF-flavor of the [`apt-buildpack`](https://github.com/pivotal-cf-experimental/apt-buildpack). This works great with [`cf-buildpack-multi`]({{< relref "multi-buildpack-deploys.md" >}}).
+
+`apt-buildpack` and `cf-buildpack-multi` are [custom buildpacks]({{< relref "apps/experimental/custom-buildpacks.md" >}}).
 
 You can see this in the wild in 18F's [`iaa-pdf-api`](https://github.com/18f/iaa-pdf-api) repo, which depends on the [`pdftk`](https://www.pdflabs.com/tools/pdftk-server/) library.

--- a/content/apps/multi-buildpack-deploys.md
+++ b/content/apps/multi-buildpack-deploys.md
@@ -1,14 +1,25 @@
 ---
-date: 2015-07-10T14:32:59-04:00
 menu:
   main:
-    parent: advanced
+    parent: experimental
 title: Multi-Language Projects
 ---
 
-CloudFoundry is capable of deploying multi-language projects by using a special [buildpack](https://bitbucket.org/cf-utilities/cf-buildpack-multi). In short, this buildpack applies any buildpacks listed in the `.buildpacks` file.
+# Supported methods
 
-Instead of using buildpack-multi, consider splitting your application into smaller components. If you are using buildpack-multi to run multiple long-running processes, you should run them as separate cloud.gov applications instead. If you're investigating multi-buildpack deploys to build static assets on cloud.gov, you can avoid this issue by [building assets on CI]({{< relref "assets.md#build-assets-on-ci" >}}).
+If you're setting up a multi-language project that might need `cf-buildpack-multi`, here are alternative supported ways to do that:
+
+* Split your project into smaller applications, so that you can use a supported buildpack for each application.
+* To run multiple long-running processes, run them as separate applications.
+* To build static assets on cloud.gov, [build assets on CI]({{< relref "assets.md#build-assets-on-ci" >}}).
+
+# buildpack-multi
+
+[**This uses an experimental feature.**]({{< relref "apps/experimental/experimental.md" >}})
+
+CloudFoundry is capable of deploying multi-language projects by using a special buildpack, [`cf-buildpack-multi`](https://bitbucket.org/cf-utilities/cf-buildpack-multi). This buildpack applies any buildpacks listed in the `.buildpacks` file. `cf-buildpack-multi` is a [custom buildpack]({{< relref "apps/experimental/custom-buildpacks.md" >}}). 
+
+
 
 ## Preparing an app for a multi-buildpack deploy
 
@@ -33,4 +44,4 @@ https://github.com/cloudfoundry/nodejs-buildpack
 ```
 
 ## Debugging
-Multi-buildpacks deploys can be difficult to debug because [cf-buildpack-multi](https://bitbucket.org/cf-utilities/cf-buildpack-multi) hides the error logs. For more verbose output use [ozzyjohnson/heroku-buildpack-multi](https://github.com/ozzyjohnson/heroku-buildpack-multi).
+Multi-buildpacks deploys can be difficult to debug because [`cf-buildpack-multi`](https://bitbucket.org/cf-utilities/cf-buildpack-multi) hides the error logs.


### PR DESCRIPTION
This moves info about [apt-buildpack](https://docs.cloud.gov/apps/apt-get/) and [buildpack-multi](https://docs.cloud.gov/apps/multi-buildpack-deploys/) into our experiments section (without breaking their URLs).

I reframed the buildpack-multi page to start with clearly-marked supported recommendations and then explain the experimental option. Please fact-check this change to make sure I didn't introduce errors. :D

This helps with https://github.com/18F/cg-docs/issues/248, although it doesn't fully resolve the problem.

I also removed a link to https://github.com/ozzyjohnson/heroku-buildpack-multi since that seemed unmaintained.
