### PR TITLE
Update "about" nav link and fix <title>

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseurl = "https://docs.cloud.gov/"
 MetaDataFormat = "yaml"
-title = "docs.cloud.gov"
+title = "Documentation"
 publishdir = "public"
 
 [params]

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -57,7 +57,7 @@
               </form>
               <ul class="nav">
                 <li class="nav-link">
-                  <a href="https://cloud.gov/#about">About</a>
+                  <a href="https://cloud.gov/overview/">Overview</a>
                 </li>
                 <li class="nav-link usa-current">
                   <a href="/">Documentation</a>


### PR DESCRIPTION
Small navigation cleanup party:
- Update https://cloud.gov/#about to https://cloud.gov/overview/ to match the new homepage.
- The `<title>` of this section is currently "docs.cloud.gov", so I switched it to the more human-friendly "Documentation".
