### PR TITLE
Update access information on GovCloud page

### DIFF
--- a/content/apps/govcloud.md
+++ b/content/apps/govcloud.md
@@ -11,7 +11,7 @@ When your org starts using cloud.gov's GovCloud environment, here are changes to
 
 ### Breaking changes
 
-- GSA accounts still work in GovCloud. No other login credentials work at this time.
+- GSA and EPA accounts still work in GovCloud. No other login credentials work at this time.
 - The API endpoint (for now) is `api.fr.cloud.gov`. When you [log in on the command line]({{< relref "getting-started/setup.md" >}}), use this new command: `cf login -a api.fr.cloud.gov --sso`
 - To access the Dashboard, visit [`https://dashboard.fr.cloud.gov/`](https://dashboard.fr.cloud.gov/).
 

--- a/content/getting-started/accounts.md
+++ b/content/getting-started/accounts.md
@@ -12,17 +12,17 @@ To start using cloud.gov:
 
 * **If you're in GSA or EPA:** You automatically have access to cloud.gov; you don't need to take any account creation steps before you start using cloud.gov.
     * To log into the [cloud.gov web interface](https://login.cloud.gov/): click "agree and continue", click your agency name, and log in using your agency credentials.
-    * To log into the cloud.gov command line interface (CLI), follow [these instructions to use your agency credentials on the CLI](https://docs.cloud.gov/getting-started/setup/).
+    * To log into the cloud.gov command line interface (CLI), follow [these instructions to use your agency credentials on the CLI]({{< relref "getting-started/setup.md" >}}).
 * **If you're outside GSA/EPA and your organization/project is registered with cloud.gov:** Ask one of your teammates to follow [these instructions for adding teammates]({{< relref "managing-teammates.md" >}}).
 * **Otherwise:** See [who can use cloud.gov]({{< relref "intro/overview/who-can-use-cloudgov.md" >}}).
 
 ## Resetting your password
 
-If you're in GSA or EPA and can't seem to log into cloud.gov from the command line, first try [these instructions to use your agency credentials on the CLI](https://docs.cloud.gov/getting-started/setup/).
+If you're in GSA or EPA and can't seem to log into cloud.gov from the command line, first try [these instructions to use your agency credentials on the CLI]({{< relref "getting-started/setup.md" >}}).
 
 If you're in GSA or EPA and you need to reset your agency account password, reset your password using your agency's normal process.
 
-If you log in with a cloud.gov account that has its own password (such as `ORGNAME_deployer` accounts), you can reset your password by going to https://login.cloud.gov/forgot_password.
+If you have a cloud.gov account that has its own password (such as `ORGNAME_deployer` accounts), you can [reset the password](https://login.cloud.gov/forgot_password).
 
 ## Using your account responsibly
 


### PR DESCRIPTION
This should be merged when we've confirmed that EPA people can log into the GovCloud environment - I'll leave that up to @cnelson.

I also ended up updating a few links in the intro material while looking for any other GSA/EPA info that should be updated.
