### PR TITLE
Switch search.usa.gov URL to HTTPS

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -44,7 +44,7 @@
         <nav role="navigation" class="header-side">
           <div class="usa-nav-inner">
             <div class="usa-nav-secondary">
-              <form class="usa-search js-search-form" accept-charset="UTF-8" action="http://search.usa.gov/search" id="search_form" method="get">
+              <form class="usa-search js-search-form" accept-charset="UTF-8" action="https://search.usa.gov/search" id="search_form" method="get">
                 <div role="search">
                   <label class="usa-sr-only" for="search-field-small">Search small</label>
                   <input id="affiliate" name="affiliate" type="hidden" value="cloud.gov" />


### PR DESCRIPTION
Since we were getting a mixed content warning. cc @adborden for review.
