### PR TITLE
Removing Backhub mention from Contingency Plan

### DIFF
--- a/content/ops/contingency-plan.md
+++ b/content/ops/contingency-plan.md
@@ -70,7 +70,7 @@ If GitHub becomes unavailable, the live cloud.gov will continue to operate in it
 #### Disruption lasting less than 7 days
 Cloud Operations will postpone any non-critical updates to the platform until the disruption is resolved.  If a critical update **must** be deployed, Cloud Operations will:
 
-* Locate a copy of the current version of the required [git](https://git-scm.com/) repository by comparing last commit times of all checked out versions on Cloud Operations local systems and any copies held by cloud.gov systems (Concourse, BOSH director, etc.) Cloud Operations can also coordinate with the 18F Infrastructure team to retrieve 18F's org-wide GitHub backups, which are stored in [Backhub](https://backhub.co/).
+* Locate a copy of the current version of the required [git](https://git-scm.com/) repository by comparing last commit times of all checked out versions on Cloud Operations local systems and any copies held by cloud.gov systems (Concourse, BOSH director, etc.)
 * Pair with another member of Cloud Operations to:
   * Perform the change on the local copy of the repository
   * Manually deploy the change by provisioning a Concourse jumpbox container, copying in the repository, and executing any required steps by hand


### PR DESCRIPTION
Since this is not currently part of our plan for handling a GitHub problem. cc @datn @NoahKunin 
