### PR TITLE
Document deployer account broker in govcloud.

### DIFF
--- a/content/docs/apps/continuous-deployment.md
+++ b/content/docs/apps/continuous-deployment.md
@@ -10,8 +10,46 @@ changes to your desired environment.
 
 Make sure that you've previously looked at the [Production Ready Guide]({{< relref "production-ready.md" >}}) and followed best practices.
 
-
 ## Continuous integration services
+
+*These instructions are different depending on the "environment" your application lives in. If you're not sure, pick East/West. (GovCloud is our new environment.)*
+
+### *GovCloud environment:* Deployer account broker
+
+You can provision a deployer account with permission to deploy to a single org and space using the deployer account service broker:
+
+1. Target the org and space you want to deploy to
+
+    ```bash
+    $ cf target -o $ORG -s $SPACE
+    ```
+
+1. Create a deployer account service instance
+
+    ```bash
+    $ cf create-service deployer-account deployer-account my-deployer-account
+    ```
+
+1. Get the ephemeral credentials link from the service instance
+
+    ```bash
+    $ cf service my-deployer-account
+
+    Service instance: my-deployer-account
+    Service: deployer-account
+    ...
+    Dashboard: https://fugacio.us/m/k3MtzJWVZaNlnjBYJ7FUdpW2ZkDvhmQz
+    ```
+
+1. Retrieve your credentials from the dashboard link. Be sure to retrieve your credentials right away, since the link will only work for a brief length of time.
+
+To delete your deployer account, delete the service instance:
+
+```bash
+$ cf delete-service my-deployer-account
+```
+
+### *East/West environment:* Ask an admin
 
 The first thing you need to do is ask an admin to setup a "deployer" user in your organization and give it permission to deploy to the desired space:
 

--- a/content/docs/getting-started/accounts.md
+++ b/content/docs/getting-started/accounts.md
@@ -24,7 +24,7 @@ If you're in GSA or EPA and you need to reset your agency account password, rese
 
 If you log in with a cloud.gov account that has its own password, you can reset your password by going to https://login.cloud.gov/forgot_password.
 
-For `ORGNAME_deployer` accounts, if you need the password reset, please contact [cloud.gov support](/help/), providing the account name with your request, and a member of the cloud.gov team will provide you with a new password. If you are using our [deployer account broker]({{< relref "apps/continuous-deployment.md" >}}) you can delete and recreate your account to reset the credentials.
+For `ORGNAME_deployer` accounts, if you need the password reset, please contact [cloud.gov support](/help/), providing the account name with your request, and a member of the cloud.gov team will provide you with a new password. If you are using our [deployer account broker]({{< relref "docs/apps/continuous-deployment.md" >}}) you can delete and recreate your account to reset the credentials.
 
 ## Using your account responsibly
 

--- a/content/docs/getting-started/accounts.md
+++ b/content/docs/getting-started/accounts.md
@@ -22,7 +22,9 @@ If you're in GSA or EPA and can't seem to log into cloud.gov from the command li
 
 If you're in GSA or EPA and you need to reset your agency account password, reset your password using your agency's normal process.
 
-If you log in with a cloud.gov account that has its own password (such as `ORGNAME_deployer` accounts), you can reset your password by going to https://login.cloud.gov/forgot_password.
+If you log in with a cloud.gov account that has its own password, you can reset your password by going to https://login.cloud.gov/forgot_password.
+
+For `ORGNAME_deployer` accounts, if you need the password reset, please contact [cloud.gov support](/help/), providing the account name with your request, and a member of the cloud.gov team will provide you with a new password. If you are using our [deployer account broker]({{< relref "apps/continuous-deployment.md" >}}) you can delete and recreate your account to reset the credentials.
 
 ## Using your account responsibly
 


### PR DESCRIPTION
Show users what to do with https://github.com/18F/deployer-account-broker, which will be available in govcloud production later today.