### PR TITLE
Adding link + removing unhelpful bit from config management page

### DIFF
--- a/content/ops/configuration-management.md
+++ b/content/ops/configuration-management.md
@@ -4,6 +4,9 @@ menu:
     parent: operations
 title: Configuration Management
 ---
+
+<!-- This page is important for FedRAMP compliance. See the CM family of controls, including CM-9. -->
+
 This document describes how the 18F cloud.gov team approaches configuration management of the core platform.
 
 ## What goes into configuration management?

--- a/content/ops/configuration-management.md
+++ b/content/ops/configuration-management.md
@@ -4,28 +4,27 @@ menu:
     parent: operations
 title: Configuration Management
 ---
-# Configuration Management Plan
 This document describes how the 18F cloud.gov team approaches configuration management of the core platform.
 
 ## What goes into configuration management?
-In short, everything needed to run and operate the platform that is not a _secret_. 
+In short, everything needed to run and operate the platform that is not a _secret_. (See [Secret Key Management]({{< relref "ops/secrets.md" >}}) for that.)
 
-Here are some examples:
+Here are some examples that should be in configuration management:
 
-- CI Pipelines (Concourse)
-- Infrastructure/Network configuration (Terraform)
-- VM setup and quantity (Bosh)
-- Software configuration (Bosh)
+- CI pipelines (Concourse)
+- Infrastructure/network configuration (Terraform)
+- VM setup and quantity (BOSH)
+- Software configuration (BOSH)
 
 
 ## Where should all this configuration go?
 All configuration must be stored in GitHub using the following "Change Workflow" unless it is a _secret_.
 
 ## How do we test these changes?
-If possible, first test the changes locally. After that they need to be uploaded to a staging environment where either manual or automated testing needs to be run.
+If possible, first test the changes locally. After that, upload them to a staging environment where either manual or automated testing needs to be run.
 Security tests need to be executed in the staging environment where changes are applied.
 
-## Change Workflow
+## Change workflow
 
 1. All configuration changes must flow through a git repository, centrally managed through GitHub, unless they contain sensitive information. In these cases, sensitive information should be stored in an S3 bucket with a proper security policy, encryption, and versioned, so that changes can be easily rolled back.
 1. A change is initiated and discussed as a [GitHub issue in 18F/cg-atlas repository](https://github.com/18F/cg-atlas/issues).
@@ -40,14 +39,17 @@ is encouraged and qualifies as a review. Review should include architectural des
     - Any and all automated tests are run.
     - If all tests pass, changes can be promoted for deployment to production in the pipeline.
 
-1. The CI/CD tool uses GitHub repositories and S3 stored sensitive content as the canonical source of truth for what the platform should look like, and will reset the state of all systems to match in the case of any manual changes.
+1. The CI/CD tool uses GitHub repositories and S3 stored sensitive content as the canonical source of truth for what the platform should look like, and it will reset the state of all systems to match in the case of any manual changes.
 
 ![Pipeline Example](/img/pipeline-example.png)
 
 A more detailed example of this process can be seen in [Updating Cloud Foundry]({{< relref "updating-cf.md" >}}).
 
-## GitHub Contribution Guidelines
-### Forking vs Branching
+## What if a configuration changed and it is not in Configuration Management?
+If possible, Configuration Management tools need to be set up to always roll back to a known state. Other than that, these tools need to be able to "recreate" all settings from the known configurations.
+
+## GitHub contribution guidelines
+### Forking vs. branching
 
 The team prefers forking.
 
@@ -58,7 +60,7 @@ regardless of whether or not they may commit directly to the canonical repositor
 
 [Squashing commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Squashing-Commits) is allowed but discouraged, except in rare instances.
 
-### Rebase or Merge
+### Rebase or merge
 
 The team prefers [rebasing over merging](https://www.atlassian.com/git/tutorials/merging-vs-rebasing/).
 
@@ -76,13 +78,3 @@ context to request a review is preferred.
 ### When reviewing a PR, should the change be tested locally?
 
 Whenever possible, the proposed changes should be tested locally. Because of the nature of many of the cloud.gov repositories and deployment environments, local testing is not always possible or practical. Visual code review, however, is always required.
-
-## What if a configuration changed and it is not in Configuration Management?
-If possible Configuration Management tools need to be set up to always roll back to a known state. Other than that, these tools need to be able to "recreate" all settings from the known configurations.
-
-
-### Continuous Monitoring
-
-FedRAMP requires Cloud Service Providers (CSP) to continuously monitor and report vulnerabilities on the system.
-
-cloud.gov adopts the [FedRAMP Continuous Monitoring Strategy Guide](https://www.fedramp.gov/files/2015/03/FedRAMP-Continuous-Monitoring-Strategy-Guide-v2.0-3.docx) as its Continuous Monitoring process.


### PR DESCRIPTION
Changes:
- Add hidden note that this page is important for compliance
- Remove redundant title
- Link to [secret key management](https://docs.cloud.gov/ops/secrets/)
- Move configuration management topic from the bottom of the page into the main section
- Remove outdated mention of the FedRAMP Continuous Monitoring Strategy Guide (we have our own custom Continuous Monitoring Strategy Guide that aligns with it, which is just in Google Drive for now - see https://github.com/18F/cg-product/issues/290)
- Copyedits
