### PR TITLE
Small updates for SSH info

### DIFF
--- a/content/docs/apps/govcloud.md
+++ b/content/docs/apps/govcloud.md
@@ -17,7 +17,7 @@ When your org starts using cloud.gov's GovCloud environment, here are changes to
 
 ### New features
 
-- To run [one-off tasks]({{< relref "docs/getting-started/one-off-tasks.md" >}}), [`cf-ssh`]({{< relref "docs/getting-started/one-off-tasks.md#cf-ssh" >}}) is not available in GovCloud. Instead, you can use [`cf ssh`]({{< relref "docs/getting-started/one-off-tasks.md#govcloud-environment-cf-ssh" >}}) (note the space instead of the `-`), which is more flexible than `cf-ssh`.
+- To run [one-off tasks]({{< relref "docs/getting-started/one-off-tasks.md" >}}), [`cf-ssh`]({{< relref "docs/apps/using-ssh.md#east-west-environment-cf-ssh" >}}) is not available in GovCloud. Instead, you can use [`cf ssh`]({{< relref "docs/apps/using-ssh.md#govcloud-environment-cf-ssh" >}}) (note the space instead of the `-`), which is more flexible than `cf-ssh`.
 - To set up custom domains, you can use the [managed service method]({{< relref "docs/apps/custom-domains.md#managed-service-method" >}}).
 
 #### Experimental new features

--- a/content/docs/apps/using-ssh.md
+++ b/content/docs/apps/using-ssh.md
@@ -5,19 +5,19 @@ menu:
 title: Using SSH
 ---
 
-You may on occasion want to get a SSH shell in the environment where your app is running. This is useful for inspecting how your app is operating, transferring files via SCP, or interacting directly with your bound services.
+Here's how to get a SSH shell in the environment where your app is running. You can use this to inspect how your app is operating, transfer files via SCP, or interact directly with your bound services. (To run one-off tasks, you can also [deploy a short-lived app]({{< relref "docs/getting-started/one-off-tasks.md" >}}).)
 
-
-*These instructions are different depending on the "environment" your application lives in. If you're not sure, pick East/West. (GovCloud is our new environment.)*
+*These instructions are different depending on the "environment" your application lives in. [GovCloud]({{< relref "docs/apps/govcloud.md" >}}) is our new environment.*
 
 ### *GovCloud environment:* CF SSH
 
 You can get a shell via the [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-command) command, which lets you securely login to an application instance where you can perform debugging, environment inspection, and other tasks.
+
 You can also interact directly with your the services bound to your application via [port-forwarding](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-services.html). This allows you to access those services using native clients on your local machine.
 
 ### *East/West environment:* CF-SSH
 
-You can get a shell via the `cf-ssh` command (note the dash). `cf-ssh` is a shared ssh session with an application container that you can connect to. This allows you to debug the environment and your application without disturbing a running container.
+You can get a shell via the `cf-ssh` command (note the dash). `cf-ssh` is a shared SSH session with an application container that you can connect to. This allows you to debug the environment and your application without disturbing a running container.
 
 Our `cf-ssh` is customized to our Cloud Foundry installation, so please **do not use the community version of [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html)**. Also note that only one person can use `cf-ssh` for any particular app at any particular time.
 

--- a/content/docs/getting-started/one-off-tasks.md
+++ b/content/docs/getting-started/one-off-tasks.md
@@ -7,21 +7,24 @@ aliases:
 - /getting-started/cf-ssh/
 ---
 
-The most reliable way to do one-off tasks is by deploying a short-lived app. If you need to perform deeper inspection of how your application is running you may want to [use SSH]({{< relref "docs/apps/using-ssh.md" >}}) instead.
+The most reliable way to do one-off tasks is by deploying a short-lived app. If you need to perform deeper inspection of how your application is running, you may want to [use SSH]({{< relref "docs/apps/using-ssh.md" >}}) instead.
 
-## Disclaimers
 
-* Both require a "complete" [application manifest](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) (which needs to include all of your service bindings, etc.) &mdash; if you don't have one yet, generate one from an existing app:
+## Deploy a short-lived app
+
+### Know before you deploy
+
+* This requires a "complete" [application manifest](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) (which needs to include all of your service bindings, etc.) &mdash; if you don't have one yet, generate one from an existing app:
 
     ```bash
     cf create-app-manifest <APP_NAME> -p manifest.yml
     ```
 
-* Both will spin up an instance of your environment uploading your **local** code.
+* This will spin up an instance of your environment uploading your **local** code.
     * Note that this may not be in sync with your live app.
     * You can leverage this fact to include files that your one-off task might need, such as a data file for importing.
 
-## Short-lived app
+### How to deploy
 
 The idea here is that we are going to deploy a new application, but running the one-off task, rather than starting a server or whatever it would normally do. Note that this will not work for any command that is interactive.
 
@@ -56,3 +59,5 @@ The idea here is that we are going to deploy a new application, but running the 
 
 1. If needed, use [`cf files`][] to collect any artifacts.
 1. Run `cf delete task-runner` to clean it up.
+
+[`cf files`]: http://cli.cloudfoundry.org/en-US/cf/files.html


### PR DESCRIPTION
Suggestions following up on https://github.com/18F/cg-site/pull/527 - cc @berndverst @mogul 

* Update GovCloud page to link to new SSH page
* Update SSH page intro to speak more directly to the reader and cross-reference one-off tasks page
* Capitalize SSH
* Refactor one-off tasks page a little bit since it now only provides one guide
* Put back missing link on one-off tasks page