### PR TITLE
Use official node image.

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -3,18 +3,10 @@
 set -e
 set -x
 
-# install dependencies, for the following (respectively): NPM, node-sass, Hugo
-# https://github.com/18F/cg-docs/issues/279
-apk add --no-cache --update \
-  git \
-  g++ make python \
-  ca-certificates wget
-
 # install Hugo
-# https://github.com/jojomi/docker-hugo/blob/f4f0b5f777950d3621340c514ad668df46136fd9/Dockerfile
 HUGO_VERSION=0.16
 cd /tmp/
-wget https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-64bit.tgz
+curl -O -L https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-64bit.tgz
 tar xzf hugo_${HUGO_VERSION}_linux-64bit.tgz
 mv hugo /usr/bin/hugo
 cd -

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -2,8 +2,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: mhart/alpine-node
-    tag: '4'
+    repository: node
 inputs:
 - name: cg-docs-source
 outputs:


### PR DESCRIPTION
[Resolves #437]

I know alpine is great and all, but building with the official image is still fast, and there should be no difference in build time once the image is cached. If @LinuxBozo or @afeld think this is dumb, I'll make a new image from alpine-node that includes requirements for gyp instead.
