### PR TITLE
Copyediting "who can use" page

### DIFF
--- a/content/overview/overview/who-can-use-cloudgov.md
+++ b/content/overview/overview/who-can-use-cloudgov.md
@@ -9,33 +9,33 @@ aliases:
   - /intro/overview/who-can-use-cloudgov
 ---
 
-## What is the best fit for cloud.gov?
+## Good fit for cloud.gov
 
-- You have a technical team, or contractor, that can push applications to cloud.gov (See technical requirements).
-- You work for a federal government organization.
+- You have a technical team (internal or contracted) that can push applications to cloud.gov. (See technical requirements below.)
+- You work for a United States federal government organization.
 - You understand that cloud.gov is a product under active development and will see changes in the future.
 - Your application is FISMA Moderate or lower.
-- You have to be able to pay for cloud.gov through the IAA/MOU process (see (pricing)[https://cloud.gov/overview/pricing/rates/]).
+- You have to be able to pay for cloud.gov through the IAA/MOU process (see [pricing]({{< relref "overview/pricing/rates.md" >}})).
 
-## What are the technical requirements?
+### Technical requirements
 
-- Your team has access to the cloud.gov API through the cloud.gov command line interface (compatible with Windows, Mac and Linux).
+- Your team has access to the cloud.gov API through the cloud.gov command line interface (compatible with Windows, Mac, and Linux).
 - Your application stores configuration in the environment.
 - Your application uses one stateless process at a time (that can be horizontally scaled).
 - Your application listens to a single port.
-- Your dependcies are explicitly declared (like `requirements.txt` for Python).
-- You don't rely on local storage for long term data stores.
-- (Optional) Your organization can integrate your identity system with cloud.gov over SAML.
+- Your dependencies are explicitly declared (such as `requirements.txt` for Python).
+- You don't rely on local storage for long-term data stores.
 
-## Who is not a good fit?
+### Optional but recommended
+- Your organization can integrate your identity system with cloud.gov over SAML.
+- Your application can follow the [12-Factor App guidelines](https://12factor.net/).
+
+## Not a good fit
 
 - .NET applications (might require custom buildpacks and be compatible with Linux deployments).
-- Your application requires Oracle, SQL Server or propietary databases.
-- You are a local/state government organization.
+- Your application requires Oracle, SQL Server, or proprietary databases.
+- You work for a local or state government organization.
 
-## Who cannot use cloud.gov?
+## Cannot use cloud.gov
 
-- Non government organizations.
-
-## Reading Material:
-- (12-factor applications)[https://12factor.net/].
+- You work for a non-government organization.


### PR DESCRIPTION
Quick small copyedit suggestions for the improvements in https://github.com/18F/cg-site/pull/504, since I was reading it and noticed a couple things:

* Fixing typos and links
* Clarifying grammar in some statements
* Declarative titles instead of question titles (18F [avoids FAQs](https://pages.18f.gov/content-guide/structure-the-content/#don't-use-faqs))
* Technical requirements are a sub-section of "good fit" since they're part of determining a good fit
* Optional items in their own section

cc @dlapiduz @jameshupp @berndverst 