### PR TITLE
Add a custom nginx config to the site

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -17,6 +17,9 @@ npm run build
 # build the site
 hugo
 
+# move our custom nginx config into the public folder so the buildpack uses it
+cp nginx.conf public/nginx.conf
+
 # copy files to output directory, so that they can be read by subsequent step
 if [ -n "$COPY_OUTPUT" ]; then
   cp -R . ../cg-docs-compiled

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,44 @@
+worker_processes 1;
+daemon off;
+
+error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
+events { worker_connections 1024; }
+
+http {
+  charset utf-8;
+  log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
+  access_log <%= ENV["APP_ROOT"] %>/nginx/logs/access.log cloudfoundry;
+  default_type application/octet-stream;
+  include mime.types;
+  sendfile on;
+
+  gzip on;
+  gzip_disable "msie6";
+  gzip_comp_level 6;
+  gzip_min_length 1100;
+  gzip_buffers 16 8k;
+  gzip_proxied any;
+  gunzip on;
+  gzip_static always;
+  gzip_types text/plain text/css text/js text/xml text/javascript application/javascript application/x-javascript application/json application/xml application/xml+rss;
+
+  tcp_nopush on;
+  keepalive_timeout 30;
+  port_in_redirect off; # Ensure that redirects don't include the internal container PORT - <%= ENV["PORT"] %>
+  server_tokens off;
+
+  server_name_in_redirect on;
+
+  server {
+    listen <%= ENV["PORT"] %>;
+    server_name cloud.gov;
+
+    location / {
+      root <%= ENV["APP_ROOT"] %>/public;
+
+      index index.html index.htm Default.htm;
+
+      add_header Cache-Control max-age=300;
+    }
+  }
+}

--- a/redirects/docs.cloud.gov/nginx.conf
+++ b/redirects/docs.cloud.gov/nginx.conf
@@ -5,10 +5,11 @@ events { worker_connections 1024; }
 
 http {
   server_tokens off;
+  port_in_redirect off;
 
   server {
     listen <%= ENV["PORT"] %>;
     server_name localhost;
-    rewrite ^ $scheme://cloud.gov/docs$request_uri permanent;
+    rewrite ^ https://cloud.gov/docs$request_uri permanent;
   }
 }


### PR DESCRIPTION
The custom nginx.conf uses the cloud.gov name in all redirects so we do not bypass cloudfront.

It also enables Cache Control headers with a max age of 5 minutes to shorten the time it takes content changes to appear on the site after publishing.
