### PR TITLE
New homepage styles to accompany new cg-style release

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -24,71 +24,44 @@
   <div class="usa-grid">
     <div class="section-content usa-content">
       <h1>Cloud deployment is better. But that doesn’t make it easy.</h1>
-      <div class="separator">
-        <div class="separator-center_piece">
-          <div class="hexagon"></div>
-        </div>
-      </div>
       <p>
-        Any federal agency deploying an app has to follow regulations, manage an
-        ATO process, and design a robust service infrastructure. Cloud hosting
-        saves one hassle — managing data centers — and creates another: operating
-        cloud infrastructure and keeping it compliant. It requires a different set
-        of skills that isn’t widely available in government yet.
+        Any federal agency deploying an app has to follow regulations, manage an ATO process, and design a robust service infrastructure. Cloud hosting saves one hassle — managing data centers — and creates another: operating cloud infrastructure and keeping it compliant. It requires a different set of skills that isn’t widely available in government yet.
       </p>
     </div>
   </div>
-  <i class="hex_icon hex_icon-alt section-icon"
+  <!--
+  <i class="hex_icon hex_icon-black section-icon"
       style="height: 5.625rem; width: 4.9rem">
     <svg class="icon">
-      <use xlink:href="assets/img/cloudgov-sprite.svg#i-court"/>
+      <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-court"/>
     </svg>
-  </i>
+  </i> -->
 </section>
 
-<section class="usa-content section section-dark section-bg-far-r">
+<section class="usa-content section section-red">
   <div class="usa-grid">
     <div class="section-content usa-content">
-      <h1>We’re familiar with the challenges of government cloud ops.</h1>
-      <div class="separator separator-alt">
-        <div class="separator-center_piece">
-          <div class="hexagon hexagon-alt"></div>
-        </div>
-      </div>
+      <h1>We’re familiar with the challenges of government cloud&nbsp;ops.</h1>
       <p>
-        18F is a team within the General Services Administration that builds
-        applications for the federal government, rapidly and iteratively. So as
-        we scaled up the number of teams deploying applications, we couldn’t let
-        cloud operations talent become the kind of bottleneck that slows down
-        development for many federal teams. Instead of working on infrastructure
-        support for every individual product, our cloud ops staff focused on how
-        they could give all our development teams a better way to work.
+        18F is a team within the General Services Administration that builds applications for the federal government, rapidly and iteratively. So as we scaled up the number of teams deploying applications, we couldn’t let cloud operations talent become the kind of bottleneck that slows down development for many federal teams. Instead of working on infrastructure support for every individual product, our cloud ops staff focused on how they could give all our development teams a better way to work.
       </p>
     </div>
   </div>
-  <i class="hex_icon hex_icon-primary section-icon"
+  <!--
+  <i class="hex_icon hex_icon hex_icon-black section-icon"
       style="height: 5.625rem; width: 4.9rem">
     <svg class="icon">
-      <use xlink:href="assets/img/cloudgov-sprite.svg#i-power"/>
+      <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-power"/>
     </svg>
-  </i>
+  </i> -->
 </section>
 
 <section class="usa-content section-middle section-light">
   <div class="usa-grid">
     <div class="section-content usa-content">
       <h1>This is why we built cloud.gov.</h1>
-      <div class="separator">
-        <div class="separator-center_piece">
-          <div class="hexagon"></div>
-        </div>
-      </div>
       <p>
-        Cloud.gov is 18F’s cloud-hosting product line for federal teams. It addresses
-        baseline security and scalability concerns consistently, right up
-        front, without requiring a huge number of cloud operations experts. Instead,
-        digital service teams can use these tools to focus on delivering quality
-        products.
+        Cloud.gov is 18F’s cloud-hosting product line for federal teams. It addresses baseline security and scalability concerns consistently, right up front, without requiring a huge number of cloud operations experts. Instead, digital service teams can use these tools to focus on delivering quality products.
       </p>
     </div>
     <div class="three_up">
@@ -96,211 +69,177 @@
         <i class="hex_icon hex_icon-primary"
           style="height: 5.625rem; width: 4.9rem">
           <svg class="icon">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-shipping"/>
+            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-shipping"/>
           </svg>
         </i>
         <h3>Platform-as-a-service</h3>
         <p>
-          We remove the complexity of the cloud infrastructure and give you a
-          usable interface that you can use to deploy secure apps quickly. This
-          is platform-as-a-service, or PaaS.
+          We remove the complexity of the cloud infrastructure and give you a usable interface that you can use to deploy secure apps quickly. This is platform-as-a-service, or PaaS.
         </p>
       </div>
       <div class="three_up-part">
-        <i class="hex_icon hex_icon-primary"
+        <i class="hex_icon hex_icon-black"
           style="height: 5.625rem; width: 4.9rem">
           <svg class="icon">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-paperwork"/>
+            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-paperwork"/>
           </svg>
         </i>
         <h3>Security documentation support</h3>
         <p>
-          As a byproduct of building the platform, we have open source,
-          software-friendly documentation of cloud.gov’s NIST controls, ready to
-          incorporate into your own FISMA and ATO documentation, however you
-          need it.
+          As a byproduct of building the platform, we have open source, software-friendly documentation of cloud.gov’s NIST controls, ready to incorporate into your own FISMA and ATO documentation, however you need it.
         </p>
       </div>
       <div class="three_up-part">
-        <i class="hex_icon hex_icon-primary"
+        <i class="hex_icon hex_icon-alt"
           style="height: 5.625rem; width: 4.9rem">
           <svg class="icon">
-            <use xlink:href="/assets/img/cloudgov-sprite.svg#i-compass"/>
+            <use xlink:href="{{ .Site.BaseURL }}/assets/img/cloudgov-sprite.svg#i-compass"/>
           </svg>
         </i>
         <h3>More to come</h3>
         <p>
-          Where cloud.gov goes from here will depend on how teams use it
-          today. Already, we are exploring additional products: domain
-          microservices, access to third-party tools, and technologies that may
-          be needed for “government-as-a-service.”
+          Where cloud.gov goes from here will depend on how teams use it today. Already, we are exploring additional products: domain microservices, access to third-party tools, and technologies that may be needed for “government-as-a-service.”
         </p>
       </div>
     </div>
   </div>
+  <!--
   <i class="hex_icon hex_icon-alt section-icon"
       style="height: 5.625rem; width: 4.9rem">
     <svg class="icon">
-      <use xlink:href="/assets/img/cloudgov-sprite.svg#i-plan"/>
+      <use xlink:href="{{ .Site.BaseURL }}/assets/img/cloudgov-sprite.svg#i-plan"/>
     </svg>
-  </i>
+  </i> -->
 </section>
 
 <section class="usa-content section section-dark section-chevron_alt">
   <div class="usa-grid">
     <div class="section-content usa-content">
       <h1>cloud.gov makes deployments easier, faster, and stronger.</h1>
-      <div class="separator separator-alt">
-        <div class="separator-center_piece">
-          <div class="hexagon hexagon-alt"></div>
-        </div>
-      </div>
       <p>
-        We don’t think the challenges we faced are unique. All agencies have a
-        mandate to deploy their services in the cloud, and all cloud deployments
-        require operations support, security, and compliance. We give you that.
+        We don’t think the challenges we faced are unique. All agencies have a mandate to deploy their services in the cloud, and all cloud deployments require operations support, security, and compliance. We give you that.
       </p>
     </div>
     <div class="four_up">
       <div class="four_up-part">
         <div class="icon-container">
           <svg class="icon icon-alt" style="width: 2.875rem">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-agreement"/>
+            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-agreement"/>
           </svg>
         </div>
         <h3>Usability</h3>
         <p>
-          We use an open source API and tools for teams to take care of
-          environments, services, applications, access points, and billing
-          structures. You use our straightforward UI to deliver a great app.
+          We use an open source API and tools for teams to take care of environments, services, applications, access points, and billing structures. You use our straightforward UI to deliver a great app.
         </p>
       </div>
       <div class="four_up-part">
         <div class="icon-container">
           <svg class="icon icon-alt">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-double_arrow"/>
+            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-double_arrow"/>
           </svg>
         </div>
         <h3>Scalability</h3>
         <p>
-          The cloud.gov support team provides spot support for teams when they
-          encounter issues. We use what we learn from this work to improve
-          cloud.gov, addressing these issues for every team at once.
+          The cloud.gov support team provides spot support for teams when they encounter issues. We use what we learn from this work to improve cloud.gov, addressing these issues for every team at once.
         </p>
       </div>
       <div class="four_up-part">
         <div class="icon-container">
           <svg class="icon icon-alt">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-locked"/>
+            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-locked"/>
           </svg>
         </div>
         <h3>Security</h3>
         <p>
-          We deploy on a hardened operating system. We centrally scan and audit
-          the platform and every application on it. And the open source,
-          publicly documented deployment creates an economy of scale that
-          benefits every app, no matter who owns it.
+          We deploy on a hardened operating system. We centrally scan and audit the platform and every application on it. And the open source, publicly documented deployment creates an economy of scale that benefits every app, no matter who owns it.
         </p>
       </div>
       <div class="four_up-part">
         <div class="icon-container">
           <svg class="icon icon-alt">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-user_researched"/>
+            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-user_researched"/>
           </svg>
         </div>
         <h3>Conformity with federal rules</h3>
         <p>
-          Every NIST control for our platform, infrastructure, and human layers
-          is documented and ready to use in many different contexts, updated
-          automatically as we update the platform. Use our work to shave dozens
-          of hours off the usual app-by-app, copy-and-paste compliance process.
+          Every NIST control for our platform, infrastructure, and human layers is documented and ready to use in many different contexts, updated automatically as we update the platform. Use our work to shave dozens of hours off the usual app-by-app, copy-and-paste compliance process.
         </p>
       </div>
     </div>
   </div>
+  <!--
   <i class="hex_icon hex_icon-primary section-icon"
       style="height: 5.625rem; width: 4.9rem">
     <svg class="icon">
-      <use xlink:href="assets/img/cloudgov-sprite.svg#i-checked"/>
+      <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-checked"/>
     </svg>
   </i>
+  -->
 </section>
 
 <section class="usa-content section-middle section-light">
   <div class="usa-grid">
     <div class="section-content usa-content">
       <h1>It’s a solution that keeps getting better.</h1>
-      <div class="separator">
-        <div class="separator-center_piece">
-          <div class="hexagon"></div>
-        </div>
-      </div>
       <p>
-        We built cloud.gov on the open source, public Cloud Foundry project. We
-        completed the first prototype in about three months, and we started
-        launching production apps about a month after that. We continue to
-        fine-tune it based on the needs of the apps that teams have built.
+        We built cloud.gov on the open source, public Cloud Foundry project. We completed the first prototype in about three months, and we started launching production apps about a month after that. We continue to fine-tune it based on the needs of the apps that teams have built.
       </p>
       <p>
-        Because it’s open source, we can continue to take advantage of
-        improvements to the operability and security of Cloud Foundry. It helps
-        us scale.
+        Because it’s open source, we can continue to take advantage of improvements to the operability and security of Cloud Foundry. It helps us scale.
       </p>
       <p>
-        Because it’s an agile project, cloud.gov is always under development. As
-        we observe its use, we will continue to add new capabilities. Therefore,
-        we do not say it is “complete” and we probably never will.
+        Because it’s an agile project, cloud.gov is always under development. As we observe its use, we will continue to add new capabilities. Therefore, we do not say it is “complete” and we probably never will.
       </p>
     </div>
   </div>
+  <!--
   <i class="hex_icon hex_icon-alt section-icon"
       style="height: 5.625rem; width: 4.9rem">
     <svg class="icon">
-      <use xlink:href="assets/img/cloudgov-sprite.svg#i-user"/>
+      <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-user"/>
     </svg>
   </i>
+  -->
 </section>
 
-<section class="usa-content section section-dark">
+<section class="usa-content section section-cream">
   <div class="usa-grid">
     <div class="section-content usa-content">
       <h1>Testimonials</h1>
-      <blockquote>
+      <blockquote class="big-quote">
         <p>
-          “With the help of cloud.gov, College Scorecard was able to focus on
-          making important data available to the public. The streamlined ATO
-          process was incredibly helpful in launching the project on
-          schedule. We needed specific services that were not yet available in
-          the platform, and the cloud.gov team responded quickly and supported
-          our needs, letting us focus on the data and the software.” —
-          <strong>Sarah Allen, 18F developer on the <a
-                href="https://collegescorecard.ed.gov/">College Scorecard</a>
-            team.</strong>
+          “With the help of cloud.gov, College Scorecard was able to focus on making important data available to the public. The streamlined ATO process was incredibly helpful in launching the project on schedule. We needed specific services that were not yet available in the platform, and the cloud.gov team responded quickly and supported our needs, letting us focus on the data and the software.” <strong><span>Sarah Allen,</span> 18F developer on the <a href="https://collegescorecard.ed.gov/">College Scorecard</a>
+            team</strong>
         </p>
       </blockquote>
-      <blockquote>
+      <blockquote class="big-quote">
         <p>
-          “I managed the staging environment for the eRegs instance at CFPB and
-          spent at least a fifth of my time managing the instance. On ATF's
-          eRegs instance, which runs on cloud.gov, that time was cut down to
-          less than a day of configuration. I will gladly remove "server
-          management" from my resume now.” — <strong>CM Lubinksi, 18F developer
-            on the <a href="https://atf-eregs.apps.cloud.gov/">ATF eRegulations</a>
-            team.</strong>
+          “I managed the staging environment for the eRegs instance at CFPB and spent at least a fifth of my time managing the instance. On ATF’s eRegs instance, which runs on cloud.gov, that time was cut down to less than a day of configuration. I will gladly remove ‘server management’ from my resume now.” <strong><span>CM Lubinksi,</span> 18F developer on the <a href="https://atf-eregs.apps.cloud.gov/">ATF eRegulations</a> team</strong>
         </p>
       </blockquote>
-      <blockquote>
+      <blockquote class="big-quote">
         <p>
-          “The platform actually allows us to follow the fundamental software
-          tenet of not repeating ourselves versus our previous framework. Every
-          subsequent deploy of a stack allows us to add to our toolset for
-          future re-use.” — <strong>Kaitlin Devine, 18F Director of Engineering.
-          </strong>
+          “The platform actually allows us to follow the fundamental software tenet of not repeating ourselves versus our previous framework. Every subsequent deploy of a stack allows us to add to our toolset for future re-use.” <strong><span>Kaitlin Devine,</span> 18F Director of Engineering </strong>
         </p>
       </blockquote>
     </div>
   </div>
 </section>
+
+<!--
+<section class="usa-content section-middle section-light">
+  <div class="usa-grid">
+    <div class="section-content usa-content">
+      <h1>Learn more about cloud.gov</h1>
+      <h4><a href="http://docs.cloudfoundry.org/">Platform
+          documentation</a></h4>
+      <h4><a href="http://docs.cloud.gov">Cloud.gov documentation</a></h4>
+      <h4><a href="http://">Problems or questions</a></h4>
+    </div>
+  </div>
+</section>
+-->
+
 
 <section class="usa-content section-middle section-light">
   <div class="usa-grid">
@@ -316,4 +255,3 @@
 
   </body>
 </html>
-

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -33,7 +33,7 @@
   <i class="hex_icon hex_icon-black section-icon"
       style="height: 5.625rem; width: 4.9rem">
     <svg class="icon">
-      <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-court"/>
+      <use xlink:href="assets/img/cloudgov-sprite.svg#i-court"/>
     </svg>
   </i> -->
 </section>
@@ -51,7 +51,7 @@
   <i class="hex_icon hex_icon hex_icon-black section-icon"
       style="height: 5.625rem; width: 4.9rem">
     <svg class="icon">
-      <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-power"/>
+      <use xlink:href="assets/img/cloudgov-sprite.svg#i-power"/>
     </svg>
   </i> -->
 </section>
@@ -69,7 +69,7 @@
         <i class="hex_icon hex_icon-primary"
           style="height: 5.625rem; width: 4.9rem">
           <svg class="icon">
-            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-shipping"/>
+            <use xlink:href="assets/img/cloudgov-sprite.svg#i-shipping"/>
           </svg>
         </i>
         <h3>Platform-as-a-service</h3>
@@ -81,7 +81,7 @@
         <i class="hex_icon hex_icon-black"
           style="height: 5.625rem; width: 4.9rem">
           <svg class="icon">
-            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-paperwork"/>
+            <use xlink:href="assets/img/cloudgov-sprite.svg#i-paperwork"/>
           </svg>
         </i>
         <h3>Security documentation support</h3>
@@ -93,7 +93,7 @@
         <i class="hex_icon hex_icon-alt"
           style="height: 5.625rem; width: 4.9rem">
           <svg class="icon">
-            <use xlink:href="{{ .Site.BaseURL }}/assets/img/cloudgov-sprite.svg#i-compass"/>
+            <use xlink:href="assets/img/cloudgov-sprite.svg#i-compass"/>
           </svg>
         </i>
         <h3>More to come</h3>
@@ -107,7 +107,7 @@
   <i class="hex_icon hex_icon-alt section-icon"
       style="height: 5.625rem; width: 4.9rem">
     <svg class="icon">
-      <use xlink:href="{{ .Site.BaseURL }}/assets/img/cloudgov-sprite.svg#i-plan"/>
+      <use xlink:href="assets/img/cloudgov-sprite.svg#i-plan"/>
     </svg>
   </i> -->
 </section>
@@ -124,7 +124,7 @@
       <div class="four_up-part">
         <div class="icon-container">
           <svg class="icon icon-alt" style="width: 2.875rem">
-            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-agreement"/>
+            <use xlink:href="assets/img/cloudgov-sprite.svg#i-agreement"/>
           </svg>
         </div>
         <h3>Usability</h3>
@@ -135,7 +135,7 @@
       <div class="four_up-part">
         <div class="icon-container">
           <svg class="icon icon-alt">
-            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-double_arrow"/>
+            <use xlink:href="assets/img/cloudgov-sprite.svg#i-double_arrow"/>
           </svg>
         </div>
         <h3>Scalability</h3>
@@ -146,7 +146,7 @@
       <div class="four_up-part">
         <div class="icon-container">
           <svg class="icon icon-alt">
-            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-locked"/>
+            <use xlink:href="assets/img/cloudgov-sprite.svg#i-locked"/>
           </svg>
         </div>
         <h3>Security</h3>
@@ -157,7 +157,7 @@
       <div class="four_up-part">
         <div class="icon-container">
           <svg class="icon icon-alt">
-            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-user_researched"/>
+            <use xlink:href="assets/img/cloudgov-sprite.svg#i-user_researched"/>
           </svg>
         </div>
         <h3>Conformity with federal rules</h3>
@@ -171,7 +171,7 @@
   <i class="hex_icon hex_icon-primary section-icon"
       style="height: 5.625rem; width: 4.9rem">
     <svg class="icon">
-      <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-checked"/>
+      <use xlink:href="assets/img/cloudgov-sprite.svg#i-checked"/>
     </svg>
   </i>
   -->
@@ -196,7 +196,7 @@
   <i class="hex_icon hex_icon-alt section-icon"
       style="height: 5.625rem; width: 4.9rem">
     <svg class="icon">
-      <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-user"/>
+      <use xlink:href="assets/img/cloudgov-sprite.svg#i-user"/>
     </svg>
   </i>
   -->

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -206,18 +206,18 @@
   <div class="usa-grid">
     <div class="section-content usa-content">
       <h1>Testimonials</h1>
-      <blockquote class="big-quote">
+      <blockquote class="quote-big">
         <p>
           “With the help of cloud.gov, College Scorecard was able to focus on making important data available to the public. The streamlined ATO process was incredibly helpful in launching the project on schedule. We needed specific services that were not yet available in the platform, and the cloud.gov team responded quickly and supported our needs, letting us focus on the data and the software.” <span class="quote-attrib"><span class="quote-attrib-name">Sarah Allen,</span> 18F developer on the <a href="https://collegescorecard.ed.gov/">College Scorecard</a>
             team</span>
         </p>
       </blockquote>
-      <blockquote class="big-quote">
+      <blockquote class="quote-big">
         <p>
           “I managed the staging environment for the eRegs instance at CFPB and spent at least a fifth of my time managing the instance. On ATF’s eRegs instance, which runs on cloud.gov, that time was cut down to less than a day of configuration. I will gladly remove ‘server management’ from my resume now.” <span class="quote-attrib"><span class="quote-attrib-name">CM Lubinksi,</span> 18F developer on the <a href="https://atf-eregs.apps.cloud.gov/">ATF eRegulations</a> team</span>
         </p>
       </blockquote>
-      <blockquote class="big-quote">
+      <blockquote class="quote-big">
         <p>
           “The platform actually allows us to follow the fundamental software tenet of not repeating ourselves versus our previous framework. Every subsequent deploy of a stack allows us to add to our toolset for future re-use.” <span class="quote-attrib"><span class="quote-attrib-name">Kaitlin Devine,</span> 18F Director of Engineering </span>
         </p>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,7 +9,7 @@
 
 
 
-<section class="section section-dark section-chevron_alt section-first"
+<section class="section section-blue section-chevron_alt section-first"
     id="main">
   <div class="usa-grid section-bg-parent">
     <div class="usa-width-whole billboard  section-bg">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -38,7 +38,7 @@
   </i> -->
 </section>
 
-<section class="usa-content section section-red">
+<section class="usa-content section section-cream">
   <div class="usa-grid">
     <div class="section-content usa-content">
       <h1>We’re familiar with the challenges of government cloud&nbsp;ops.</h1>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -208,18 +208,18 @@
       <h1>Testimonials</h1>
       <blockquote class="big-quote">
         <p>
-          “With the help of cloud.gov, College Scorecard was able to focus on making important data available to the public. The streamlined ATO process was incredibly helpful in launching the project on schedule. We needed specific services that were not yet available in the platform, and the cloud.gov team responded quickly and supported our needs, letting us focus on the data and the software.” <strong><span>Sarah Allen,</span> 18F developer on the <a href="https://collegescorecard.ed.gov/">College Scorecard</a>
-            team</strong>
+          “With the help of cloud.gov, College Scorecard was able to focus on making important data available to the public. The streamlined ATO process was incredibly helpful in launching the project on schedule. We needed specific services that were not yet available in the platform, and the cloud.gov team responded quickly and supported our needs, letting us focus on the data and the software.” <span class="quote-attrib"><span class="quote-attrib-name">Sarah Allen,</span> 18F developer on the <a href="https://collegescorecard.ed.gov/">College Scorecard</a>
+            team</span>
         </p>
       </blockquote>
       <blockquote class="big-quote">
         <p>
-          “I managed the staging environment for the eRegs instance at CFPB and spent at least a fifth of my time managing the instance. On ATF’s eRegs instance, which runs on cloud.gov, that time was cut down to less than a day of configuration. I will gladly remove ‘server management’ from my resume now.” <strong><span>CM Lubinksi,</span> 18F developer on the <a href="https://atf-eregs.apps.cloud.gov/">ATF eRegulations</a> team</strong>
+          “I managed the staging environment for the eRegs instance at CFPB and spent at least a fifth of my time managing the instance. On ATF’s eRegs instance, which runs on cloud.gov, that time was cut down to less than a day of configuration. I will gladly remove ‘server management’ from my resume now.” <span class="quote-attrib"><span class="quote-attrib-name">CM Lubinksi,</span> 18F developer on the <a href="https://atf-eregs.apps.cloud.gov/">ATF eRegulations</a> team</span>
         </p>
       </blockquote>
       <blockquote class="big-quote">
         <p>
-          “The platform actually allows us to follow the fundamental software tenet of not repeating ourselves versus our previous framework. Every subsequent deploy of a stack allows us to add to our toolset for future re-use.” <strong><span>Kaitlin Devine,</span> 18F Director of Engineering </strong>
+          “The platform actually allows us to follow the fundamental software tenet of not repeating ourselves versus our previous framework. Every subsequent deploy of a stack allows us to add to our toolset for future re-use.” <span class="quote-attrib"><span class="quote-attrib-name">Kaitlin Devine,</span> 18F Director of Engineering </span>
         </p>
       </blockquote>
     </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -33,7 +33,7 @@
   <i class="hex_icon hex_icon-black section-icon"
       style="height: 5.625rem; width: 4.9rem">
     <svg class="icon">
-      <use xlink:href="assets/img/cloudgov-sprite.svg#i-court"/>
+      <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-court"/>
     </svg>
   </i> -->
 </section>
@@ -51,7 +51,7 @@
   <i class="hex_icon hex_icon hex_icon-black section-icon"
       style="height: 5.625rem; width: 4.9rem">
     <svg class="icon">
-      <use xlink:href="assets/img/cloudgov-sprite.svg#i-power"/>
+      <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-power"/>
     </svg>
   </i> -->
 </section>
@@ -69,7 +69,7 @@
         <i class="hex_icon hex_icon-primary"
           style="height: 5.625rem; width: 4.9rem">
           <svg class="icon">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-shipping"/>
+            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-shipping"/>
           </svg>
         </i>
         <h3>Platform-as-a-service</h3>
@@ -81,7 +81,7 @@
         <i class="hex_icon hex_icon-black"
           style="height: 5.625rem; width: 4.9rem">
           <svg class="icon">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-paperwork"/>
+            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-paperwork"/>
           </svg>
         </i>
         <h3>Security documentation support</h3>
@@ -93,7 +93,7 @@
         <i class="hex_icon hex_icon-alt"
           style="height: 5.625rem; width: 4.9rem">
           <svg class="icon">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-compass"/>
+            <use xlink:href="{{ .Site.BaseURL }}/assets/img/cloudgov-sprite.svg#i-compass"/>
           </svg>
         </i>
         <h3>More to come</h3>
@@ -107,7 +107,7 @@
   <i class="hex_icon hex_icon-alt section-icon"
       style="height: 5.625rem; width: 4.9rem">
     <svg class="icon">
-      <use xlink:href="assets/img/cloudgov-sprite.svg#i-plan"/>
+      <use xlink:href="{{ .Site.BaseURL }}/assets/img/cloudgov-sprite.svg#i-plan"/>
     </svg>
   </i> -->
 </section>
@@ -124,7 +124,7 @@
       <div class="four_up-part">
         <div class="icon-container">
           <svg class="icon icon-alt" style="width: 2.875rem">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-agreement"/>
+            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-agreement"/>
           </svg>
         </div>
         <h3>Usability</h3>
@@ -135,7 +135,7 @@
       <div class="four_up-part">
         <div class="icon-container">
           <svg class="icon icon-alt">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-double_arrow"/>
+            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-double_arrow"/>
           </svg>
         </div>
         <h3>Scalability</h3>
@@ -146,7 +146,7 @@
       <div class="four_up-part">
         <div class="icon-container">
           <svg class="icon icon-alt">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-locked"/>
+            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-locked"/>
           </svg>
         </div>
         <h3>Security</h3>
@@ -157,7 +157,7 @@
       <div class="four_up-part">
         <div class="icon-container">
           <svg class="icon icon-alt">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-user_researched"/>
+            <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-user_researched"/>
           </svg>
         </div>
         <h3>Conformity with federal rules</h3>
@@ -171,7 +171,7 @@
   <i class="hex_icon hex_icon-primary section-icon"
       style="height: 5.625rem; width: 4.9rem">
     <svg class="icon">
-      <use xlink:href="assets/img/cloudgov-sprite.svg#i-checked"/>
+      <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-checked"/>
     </svg>
   </i>
   -->
@@ -196,7 +196,7 @@
   <i class="hex_icon hex_icon-alt section-icon"
       style="height: 5.625rem; width: 4.9rem">
     <svg class="icon">
-      <use xlink:href="assets/img/cloudgov-sprite.svg#i-user"/>
+      <use xlink:href="{{ .Site.BaseURL }}assets/img/cloudgov-sprite.svg#i-user"/>
     </svg>
   </i>
   -->
@@ -208,18 +208,18 @@
       <h1>Testimonials</h1>
       <blockquote class="big-quote">
         <p>
-          “With the help of cloud.gov, College Scorecard was able to focus on making important data available to the public. The streamlined ATO process was incredibly helpful in launching the project on schedule. We needed specific services that were not yet available in the platform, and the cloud.gov team responded quickly and supported our needs, letting us focus on the data and the software.” <span class="quote-attrib"><span class="quote-attrib-name">Sarah Allen,</span> 18F developer on the <a href="https://collegescorecard.ed.gov/">College Scorecard</a>
-            team</span>
+          “With the help of cloud.gov, College Scorecard was able to focus on making important data available to the public. The streamlined ATO process was incredibly helpful in launching the project on schedule. We needed specific services that were not yet available in the platform, and the cloud.gov team responded quickly and supported our needs, letting us focus on the data and the software.” <strong><span>Sarah Allen,</span> 18F developer on the <a href="https://collegescorecard.ed.gov/">College Scorecard</a>
+            team</strong>
         </p>
       </blockquote>
       <blockquote class="big-quote">
         <p>
-          “I managed the staging environment for the eRegs instance at CFPB and spent at least a fifth of my time managing the instance. On ATF’s eRegs instance, which runs on cloud.gov, that time was cut down to less than a day of configuration. I will gladly remove ‘server management’ from my resume now.” <span class="quote-attrib"><span class="quote-attrib-name">CM Lubinksi,</span> 18F developer on the <a href="https://atf-eregs.apps.cloud.gov/">ATF eRegulations</a> team</span>
+          “I managed the staging environment for the eRegs instance at CFPB and spent at least a fifth of my time managing the instance. On ATF’s eRegs instance, which runs on cloud.gov, that time was cut down to less than a day of configuration. I will gladly remove ‘server management’ from my resume now.” <strong><span>CM Lubinksi,</span> 18F developer on the <a href="https://atf-eregs.apps.cloud.gov/">ATF eRegulations</a> team</strong>
         </p>
       </blockquote>
       <blockquote class="big-quote">
         <p>
-          “The platform actually allows us to follow the fundamental software tenet of not repeating ourselves versus our previous framework. Every subsequent deploy of a stack allows us to add to our toolset for future re-use.” <span class="quote-attrib"><span class="quote-attrib-name">Kaitlin Devine,</span> 18F Director of Engineering </span>
+          “The platform actually allows us to follow the fundamental software tenet of not repeating ourselves versus our previous framework. Every subsequent deploy of a stack allows us to add to our toolset for future re-use.” <strong><span>Kaitlin Devine,</span> 18F Director of Engineering </strong>
         </p>
       </blockquote>
     </div>

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -1,9 +1,9 @@
 <section>
   <a name="contact"></a>
   <h1>Contact us</h1>
+  <p class="section-subhed">Sign up for updates about the availability of cloud.gov from 18F</p>
     <form action="//gsa.us9.list-manage.com/subscribe/post?u=6f1977de9eff4c384dc8d6527&amp;id=ab90bdad59" method="post" id="contact" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
       <fieldset>
-        <h4>Sign up for updates about the availability of cloud.gov from 18F</h4>
         <div class="text_block">
           <label for="mce-EMAIL">Email Address </label>
           <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">

--- a/layouts/partials/docs-header.html
+++ b/layouts/partials/docs-header.html
@@ -33,7 +33,7 @@
         <!-- start logo -->
         <h2 class="header-title">
           <a href="/" class="logo" title="Home" accesskey="1" aria-label="Home">
-            <svg class="logo">
+            <svg class="logo-img">
               <use xlink:href="/assets/img/cloudgov-sprite.svg#logo"/>
             </svg>
           </a>
@@ -51,7 +51,7 @@
                   <input name="utf8" type="hidden" value="&#x2713;" />
                   <input id="search-field" autocomplete="off" type="search" name="query" placeholder="Search documentation">
                   <button type="submit">
-                    <span class="usa-sr-only">Search</span> 
+                    <span class="usa-sr-only">Search</span>
                   </button>
                 </div>
               </form>
@@ -61,7 +61,7 @@
                 </li>
                 <li class="nav-link">
                   <a href="/docs/">Documentation</a>
-                </li> 
+                </li>
                 <li class="nav-link">
                   <a href="/updates/">Updates</a>
                 </li>
@@ -82,7 +82,7 @@
               </ul>
             </div>
           </div>
-        </nav> 
+        </nav>
       </div>
 
     </header>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -13,7 +13,7 @@
     <!-- start logo -->
     <h2 class="header-title">
       <a href="/" class="logo" title="Home">
-        <svg class="logo">
+        <svg class="logo-img">
           <use xlink:href="/assets/img/cloudgov-sprite.svg#logo"/>
         </svg>
       </a>

--- a/layouts/partials/overview-header.html
+++ b/layouts/partials/overview-header.html
@@ -33,7 +33,7 @@
         <!-- start logo -->
         <h2 class="header-title">
           <a href="/" class="logo" title="Home" accesskey="1" aria-label="Home">
-            <svg class="logo">
+            <svg class="logo-img">
               <use xlink:href="/assets/img/cloudgov-sprite.svg#logo"/>
             </svg>
           </a>
@@ -51,7 +51,7 @@
                   <input name="utf8" type="hidden" value="&#x2713;" />
                   <input id="search-field" autocomplete="off" type="search" name="query" placeholder="Search documentation">
                   <button type="submit">
-                    <span class="usa-sr-only">Search</span> 
+                    <span class="usa-sr-only">Search</span>
                   </button>
                 </div>
               </form>
@@ -61,7 +61,7 @@
                 </li>
                 <li class="nav-link">
                   <a href="/docs/">Documentation</a>
-                </li> 
+                </li>
                 <li class="nav-link">
                   <a href="/updates/">Updates</a>
                 </li>
@@ -82,7 +82,7 @@
               </ul>
             </div>
           </div>
-        </nav> 
+        </nav>
       </div>
 
     </header>

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "anchor-js": "git+https://github.com/msecret/anchorjs.git",
-    "cloudgov-style": "^1.x",
+    "cloudgov-style": "^2.0.0",
     "highlight": "^0.2.4",
     "jquery": "^2.2.0",
     "jquery.scrollto": "^2.1.2"


### PR DESCRIPTION
Pending @vz review

---

**Requires https://github.com/18F/cg-style/pull/169**

Updates look and feel of `cg-docs` homepage to match new lightweight styles for the `cg-dashboard` app.

We're in the process of a major refresh of the dashboard for the coming planning increment. This design refresh uses the design motifs, colors, and typography from that redesign to give coherence across cloud.gov. I've attempted to pare down the motif overhead and give a more streamlined feel to the page. I'm focussing on clarity and solid trustworthy tone in addition to style conformity. (First draft of Design Principles here: https://github.com/18F/cg-product/wiki/Design-principles)

This is only the first phase. Docs also has a refresh. (https://github.com/18F/cg-docs/pull/475)

@berndverst @nickykrause @mogul This work crosses outside the Liberator domain into Skyporter (and beyond). Please consider this a first volley in a design discussion about the cg-site look and feel, and how that relates to the end-to-end look and feel of the cloud.gov experience. I suspect there's much more you all have in mind for this side of cloud.gov.

Discuss?

---

![197898251](https://cloud.githubusercontent.com/assets/11464021/19483783/6aecffa8-950a-11e6-9ea5-db21f29dbfb5.png)
