### PR TITLE
Clarifying Fugacious policy

### DIFF
--- a/content/docs/ops/secrets.md
+++ b/content/docs/ops/secrets.md
@@ -7,7 +7,7 @@ title: Secret Key Management
 
 ### Sharing secret keys
 
-For sharing the following types of [sensitive information](https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information) related to cloud.gov, cloud.gov team members must use [Fugacious](https://fugacious.18f.gov/) links, shared over GSA applications (such as GSA Gmail or TTS Slack) only with the intended recipient(s).
+For sharing the following types of [sensitive information](https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information) related to cloud.gov, cloud.gov team members must use [Fugacious](https://fugacious.18f.gov/) links, shared over a GSA application (such as GSA Gmail or TTS Slack). The team member must share the Fugacious link only with intended recipient(s) who need to know the sensitive information.
 
 * Passwords
 * Secret keys


### PR DESCRIPTION
Noting that we should send a Fugacious link only to people who need to know the info.
