### PR TITLE
SSH docs refactor

### DIFF
--- a/content/docs/apps/using-ssh.md
+++ b/content/docs/apps/using-ssh.md
@@ -17,7 +17,7 @@ You can also interact directly with your the services bound to your application 
 
 ### *East/West environment:* CF-SSH
 
-Another way to run one-off commands is via `cf-ssh`. `cf-ssh` is a shared ssh session with an application container that you can connect to. This allows you to debug the environment and your application without disturbing a running container.
+You can get a shell via the `cf-ssh` command (note the dash). `cf-ssh` is a shared ssh session with an application container that you can connect to. This allows you to debug the environment and your application without disturbing a running container.
 
 Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not use the community version of [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html)**. Also note that only one person can use `cf-ssh` for any particular app at any particular time.
 

--- a/content/docs/apps/using-ssh.md
+++ b/content/docs/apps/using-ssh.md
@@ -1,0 +1,48 @@
+---
+menu:
+  docs:
+    parent: advanced
+title: Using SSH
+---
+
+You may on occasion want to get a SSH shell in the environment where your app is running. This is useful for inspecting how your app is operating, transferring files via SCP, or interacting directly with your bound services.
+
+
+*These instructions are different depending on the "environment" your application lives in. If you're not sure, pick East/West. (GovCloud is our new environment.)*
+
+### *GovCloud environment:* CF SSH
+
+Another way to run one-off commands is via [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-command), which lets you securely login to an application instance where you can perform debugging, environment inspection, and other tasks.
+
+### *East/West environment:* CF-SSH
+
+Another way to run one-off commands is via `cf-ssh`. `cf-ssh` is a shared ssh session with an application container that you can connect to. This allows you to debug the environment and your application without disturbing a running container.
+
+Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not use the community version of [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html)**. Also note that only one person can use `cf-ssh` for any particular app at any particular time.
+
+#### Installation
+
+1. [Download cloud.gov's `cf-ssh` for your environment](https://github.com/18F/cf-ssh/releases/) ([source](https://github.com/18F/cf-ssh/tree/18f)).
+1. Run
+
+    ```bash
+    cd ~/Downloads
+    chmod a+x cf-ssh
+    if [ -w /usr/local/bin ]; then mv cf-ssh /usr/local/bin; else sudo mv cf-ssh /usr/local/bin; fi
+    ```
+
+#### Usage
+
+1. In your project folder, run
+
+    ```bash
+    cf-ssh --verbose -f manifest.yml
+    ```
+
+1. The process takes between 2 to 10 minutes to start the session since it is compiling your application in the background. When it completes, you will see a command prompt.
+
+1. If you need to collect any files on the remote machine, you can use [`cf files`][] from a separate terminal window (do *not* close your SSH session, as the machine will be destroyed upon exit). For example, if your project's name in your `manifest.yml` is `foo`, then `cf files foo-ssh app/` should list all the files in your SSH session's default working directory.
+
+1. When done, run `exit`.
+
+[`cf files`]: http://cli.cloudfoundry.org/en-US/cf/files.html

--- a/content/docs/apps/using-ssh.md
+++ b/content/docs/apps/using-ssh.md
@@ -12,7 +12,8 @@ You may on occasion want to get a SSH shell in the environment where your app is
 
 ### *GovCloud environment:* CF SSH
 
-Another way to run one-off commands is via [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-command), which lets you securely login to an application instance where you can perform debugging, environment inspection, and other tasks.
+You can get a shell via the [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-command) command, which lets you securely login to an application instance where you can perform debugging, environment inspection, and other tasks.
+You can also interact directly with your the services bound to your application via [port-forwarding](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-services.html). This allows you to access those services using native clients on your local machine.
 
 ### *East/West environment:* CF-SSH
 

--- a/content/docs/getting-started/one-off-tasks.md
+++ b/content/docs/getting-started/one-off-tasks.md
@@ -7,7 +7,7 @@ aliases:
 - /getting-started/cf-ssh/
 ---
 
-There are a couple of ways to run one-off tasks in cloud.gov's version of Cloud Foundry. The most reliable way to do one-off tasks is by deploying a short-lived app.
+There are a couple of ways to run one-off tasks in cloud.gov's version of Cloud Foundry. The most reliable way to do one-off tasks is by deploying a short-lived app. If {{< relref "docs/apps/ssh-support.md" >}}
 
 ## Disclaimers
 
@@ -56,45 +56,3 @@ The idea here is that we are going to deploy a new application, but running the 
 
 1. If needed, use [`cf files`][] to collect any artifacts.
 1. Run `cf delete task-runner` to clean it up.
-
-## CF SSH
-
-*These instructions are different depending on the "environment" your application lives in. If you're not sure, pick East/West. (GovCloud is our new environment.)*
-
-### *East/West environment:* CF-SSH
-
-Another way to run one-off commands is via `cf-ssh`. `cf-ssh` is a shared ssh session with an application container that you can connect to. This allows you to debug the environment and your application without disturbing a running container.
-
-Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not use the community version of [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html)**. Also note that only one person can use `cf-ssh` for any particular app at any particular time.
-
-#### Installation
-
-1. [Download cloud.gov's `cf-ssh` for your environment](https://github.com/18F/cf-ssh/releases/) ([source](https://github.com/18F/cf-ssh/tree/18f)).
-1. Run
-
-    ```bash
-    cd ~/Downloads
-    chmod a+x cf-ssh
-    if [ -w /usr/local/bin ]; then mv cf-ssh /usr/local/bin; else sudo mv cf-ssh /usr/local/bin; fi
-    ```
-
-#### Usage
-
-1. In your project folder, run
-
-    ```bash
-    cf-ssh --verbose -f manifest.yml
-    ```
-
-1. The process takes between 2 to 10 minutes to start the session since it is compiling your application in the background. When it completes, you will see a command prompt.
-
-1. If you need to collect any files on the remote machine, you can use [`cf files`][] from a separate terminal window (do *not* close your SSH session, as the machine will be destroyed upon exit). For example, if your project's name in your `manifest.yml` is `foo`, then `cf files foo-ssh app/` should list all the files in your SSH session's default working directory.
-
-1. When done, run `exit`.
-
-[`cf files`]: http://cli.cloudfoundry.org/en-US/cf/files.html
-
-
-### *GovCloud environment:* CF SSH
-
-Another way to run one-off commands is via [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-command), which lets you securely login to an application instance where you can perform debugging, environment inspection, and other tasks.

--- a/content/docs/getting-started/one-off-tasks.md
+++ b/content/docs/getting-started/one-off-tasks.md
@@ -7,7 +7,7 @@ aliases:
 - /getting-started/cf-ssh/
 ---
 
-There are a couple of ways to run one-off tasks in cloud.gov's version of Cloud Foundry. The most reliable way to do one-off tasks is by deploying a short-lived app. If you need to perform deeper inspection of how your application is running you may want to [use SSH]({{< relref "docs/apps/using-ssh.md" >}}) instead.
+The most reliable way to do one-off tasks is by deploying a short-lived app. If you need to perform deeper inspection of how your application is running you may want to [use SSH]({{< relref "docs/apps/using-ssh.md" >}}) instead.
 
 ## Disclaimers
 

--- a/content/docs/getting-started/one-off-tasks.md
+++ b/content/docs/getting-started/one-off-tasks.md
@@ -7,7 +7,7 @@ aliases:
 - /getting-started/cf-ssh/
 ---
 
-There are a couple of ways to run one-off tasks in cloud.gov's version of Cloud Foundry. The most reliable way to do one-off tasks is by deploying a short-lived app. If {{< relref "docs/apps/ssh-support.md" >}}
+There are a couple of ways to run one-off tasks in cloud.gov's version of Cloud Foundry. The most reliable way to do one-off tasks is by deploying a short-lived app. If you need to perform deeper inspection of how your application is running you may want to [use SSH]({{< relref "docs/apps/using-ssh.md" >}}) instead.
 
 ## Disclaimers
 


### PR DESCRIPTION
Adds better instructions for `cf ssh`