### PR TITLE
Use safest, simplest bucket URLs

### DIFF
--- a/content/docs/apps/s3.md
+++ b/content/docs/apps/s3.md
@@ -91,9 +91,15 @@ aws s3 ls s3://${BUCKET_NAME}
 ## Bucket URLs
 Objects in your bucket can be accessed most reliably via the following endpoint:
 
-* `https://s3.amazonaws.com/${BUCKET_NAME}/`
+* `https://s3-${AWS_DEFAULT_REGION}.amazonaws.com/${BUCKET_NAME}/`
 
-If the bucket is private, attempting to access this endpoint will result in `AccessDenied` errors unless your application generates [pre-signed URLs](http://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html) for objects that need to be shared.
+If you plan to enable "Website mode" for the bucket and use it that way, then you will need to use a different version of the URL:
+
+* `http://${BUCKET_NAME}.s3-website-${AWS_DEFAULT_REGION}.amazonaws.com/`
+
+But note that "website mode" URLs don't support HTTPS, and aren't appropriate for production use unless fronted by a CloudFront distribution.
+
+Either way, if the bucket is private, attempting to access resources will result in `AccessDenied` errors unless your application generates [pre-signed URLs](http://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html) for objects that need to be shared.
 
 ## Allowing Access from Other Applications
 If users wish to access their S3 buckets from outside of their Cloud.gov application then set a CORS policy, which loosens security restrictions.  This is *NOT* recommended, however with a sufficiently restricted list of sites and methods can be safe:

--- a/content/docs/apps/s3.md
+++ b/content/docs/apps/s3.md
@@ -89,7 +89,7 @@ aws s3 ls s3://${BUCKET_NAME}
 ```
 
 ## Bucket URLs
-Objects in your bucket can be accessed most reliably via the following endpoint:
+Objects in your bucket can be accessed via the following endpoint:
 
 * `https://s3-${AWS_DEFAULT_REGION}.amazonaws.com/${BUCKET_NAME}/`
 

--- a/content/docs/apps/s3.md
+++ b/content/docs/apps/s3.md
@@ -89,12 +89,11 @@ aws s3 ls s3://${BUCKET_NAME}
 ```
 
 ## Bucket URLs
-Objects in your bucket can be accessed via the following endpoints:
+Objects in your bucket can be accessed most reliably via the following endpoint:
 
-* `http://${BUCKET_NAME}.s3-website-${AWS_DEFAULT_REGION}.amazonaws.com/`
-* `http://s3-${AWS_DEFAULT_REGION}.amazonaws.com/${BUCKET_NAME}/`
+* `https://s3.amazonaws.com/${BUCKET_NAME}/`
 
-If the bucket is private, attempting to access these endpoints will result in `AccessDenied` errors unless your application generates [pre-signed URLs](http://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html) for objects that need to be shared.
+If the bucket is private, attempting to access this endpoint will result in `AccessDenied` errors unless your application generates [pre-signed URLs](http://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html) for objects that need to be shared.
 
 ## Allowing Access from Other Applications
 If users wish to access their S3 buckets from outside of their Cloud.gov application then set a CORS policy, which loosens security restrictions.  This is *NOT* recommended, however with a sufficiently restricted list of sites and methods can be safe:


### PR DESCRIPTION
This recommends the use of the `https://s3.amazonaws.com` form of S3 URLs, without the region, and uses the HTTPS URL version of it.

This is simplest and safest because it doesn't depend on the region staying the same, and HTTPS can consistently be used whether or not the bucket name itself has `.`'s in it.
