### PR TITLE
Fix command for downloading a database backup

### DIFF
--- a/content/docs/apps/databases.md
+++ b/content/docs/apps/databases.md
@@ -116,7 +116,7 @@ $ psql/bin/pg_dump --format=custom $DATABASE_URL > backup.pg
 On your local host:
 
 ```sh
-$ cf files {app name} backup.pg | tail -n +4 > backup.pg
+$ cf files {app name} app/backup.pg | tail -n +4 > backup.pg
 ```
 
 > [Documentation for `cf files`](http://cli.cloudfoundry.org/en-US/cf/files.html)


### PR DESCRIPTION
Hi cloud.gov folks!

This is a very minor change to fix the command for downloading a database backup.  When you're running an SSH session, you are in the `app` directory by default as a part of your `pwd` (present working directory) and therefore need to have `app/` in front of the file name to get to the database backup file.