### PR TITLE
Add more GovCloud info

### DIFF
--- a/content/apps/govcloud.md
+++ b/content/apps/govcloud.md
@@ -2,17 +2,17 @@
 menu:
   main:
     parent: apps
-title: GovCloud Transition Guide
+title: GovCloud Guide
 ---
 
 cloud.gov currently has two "environments" where orgs can live: the main environment that most orgs are using (located in AWS East/West) and a new GovCloud environment (located in [AWS GovCloud](https://aws.amazon.com/govcloud-us/)).
 
-When your org transitions to cloud.gov's GovCloud environment, here are changes to look out for.
+When your org starts using cloud.gov's GovCloud environment, here are changes to look out for.
 
 ### Breaking changes
 
 - GSA accounts still work in GovCloud. No other login credentials work at this time.
-- The new API endpoint (for now) is `api.fr.cloud.gov`. When you [log in on the command line]({{< relref "getting-started/setup.md" >}}), use this new command: `cf login -a api.fr.cloud.gov --sso`
+- The API endpoint (for now) is `api.fr.cloud.gov`. When you [log in on the command line]({{< relref "getting-started/setup.md" >}}), use this new command: `cf login -a api.fr.cloud.gov --sso`
 
 ### New features
 

--- a/content/apps/govcloud.md
+++ b/content/apps/govcloud.md
@@ -2,11 +2,28 @@
 menu:
   main:
     parent: apps
-title: What's New in GovCloud?
+title: GovCloud Transition Guide
 ---
 
-The [new environment](https://aws.amazon.com/govcloud-us/) is a bit different and full of shiny new things. Here are some examples:
+cloud.gov currently has two "environments" where orgs can live: the main environment that most orgs are using (located in AWS East/West) and a new GovCloud environment (located in [AWS GovCloud](https://aws.amazon.com/govcloud-us/)).
 
-- The new API endpoint (for now) is `api.fr.cloud.gov`. To use it: `cf login -a api.fr.cloud.gov --sso`. Your GSA/EPA credentials should still work there. No other credentials will work at this time.
-- `cf-ssh` is gone, long live `cf ssh`. With the current cli you have in your environment you should be able to run `cf ssh` in the new environment. `cf-ssh` is not supported in the GovCloud environment.
-- If you are going to be working in both AWS East/West and GovCloud environments, [this CloudFoundry plugin](https://github.com/guidowb/cf-targets-plugin) might be helpful.
+When your org transitions to cloud.gov's GovCloud environment, here are changes to look out for.
+
+### Breaking changes
+
+- GSA accounts still work in GovCloud. No other login credentials work at this time.
+- The new API endpoint (for now) is `api.fr.cloud.gov`. When you [log in on the command line]({{< relref "getting-started/setup.md" >}}), use this new command: `cf login -a api.fr.cloud.gov --sso`
+
+### New features
+
+- To run [one-off tasks]({{< relref "getting-started/one-off-tasks.md" >}}), [`cf-ssh`]({{< relref "getting-started/one-off-tasks.md#cf-ssh" >}}) is not available in GovCloud. Instead, you can use [`cf ssh`]({{< relref "getting-started/one-off-tasks.md#govcloud-environment-cf-ssh" >}}) (note the space instead of the `-`), which is more flexible than `cf-ssh`.
+- To set up custom domains, you can use the [managed service method]({{< relref "apps/custom-domains.md#managed-service-method" >}}).
+
+#### Experimental new features
+
+- You can [require cloud.gov authentication to access your application]({{< relref "apps/experimental/experimental-services.md#authorization-proxy" >}}).
+- You can [push Docker images]({{< relref "apps/experimental/docker.md" >}}).
+
+### Tips
+
+- If you need to work in both the East/West and GovCloud environments, [this Cloud Foundry plugin](https://github.com/guidowb/cf-targets-plugin) may be helpful.

--- a/content/apps/managing-teammates.md
+++ b/content/apps/managing-teammates.md
@@ -7,6 +7,8 @@ title: Managing Teammates
 
 ## Invite a teammate
 
+_For teams in the main cloud.gov environment (East/West):_
+
 If you're part of a team using cloud.gov, you can invite teammates to get cloud.gov accounts. You can invite anyone you need to work with, including federal employees and federal contractors.
 
 1. [Send them an invite](https://login.cloud.gov/invitations/new) (this may prompt you to log into your cloud.gov account first).
@@ -15,11 +17,17 @@ If you're part of a team using cloud.gov, you can invite teammates to get cloud.
 
 Now they have a cloud.gov account. If you invited them with an agency email address and they're part of an agency that has automatic sandbox spaces, they'll automatically get a sandbox space in their agency's cloud.gov org.
 
+_For teams in the GovCloud environment:_
+
+To add a teammate who has a GSA account and hasn't used cloud.gov, ask them to log into cloud.gov with their GSA credentials (using the [web interface](https://login.fr.cloud.gov/) or at the command line with `cf login -a api.fr.cloud.gov --sso`). cloud.gov creates a cloud.gov account for them when they log in.
+
+This environment doesn't support non-GSA accounts yet, but we're working on supporting this soon. Please [ask us for help]({{< relref "help.md" >}}) if have questions about this.
+
 ## Give roles to a teammate
 
 After a teammate gets a cloud.gov account, an Org Manager or Space Manager will need to give them roles in your orgs and spaces so they can collaborate with you.
 
-If you're an Org Manager or Space Manager, here's how to give roles to your teammates to give them permissions for your orgs and spaces. For details about how cloud.gov org and space roles and permissions work, see [Cloud Foundry roles and permissions](http://docs.cloudfoundry.org/concepts/roles.html#roles).
+If you're an Org Manager or Space Manager, here's how to give roles to your teammates to give them permissions for your orgs and spaces. For details about how cloud.gov org and space roles and permissions work, see [Cloud Foundry roles and permissions](https://docs.cloudfoundry.org/concepts/roles.html#roles).
 
 First check whether you're running version >= [6.14.0](https://github.com/cloudfoundry/cli/releases/tag/v6.14.0) of the CLI:
 

--- a/content/getting-started/one-off-tasks.md
+++ b/content/getting-started/one-off-tasks.md
@@ -63,7 +63,7 @@ The idea here is that we are going to deploy a new application, but running the 
 
 ### *East/West environment:* CF-SSH
 
-Another way to run one-off commands is via `cf-ssh`. `cf-ssh` is a shared ssh session with an application container that you can connect to. This allows you to debug the environment and your application without disturbing a running container.
+Another way to run one-off commands is via `cf-ssh`. `cf-ssh` is a shared SSH session with an application container that you can connect to. This allows you to debug the environment and your application without disturbing a running container.
 
 Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not use the community version of [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html)**. Also note that only one person can use `cf-ssh` for any particular app at any particular time.
 
@@ -97,4 +97,6 @@ Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not
 
 ### *GovCloud environment:* CF SSH
 
-Another way to run one-off commands is via [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-command), which lets you securely login to an application instance where you can perform debugging, environment inspection, and other tasks.
+You can run one-off commands via [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-command), which lets you securely login to an application instance where you can perform debugging, environment inspection, and other tasks.
+
+You don't need to install anything; you can just start using it. See the [Cloud Foundry `cf ssh` documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-command) for more about `cf ssh`.


### PR DESCRIPTION
I started to write a quick fix for a bit of missing inviting-teammates-in-GovCloud info that I [noticed via a support question](https://gsa-tts.slack.com/archives/cloud-gov-support/p1476209693001681), and I asked @jameshupp about it since he's working on related content, and this spiraled into me attempting to sort out other bits of our GovCloud documentation...

A few changes:
- Add info to the Managing Teammates page about GovCloud.
- Rename "What's New in GovCloud?" to "GovCloud Guide", since our page titles are generally statements rather than questions.
- Add more info to the GovCloud Guide, linking to other parts of the docs that explain new things in GovCloud.
- Add a little more guidance to the `cf ssh` section of the One-Off Tasks page.

This likely needs fact-checking and general review by @berndverst and others. Hope this helps!
