### PR TITLE
Copyedits for S3 access and production-ready guide

### DIFF
--- a/content/docs/apps/production-ready.md
+++ b/content/docs/apps/production-ready.md
@@ -6,9 +6,7 @@ menu:
 title: Production Ready guide
 ---
 
-## Your guide to having production ready apps on cloud.gov
-
-Read this guide early and often, especially when you’re starting to consider a future project. It explains things you can do for reliable and responsive applications deployed on cloud.gov.
+This is your guide to building production-ready apps on cloud.gov. Read this early and often, especially when you’re starting to consider a future project. It explains things you can do for reliable and responsive applications deployed on cloud.gov.
 
 ## Core best practices
 To build consistent, healthy, production-ready applications on cloud.gov, incorporate the following practices into your development workflow from the beginning.
@@ -39,49 +37,49 @@ Environment variables defined with `cf set-env` are ephemeral to the specific de
 Shared services do not have the same constraints as a dedicated service and can be affected by other customers that are performing CPU or memory intensive tasks against that service.
 
 #### How
-* Use the `cf marketplace` to consider your options and sizes for each service and choose appropriately for the resources your application will need.
+* Use `cf marketplace` to consider your options and sizes for each service, and choose appropriately for the resources your application will need.
 
 ### Space per environment
 When running an application for development or testing, it is best to have a separate space from your production instance in which to run the application. Ideally, each space will look identical to each other, with the exception of routes or number of instances.
 
 #### How
-* As an Org Manager for your organization, use the `cf create-space` command to create new spaces for each environment
+* As an Org Manager for your organization, use the `cf create-space` command to create new spaces for each environment.
 
 ### Health monitoring
-You want to be able to receive alerts about application errors, downtime, and throughput issues.
+You want to receive alerts about application errors, downtime, and throughput issues.
 
 #### How
-* NewRelic provides extensive application performance and availability monitoring with "Insights". It is easy to set up and receive alerts on a variety of metrics.
+* New Relic provides extensive application performance and availability monitoring with "Insights". You can set up and receive alerts on a variety of metrics.
 
 ## Additional practices
-The following practices are very helpful to incorporate into most cloud.gov apps. Check these out and evaluate which ones you need, depending on the needs of your team and users.
+The following practices are very helpful to incorporate into most cloud.gov apps. Evaluate which ones you need for your team and users.
 
-### Zero-Downtime deploy
-Your application should be able to be deployed without generating any downtime. Be aware there are known issues if your application automatically does database migrations when deploying.
+### Zero-downtime deploy
+Your application should be able to be deployed without any downtime. Be aware there are known issues if your application automatically does database migrations when deploying.
 
 #### How
 * Use the [autopilot](https://github.com/concourse/autopilot) Cloud Foundry CLI plugin.
 
 ### Automated deployments
-To reduce the risk associated with manual deployments, consider automating the process so it is repeatable.
+To reduce the risk associated with manual deployments, consider automating the process to make it repeatable.
 
 #### How
-* See the [continuous deployment]({{< relref "continuous-deployment.md" >}}) page.
+* See [continuous deployment]({{< relref "continuous-deployment.md" >}}).
 
 ### Caching
-The best way to prevent performance issues is by having caching enabled on your application.
+The best way to prevent performance issues is to enable caching on your application.
 
 #### How
-* Cloud.gov has a memcached service but you can also rely on [S3 file storage]({{< relref "s3.md" >}}) for caches.
+* cloud.gov has a memcached service, but you can also use [S3 file storage]({{< relref "s3.md" >}}) for caches.
 
 ### Asset Serving
-It is best not to serve static files from Cloud.gov directly.
+It's best not to serve static files from cloud.gov directly.
 
 #### How
-* You can store your files in S3 or point CloudFront to an assets folder so you serve your assets with a CDN.
+* You can [store your files in S3]({{< relref "s3.md" >}}) or point CloudFront to an assets folder so you serve your assets with a CDN.
 
 ### Custom domain name
-If and/or when you need a domain name dedicated for your application, DNS delegation for the domain is the easiest path for getting the domain up and running.
+When you need a domain name dedicated for your application, DNS delegation for the domain is the easiest path to getting the domain up and running.
 
 #### How
-* See the [custom domains]({{< relref "custom-domains.md" >}}) page.
+* See [custom domains]({{< relref "custom-domains.md" >}}).

--- a/content/docs/apps/s3.md
+++ b/content/docs/apps/s3.md
@@ -95,7 +95,7 @@ Objects in your bucket can be accessed via the following endpoint:
 
 * `https://s3-${AWS_DEFAULT_REGION}.amazonaws.com/${BUCKET_NAME}/`
 
-If you plan to enable "Wwbsite mode" for the bucket and use it that way, you will need to use a different version of the URL:
+If you plan to enable "website mode" for the bucket and use it that way, you will need to use a different version of the URL:
 
 * `http://${BUCKET_NAME}.s3-website-${AWS_DEFAULT_REGION}.amazonaws.com/`
 

--- a/content/docs/apps/s3.md
+++ b/content/docs/apps/s3.md
@@ -5,17 +5,17 @@ menu:
 title: S3 access
 ---
 
-For applications which prefer to store their content in S3, Cloud.gov provides a service which allows direct access
+You can store application content in S3 using a [managed service]({{< relref "docs/apps/managed-services.md" >}}) that provides direct access to S3.
 
-## Enable S3 for the Application
+## Enable S3 for the application
 
-First make sure the account has S3 available to it: `cf marketplace`.  If a s3 service isn't listed, #cloud-gov-support on Slack can enable S3 access for the account.
+First check whether your account has S3 available: `cf marketplace`.  If the S3 service isn't listed, ask [cloud.gov support]({{< relref "docs/help.md" >}}) to enable S3 access for your account.
 
-Once S3 is confirmed available, start the service and assign it to the application.  If only S3 is needed, a S3 only application can be provisioned to allow S3 access.
+Once you confirm S3 is available, start the service and [bind it to your application]({{< relref "docs/apps/managed-services.md#bind-the-service-instance" >}}). Or if you only need S3, you can create an application only for S3.
 
-### Create a Application only for S3
+### Create an application only for S3
 
-If only a S3 bucket is needed but there is no application, a Static application can be created:
+If you only need a S3 bucket, you can create a simple Static application:
 
 ```bash
 mkdir s3-app
@@ -24,8 +24,9 @@ touch Staticfile
 cf push
 ```
 
-### Add S3 to an Application
-Once an application is running in Cloud.gov, the next step is to create and assign S3 to the application:
+### Add S3 to an application
+
+Once an application is running in cloud.gov, the next step is to create and assign S3 to the application:
 
 First decide if the S3 bucket contents should be private or public. Objects placed in a private bucket are only accessible using the bucket credentials unless specifically [shared with others](http://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html). Objects placed in a public bucket are accessible to anyone with the link.
 
@@ -48,20 +49,21 @@ cf bind-service <APP_NAME> <APP_NAME>-s3
 cf restage <APP_NAME>
 ```
 
-This will put the S3 access information in the application's ENVIRONMENT variables, which can be viewed with `cf env <APP_NAME>`.
+This will put the S3 access information in the application's ENVIRONMENT variables, which you can view with `cf env <APP_NAME>`.
 
-If you get an error, please see the [managed service documentation]({{< relref "docs/apps/managed-services.md#paid-services" >}}).
+If you get an error, see the [managed service documentation]({{< relref "docs/apps/managed-services.md#paid-services" >}}).
 
-## Getting S3 Bucket Credentials
+## Get S3 bucket credentials
+
 Typically to interact with S3 the [AWS Command Line Interface](https://aws.amazon.com/cli/) is used.  The Amazon CLI needs the following ENVIRONMENT variables:
 
 * `AWS_ACCESS_KEY_ID`
 * `AWS_SECRET_ACCESS_KEY`
 * `AWS_DEFAULT_REGION`
 
-These environment variables contain the credentials to access your s3 bucket. Treat the contents of these and all other environment variables as sensitive.
+These environment variables contain the credentials to access your S3 bucket. Treat the contents of these and all other environment variables as sensitive.
 
-You can download the [jq](https://stedolan.github.io/jq/) tool to get this information by pasting the below (or just run `cf env` and cut and paste from it):
+You can download the [jq](https://stedolan.github.io/jq/) tool to get this information by pasting the below (or run `cf env` and cut and paste from it):
 
 ```bash
 export APP_NAME=your-app-name-here
@@ -93,16 +95,16 @@ Objects in your bucket can be accessed via the following endpoint:
 
 * `https://s3-${AWS_DEFAULT_REGION}.amazonaws.com/${BUCKET_NAME}/`
 
-If you plan to enable "Website mode" for the bucket and use it that way, then you will need to use a different version of the URL:
+If you plan to enable "Wwbsite mode" for the bucket and use it that way, you will need to use a different version of the URL:
 
 * `http://${BUCKET_NAME}.s3-website-${AWS_DEFAULT_REGION}.amazonaws.com/`
 
-But note that "website mode" URLs don't support HTTPS, and aren't appropriate for production use unless fronted by a CloudFront distribution.
+Note that "website mode" URLs don't support HTTPS, and they aren't appropriate for production use unless fronted by a CloudFront distribution.
 
 Either way, if the bucket is private, attempting to access resources will result in `AccessDenied` errors unless your application generates [pre-signed URLs](http://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html) for objects that need to be shared.
 
-## Allowing Access from Other Applications
-If users wish to access their S3 buckets from outside of their Cloud.gov application then set a CORS policy, which loosens security restrictions.  This is *NOT* recommended, however with a sufficiently restricted list of sites and methods can be safe:
+## Allow access from other applications
+If you wish to access your S3 buckets from outside an application, you can set a CORS policy, which loosens security restrictions.  We do *NOT* recommend this, but with a sufficiently restricted list of sites and methods, it can be safe:
 
 ```bash
 # Adjust CORS AllowedOrigins to known locations such as a IP address
@@ -123,9 +125,9 @@ EOF
 aws s3api put-bucket-cors --bucket $BUCKET_NAME --cors-configuration file://cors.json
 ```
 
-Additional method types above and beyond HEAD and GET, such as PUT, POST, DELETE can be added above as needed.
+You can add additional method types along with HEAD and GET (such as PUT, POST, and DELETE) as needed.
 
-## Backup and Retention
-By default, S3 data will stay where it is until `cf delete-service` is run on the `<APP_NAME>-s3` service.  This however is not a substitue for backups, and provides no protection from users accidentally deleting the contents.  
+## Backup and retention
+By default, S3 data will stay where it is until `cf delete-service` is run on the `<APP_NAME>-s3` service.  This is not a substitue for backups, and it provides no protection from users accidentally deleting the contents.  
 
-You can implement a backup scheme by storing your buckets under /data/year/month/day and keeping multiple copies in S3, using the aws cli. A Cloud.gov space can be created by your Organization Admin called backups, where the process above may be ran again to create "backup" buckets.
+You can implement a backup scheme by storing your buckets under /data/year/month/day and keeping multiple copies in S3, using the AWS CLI. Your Org Manager can create a space called "backups", and your team can run the process above again to create backup buckets.


### PR DESCRIPTION
Some minor edits for clarity on the S3 access page and production-ready guide:

* [Speak to the reader directly as "you"](https://pages.18f.gov/content-guide/address-the-user/)
* Standardize titles
* Trim extra words