### PR TITLE
Coordinate contingency plan and IR plan

### DIFF
--- a/content/docs/ops/contingency-plan.md
+++ b/content/docs/ops/contingency-plan.md
@@ -7,9 +7,7 @@ title: Contingency Plan
 
 This Contingency Plan provides guidance for our team in the case of trouble delivering our essential mission and business functions because of disruption, compromise, or failure of any component of cloud.gov. As a general guideline, we consider "disruption" to mean more than 30 minutes of unexpected downtime or significantly reduced service.
 
-Scenarios where that could happen include unexpected downtime of key external services, data loss, or high-severity security incidents.
-
-This plan coordinates with our [Security Incident Response Guide](https://docs.cloud.gov/ops/security-ir).
+Scenarios where that could happen include unexpected downtime of key external services, data loss, or [high-severity security incidents]({{< relref "security-ir.md#1-high-severity" >}}). In the case of a security incident, the team uses the [Security Incident Response Guide]({{< relref "security-ir.md" >}}) as well.
 
 ## Recovery objective
 
@@ -30,9 +28,11 @@ Team contact information is available in GSA Google Drive:
 
 ### Activation and notification
 
-Similar to our [Security Incident Response Guide](https://docs.cloud.gov/ops/security-ir), the first cloud.gov team member who notices or reports a potential contingency-plan-level problem becomes the **Incident Commander** (communications coordinator) until recovery efforts are complete or the Incident Commander role is explicitly reassigned.
+The first cloud.gov team member who notices or reports a potential contingency-plan-level problem becomes the **Incident Commander** (communications coordinator) until recovery efforts are complete or the Incident Commander role is explicitly reassigned.
 
-They first notify and coordinate with the people who are authorized to decide that cloud.gov is in a contingency plan situation:
+If the problem is identified as part of a [security incident response situation]({{< relref "security-ir.md" >}}) (or becomes a security incident response situation), the same Incident Commander (IC) should handle the overall situation, since these response processes must be coordinated.
+
+The IC first notifies and coordinates with the people who are authorized to decide that cloud.gov is in a contingency plan situation:
 
 * From cloud.gov:
     * Program Managers
@@ -41,24 +41,28 @@ They first notify and coordinate with the people who are authorized to decide th
 * 18F Products and Platforms Director
 * TTS Infrastructure Staff
 
-The Incident Commander notifies and coordinates with the following people as well:
+The IC notifies and coordinates with the following people as well:
 
 * Cloud Operations
-* GSA IT, including ISSO
+* GSA Information Security, including ISSO
 * Designated FedRAMP personnel (when applicable)
-* cloud.gov users ([through StatusPage](https://docs.cloud.gov/ops/making-announcements/)) (when applicable)
+* cloud.gov users ([through StatusPage]({{< relref "making-announcements.md" >}}) (when applicable)
 
-The Cloud Operations team assesses the situation and works to recover the system. The Incident Commander keeps a log of the situation in a GSA Google Drive document.
+The IC keeps a log of the situation in a GSA Google Drive document; if this is also a security incident, the IC also follows the [security incident communications process]({{< relref "security-ir.md#initiate" >}}) (which includes updating a GitHub issue, updating the 18F #incident-response channel, and sending sitreps by email to GSA Information Security). The IC should delegate assistant ICs for aspects of the situation as necessary.
 
 ### Recovery
 
-During the recovery phase, the team resolves the problem. See the list of [external dependencies](#external-dependencies) for procedures for recovery from problems with external services.
+The Cloud Operations team assesses the situation and works to recover the system. See the list of [external dependencies](#external-dependencies) for procedures for recovery from problems with external services.
+
+If this is also a security incident, the IC also follows the security incident [assessment]({{< relref "security-ir.md#initiate" >}}) and [remediation]({{< relref "security-ir.md#remediation" >}}) processes.
+
+If the IC assesses that the overall response process is likely to last longer than 3 hours, the IC should organize shifts so that each responder works on response for no longer than 3 hours at a time, including handing off their own responsibility to a new IC after 3 hours.
 
 ### Reconstitution
 
 The Cloud Operations team tests and validates the system as operational.
 
-The Incident Commander declares that recovery efforts are complete and notifies all relevant people. The last step is to [schedule a postmortem](https://github.com/18F/cg-postmortems) to discuss the event.
+The Incident Commander declares that recovery efforts are complete and notifies all relevant people. The last step is to [schedule a postmortem](https://github.com/18F/cg-postmortems) to discuss the event. This is the same as the [security incident retrospective process]({{< relref "security-ir.md#initiate" >}}).
 
 ## External dependencies
 

--- a/content/docs/ops/security-ir-checklist.md
+++ b/content/docs/ops/security-ir-checklist.md
@@ -13,7 +13,7 @@ title: Security IR Checklist
 
 You're the first cloud.gov team member to notice a non-team-member's report of a possible security incident regarding cloud.gov, or you've noticed an unreported possible security incident yourself. Congratulations, you're now the Incident Commander (IC)! Follow these steps:
 
-1. Notify `gsa-ir@gsa.gov`, `itservicedesk@gsa.gov`, and `devops@gsa.gov` with a description of the incident, via a single email to all three addresses. If GSA Gmail itself is down or compromised, call the GSA IT Service Desk at 1-866-450-5250. **This step needs to happen within one hour of detecting a potential incident.**
+1. As instructed by the [18F security incident response process](https://handbook.18f.gov/security-incidents/), notify `gsa-ir@gsa.gov`, `itservicedesk@gsa.gov`, and `devops@gsa.gov` with a description of the incident, via a single email to all three addresses. If GSA Gmail itself is down or compromised, call the GSA IT Service Desk at 1-866-450-5250. **This step needs to happen within one hour of detecting a potential incident.**
 1. Move incident discussion to [`#incident-response`](https://18f.slack.com/messages/incident-response/).
 1. Create an issue ([using this template]({{< relref "security-ir.md#initiate" >}})) in the [security-incidents](https://github.com/18f/security-incidents) GitHub repository with a more detailed description.
 1. If needed, create a GSA Google Doc to track sensitive information that can't be shared in Slack/GitHub.
@@ -29,6 +29,7 @@ You're the first cloud.gov team member to notice a non-team-member's report of a
     - Status → "confirmed"
     - Severity → high/medium/low
     - List of responders
+- Assess whether to also activate the [contingency plan]({{< relref "contingency-plan.md" >}}).
 - Send an initial situation report (“sitrep”) ([example sitrep]({{< relref "security-ir.md#assess" >}})) to: 
     - Post in [`#incident-response`](https://18f.slack.com/messages/incident-response/)
     - Email to `gsa-ir@gsa.gov` and `devops@gsa.gov`

--- a/content/docs/ops/security-ir.md
+++ b/content/docs/ops/security-ir.md
@@ -19,11 +19,12 @@ At a high level, incident response follows this process:
 
 - An 18F staff member inside or outside the cloud.gov team (the *reporter*) notices and reports a cloud.gov-related incident, using the [18F incident response process](https://github.com/18F/security-incidents#process) and notifying the cloud.gov team in [`#cloud-gov`](https://18f.slack.com/messages/cloud-gov/).
 - The first responder on the cloud.gov team (which could be the reporter if the reporter is on the team) becomes the initial *Incident Commander* (IC).
-- The IC follows the [18F incident response process](https://github.com/18F/security-incidents#process) (or supports the reporter if the reporter already started it), including notifying GSA IT, notifying [`#incident-response`](https://18f.slack.com/messages/incident-response/), and creating an issue in the [security-incidents](https://github.com/18f/security-incidents) GitHub repository to track the event.
+- The IC follows the [18F incident response process](https://handbook.18f.gov/security-incidents/) (or supports the reporter if the reporter already started it), including notifying GSA IT, notifying [`#incident-response`](https://18f.slack.com/messages/incident-response/), and creating an issue in the [security-incidents](https://github.com/18f/security-incidents) GitHub repository to track the event.
 
 [Assess](#assess):
 
 - The IC forms a team (*responders*) to determine if the event is actually a confirmed incident, and if so [assesses the severity](#incident-severities).
+- The IC assesses whether to also activate the [contingency plan]({{< relref "contingency-plan.md" >}}).
 - The IC sends out an initial situation report (sitrep), or a false-alarm notification.
 
 [Remediate](#remediate):
@@ -49,19 +50,19 @@ For full details, read on.
 
 An incident begins when someone becomes aware of a potential incident. We define "incident" broadly, following [NIST SP 800-61](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf), as "a violation or imminent threat of violation of computer security policies, acceptable use policies, or standard security practices" (6). This is a deliberately broad definition, designed to encompass any scenario that might threaten the security of cloud.gov.
 
-When a person outside the cloud.gov team (the *reporter*) notices a cloud.gov-related incident, they should begin reporting it by using the [18F incident response process](https://github.com/18F/security-incidents#process), and then post about it in [`#cloud-gov`](https://18f.slack.com/messages/cloud-gov/). If they don't get acknowledgment from the cloud.gov team right away, they should escalate by contacting the cloud.gov leads directly until they receive acknowledgment of their report.
+When a person outside the cloud.gov team (the *reporter*) notices a cloud.gov-related incident, they should begin reporting it by using the [18F incident response process](https://handbook.18f.gov/security-incidents/), and then post about it in [`#cloud-gov`](https://18f.slack.com/messages/cloud-gov/). If they don't get acknowledgment from the cloud.gov team right away, they should escalate by contacting the cloud.gov leads directly until they receive acknowledgment of their report.
 
-When a cloud.gov team member is the first person to notice an incident, they should also begin reporting it by using the [18F incident response process](https://github.com/18F/security-incidents#process) and posting about it in [`#cloud-gov`](https://18f.slack.com/messages/cloud-gov/) (including notifying the cloud.gov leads).
+When a cloud.gov team member is the first person to notice an incident, they should also begin reporting it by using the [18F incident response process](https://handbook.18f.gov/security-incidents/) and posting about it in [`#cloud-gov`](https://18f.slack.com/messages/cloud-gov/) (including notifying the cloud.gov leads).
 
 In either case, the first participant on the cloud.gov team becomes the initial *Incident Commander* (IC) and carries out the next steps in the response. The IC's responsibility is coordination, not necessarily investigation. The IC's primary role is to guide the process. The first responder may remain IC throughout the process, or they may hand off IC duties later in the process.
 
-The IC makes sure that the [18F incident response process](https://github.com/18F/security-incidents#process) is followed, including supporting the reporter if the reporter already started it, or starting it if nobody has started it yet.
+The IC makes sure that the [18F incident response process](https://handbook.18f.gov/security-incidents/) is followed, including supporting the reporter if the reporter already started it, or starting it if nobody has started it yet.
 
 #### Comms at the Initiate phase
 
 Note that at this point the issue's status is "investigating" — we haven't confirmed that it's really an issue yet. So, we should actually refer to this as just an "event" at this point; it doesn't become an "incident" until we've confirmed it. 
 
-At this phase, communications should follow these steps (and any additional steps listed at [18F incident response process](https://github.com/18F/security-incidents#process)):
+At this phase, communications should follow these steps (and any additional steps listed at [18F incident response process](https://handbook.18f.gov/security-incidents/)):
 
 - The IC should inform GSA IT, the GSA IT Service Desk, and our DevOps teams of the investigation by emailing `gsa-ir@gsa.gov`, `itservicedesk@gsa.gov`, and `devops@gsa.gov` with a description of the incident, via a single email to all three addresses. If GSA Gmail itself is down or compromised, call the GSA IT Service Desk at 1-866-450-5250. **This step needs to happen within one hour of detecting a potential incident.**
 - Real-time chat should happen in [`#incident-response`](https://18f.slack.com/messages/incident-response/).
@@ -102,6 +103,8 @@ Once this is done, the IC should update the ticket, noting:
 - Status: "confirmed"
 - Severity: High/Med/Low
 - Any new/changed responders
+
+The IC should assess whether to also activate the [contingency plan]({{< relref "contingency-plan.md" >}}).
 
 At this point, the IC should write an initial situation report ("sitrep") confirming the incident, summarizing what's going on, identifying the IC, and linking to the issue. Here's an example sitrep:
 


### PR DESCRIPTION
To fulfill the requirements of https://github.com/18F/cg-product/issues/398, we need to make our contingency plan and IR plan fit together better.

This change updates both plans (and the IR checklist) to have appropriate cross-references in several places.

I also updated some links.
