### PR TITLE
Add more guidance to setup for new users

### DIFF
--- a/content/apps/govcloud.md
+++ b/content/apps/govcloud.md
@@ -13,6 +13,7 @@ When your org starts using cloud.gov's GovCloud environment, here are changes to
 
 - GSA accounts still work in GovCloud. No other login credentials work at this time.
 - The API endpoint (for now) is `api.fr.cloud.gov`. When you [log in on the command line]({{< relref "getting-started/setup.md" >}}), use this new command: `cf login -a api.fr.cloud.gov --sso`
+- To access the Dashboard, visit [`https://dashboard.fr.cloud.gov/`](https://dashboard.fr.cloud.gov/).
 
 ### New features
 

--- a/content/getting-started/setup.md
+++ b/content/getting-started/setup.md
@@ -6,12 +6,15 @@ title: Setup
 weight: -50
 ---
 
-## Setting up the command line
+If you haven't set up your cloud.gov account, [get your account first]({{< relref "accounts.md" >}}).
 
-As a user, nearly all of your interactions with Cloud Foundry will be through the command line. To get it set up:
+You can interact with cloud.gov through the **command line interface** (for full management and deployment of apps) and the [**Dashboard**](https://dashboard.cloud.gov/) (a web interface with a visual overview of apps and several click-the-buttons options for common tasks). You can use just the command line or use both. We recommend setting up the command line as part of getting started.
 
-1. [Get an account]({{< relref "accounts.md" >}}).
-1. [Install the CLI](https://docs.cloudfoundry.org/devguide/installcf/install-go-cli.html).
+## Set up the command line
+
+To set up the cloud.gov command line interface (CLI):
+
+1. [Install the Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/installcf/install-go-cli.html). cloud.gov is based on Cloud Foundry, so we use the CF CLI.
 1. Confirm the installation by running
 
     ```bash
@@ -25,6 +28,8 @@ As a user, nearly all of your interactions with Cloud Foundry will be through th
     ```
 
     Then follow the link to get your one-time authentication code and enter it to log in.
+    
+    *(If you know your org is [in GovCloud]({{< relref "apps/govcloud.md" >}}), use `api.fr.cloud.gov`.)*
 
     **Or if you log in with a cloud.gov account that has its own password** (including `ORGNAME_deployer` accounts), log in by running
 
@@ -50,4 +55,4 @@ cf target -o sandbox-gsa -s harry.truman
 ```
 **If you log in immediately after your account or organization was created,** you may not see any orgs or spaces to which you have access. Your sandbox space may take up to **5 minutes** to provision.
 
-**Be tidy**: When you're done, please `cf delete <APPNAME>`. See the walkthrough for [your first deploy]({{< relref "your-first-deploy.md" >}}).
+Try the walkthrough for [your first deploy]({{< relref "your-first-deploy.md" >}}).

--- a/content/getting-started/your-first-deploy.md
+++ b/content/getting-started/your-first-deploy.md
@@ -19,4 +19,6 @@ To get used to Cloud Foundry, we recommend that you practice by deploying a simp
 
 The changes will be reflected in Cloud Foundry even without being committed to Git. Cloud Foundry is not Git-aware – it simply deploys whatever is contained in the directory that you `push` from. That being said, you _can_ set up [continuous deployment]({{< relref "apps/continuous-deployment.md" >}}) from a Git repository.
 
+You can delete an app using `cf delete <APPNAME>`. 
+
 Next, take a look at the [Concepts]({{< relref "concepts.md" >}}) page. Once you're ready to deploy your own application, head over to the [general deployment tips]({{< relref "apps/deployment.md" >}}).


### PR DESCRIPTION
Talking to @jameshupp about his onboarding experience reminded me of a few quick fixes we could make to our intro docs to help people get started. Here are a few incremental improvements:

Setup: 
- Link to and explain the Dashboard
- Tip GovCloud users to use the GovCloud endpoint
- More explicitly direct people to try a "hello world" deploy after setting up the CLI
- Don't mention `cf delete` yet, since people probably haven't pushed an app yet

Your First Deploy:
- Mention `cf delete` after the explanation of your first deploy

GovCloud Guide:
- Note the GovCloud Dashboard URL

Also cc @berndverst since this is new-customer material. :)

We'd need to update an anchor URL in https://github.com/18F/cf-hello-worlds/pull/29 after merging this - `#setting-up-the-command-line` to `#set-up-the-command-line`.
