### PR TITLE
visually distinguish environment-specific blocks of content

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ Hugo uses Markdown to build the pages. Add your page to the section you want ins
 1. Run `npm install` to download all the dependencies.
 1. Run `npm run start` and browse to [http://localhost:1313](http://localhost:1313).
 
+### Environment-specific information
+
+For a block of content that is specific to AWS East/West, use the following [shortcode](https://gohugo.io/extras/shortcodes/):
+
+```
+{{% eastwest %}}
+East/West-specific Markdown content goes here.
+{{% /eastwest %}}
+```
+
+Ditto for `govcloud`.
+
 ### Making redirects
 
 If you delete or rename a page, you can make a redirect to avoid breaking links from other sites: [make an alias](https://gohugo.io/extras/aliases/) (use the "YAML frontmatter" style).

--- a/content/docs/apps/databases.md
+++ b/content/docs/apps/databases.md
@@ -61,8 +61,6 @@ GovCloud)
 
 ## Access a postgres database
 
-*These instructions are different depending on the "environment" your application lives in. If you're not sure, pick East/West. (GovCloud is our new environment.)*
-
 {{% eastwest %}}
 ### Using cf-ssh
 

--- a/content/docs/apps/databases.md
+++ b/content/docs/apps/databases.md
@@ -89,9 +89,8 @@ You should now have an open `psql` terminal connected to the service database.
 
 ### Create backup
 
-*These instructions are different depending on the "environment" your application lives in. If you're not sure, pick East/West. (GovCloud is our new environment.)*
-
-#### *East/West environment:* Using cf-ssh
+{{% eastwest %}}
+#### Using cf-ssh
 
 First, spin up a host to connect to the database:
 
@@ -113,8 +112,10 @@ $ psql/bin/pg_dump --format=custom $DATABASE_URL > backup.pg
 ```
 
 Leave the ssh connection open.
+{{% /eastwest %}}
 
-#### *GovCloud environment:* Using cf ssh
+{{% govcloud %}}
+#### Using cf ssh
 
 First, connect to an instance:
 
@@ -134,14 +135,11 @@ Now you can create the export file:
 ```sh
 $ psql/bin/pg_dump --format=custom $DATABASE_URL > backup.pg
 ```
-
+{{% /govcloud %}}
 
 ### Download
 
-*These instructions are different depending on the "environment" your application lives in. If you're not sure, pick East/West. (GovCloud is our new environment.)*
-
-#### *East/West environment*
-
+{{% eastwest %}}
 On your local host:
 
 ```sh
@@ -155,9 +153,9 @@ Now you may close the ssh connection to cloud.gov, back in tmux:
 ```sh
 $ exit
 ```
+{{% /eastwest %}}
 
-#### *GovCloud environment*
-
+{{% govcloud %}}
 > [Documentation for using scp and sftp](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#other-ssh-access)
 
 On your local host:
@@ -185,7 +183,7 @@ Connected to ssh.fr.cloud.gov.
 sftp> get backup.pg
 sftp> quit
 ```
-
+{{% /govcloud %}}
 
 ### Restore to local database
 

--- a/content/docs/apps/databases.md
+++ b/content/docs/apps/databases.md
@@ -63,7 +63,8 @@ GovCloud)
 
 *These instructions are different depending on the "environment" your application lives in. If you're not sure, pick East/West. (GovCloud is our new environment.)*
 
-### *East/West environment:* Using cf-ssh
+{{% eastwest %}}
+### Using cf-ssh
 
 To access a service database, use the [cf-ssh]({{< relref "docs/getting-started/one-off-tasks.md#cf-ssh" >}}) CLI to start an instance that is bound to the service and download the `psql` binary to that instance:
 
@@ -72,8 +73,10 @@ To access a service database, use the [cf-ssh]({{< relref "docs/getting-started/
     ./psql/bin/psql $DATABASE_URL
 
 You should now have an open `psql` terminal connected to the service database.
+{{% /eastwest %}}
 
-### *GovCloud environment:* Using cf ssh
+{{% govcloud %}}
+### Using cf ssh
 
 To access a service database, use the [cf ssh]({{< relref "docs/getting-started/one-off-tasks.md#cf-ssh" >}}) CLI command to login to an instance that is bound to the service and download the `psql` binary to that instance:
 
@@ -82,7 +85,7 @@ To access a service database, use the [cf ssh]({{< relref "docs/getting-started/
     ./psql/bin/psql $DATABASE_URL
 
 You should now have an open `psql` terminal connected to the service database.
-
+{{% /govcloud %}}
 
 ## Export
 

--- a/content/docs/apps/govcloud.md
+++ b/content/docs/apps/govcloud.md
@@ -9,6 +9,18 @@ cloud.gov currently has two "environments" where orgs can live: the main environ
 
 When your org starts using cloud.gov's GovCloud environment, here are changes to look out for.
 
+### Documentation
+
+Some instructions/information will vary from one environment to the other. You will see the following throughout this site:
+
+{{% eastwest %}}
+East/West-specific information
+{{% /eastwest %}}
+
+{{% govcloud %}}
+GovCloud-specific information
+{{% /govcloud %}}
+
 ### Breaking changes
 
 - GSA and EPA accounts already work in GovCloud. No other login credentials work at this time.

--- a/layouts/partials/docs-header.html
+++ b/layouts/partials/docs-header.html
@@ -10,6 +10,7 @@
 
     <link href="/assets/font-awesome/css/font-awesome.min.css" rel="stylesheet" />
     <link href="/assets/css/cloudgov-style.css" rel="stylesheet">
+    <link href="/assets/css/main.css" rel="stylesheet">
     <link rel="shortcut icon" type="image/x-icon" href="/assets/img/favicon.ico" />
 
   </head>

--- a/layouts/partials/docs-header.html
+++ b/layouts/partials/docs-header.html
@@ -104,5 +104,5 @@
 
 
       <main class="sidenav-main" id="main-content">
-        <div class="usa-content content">
+        <div class="usa-content content content-text">
 <h1 id="{{.Title | urlize }}">{{ .Title }}</h1>

--- a/layouts/shortcodes/eastwest.html
+++ b/layouts/shortcodes/eastwest.html
@@ -1,6 +1,6 @@
 <div class="env-block env-east-west">
   <p class="env-specifier">
-    East/West (<a href="/docs/apps/govcloud/">what's this?</a>)
+    <strong>In the East/West environment</strong> (<a href="/docs/apps/govcloud/">what's this?</a>)
   </p>
   {{ .Inner }}
 </div>

--- a/layouts/shortcodes/eastwest.html
+++ b/layouts/shortcodes/eastwest.html
@@ -1,6 +1,6 @@
 <div class="env-block env-east-west">
   <p class="env-specifier">
-    East/West only
+    East/West (<a href="/docs/apps/govcloud/">What's this?</a>)
   </p>
   {{ .Inner }}
 </div>

--- a/layouts/shortcodes/eastwest.html
+++ b/layouts/shortcodes/eastwest.html
@@ -1,0 +1,6 @@
+<div class="env-block env-east-west">
+  <p class="env-specifier">
+    East/West only
+  </p>
+  {{ .Inner }}
+</div>

--- a/layouts/shortcodes/eastwest.html
+++ b/layouts/shortcodes/eastwest.html
@@ -1,6 +1,6 @@
 <div class="env-block env-east-west">
   <p class="env-specifier">
-    East/West (<a href="/docs/apps/govcloud/">What's this?</a>)
+    East/West (<a href="/docs/apps/govcloud/">what's this?</a>)
   </p>
   {{ .Inner }}
 </div>

--- a/layouts/shortcodes/govcloud.html
+++ b/layouts/shortcodes/govcloud.html
@@ -1,6 +1,6 @@
 <div class="env-block env-govcloud">
   <p class="env-specifier">
-    GovCloud only
+    GovCloud (<a href="/docs/apps/govcloud/">What's this?</a>)
   </p>
   {{ .Inner }}
 </div>

--- a/layouts/shortcodes/govcloud.html
+++ b/layouts/shortcodes/govcloud.html
@@ -1,6 +1,6 @@
 <div class="env-block env-govcloud">
   <p class="env-specifier">
-    GovCloud (<a href="/docs/apps/govcloud/">What's this?</a>)
+    GovCloud (<a href="/docs/apps/govcloud/">what's this?</a>)
   </p>
   {{ .Inner }}
 </div>

--- a/layouts/shortcodes/govcloud.html
+++ b/layouts/shortcodes/govcloud.html
@@ -1,0 +1,6 @@
+<div class="env-block env-govcloud">
+  <p class="env-specifier">
+    GovCloud only
+  </p>
+  {{ .Inner }}
+</div>

--- a/layouts/shortcodes/govcloud.html
+++ b/layouts/shortcodes/govcloud.html
@@ -1,6 +1,6 @@
 <div class="env-block env-govcloud">
   <p class="env-specifier">
-    GovCloud (<a href="/docs/apps/govcloud/">what's this?</a>)
+    <strong>In the GovCloud environment</strong> (<a href="/docs/apps/govcloud/">what's this?</a>)
   </p>
   {{ .Inner }}
 </div>

--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -17,7 +17,7 @@
 
 .env-specifier {
   color: #333; /* $color-textblack */
-  font-family: '18Franklin'; /* $font-sans */
+  font-family: '18Franklin-webfont', system, -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif; /* $font-sans */
   font-size: 14px; /* $sans-s4 */
   font-weight: 400;
 }

--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -1,41 +1,57 @@
 .env-block {
-  margin-bottom: 1.5rem;
-  margin-top: 1.5rem;
+  margin-bottom: 24px; /* $grid-3 */
+  margin-left: 16px; /* $grid-3 */
+  margin-top: 24px; /* $grid-3 */
   position: relative;
 }
 
 .env-block::before {
   border-radius: 3px;
   border-style: solid;
-  border-width: 3px;
+  border-width: 2px;
   content: '';
   height: 100%;
-  left: -1rem;
+  left: -16px; /* -$grid-3 */
   position: absolute;
 }
 
 .env-specifier {
-  font-size: 0.8em;
-  font-weight: bold;
+  color: #333; /* $color-textblack */
+  font-family: '18Franklin'; /* $font-sans */
+  font-size: 14px; /* $sans-s4 */
+  font-weight: 400;
 }
+
+.env-specifier strong {
+  font-size: 14px; /* $sans-s4 */
+  font-weight: 600;
+}
+
 .env-specifier a {
+  color: #333; /* $color-textblack */
   text-decoration: underline;
 }
 
-/* $color-primary-darker from cg-style */
-.env-east-west::before {
-  border-color: #2c3e50;
-}
-.env-east-west .env-specifier,
-.env-east-west .env-specifier a {
-  color: #2c3e50;
+.env-specifier + h2,
+.env-specifier + h3,
+.env-specifier + h4{
+  margin-top: 8px; /* $grid-1 */
 }
 
-/* $color-blue from cg-style */
-.env-govcloud::before {
-  border-color: #056dd4;
+.env-east-west .env-specifier,
+.env-east-west .env-specifier a {
+  color: #333; /* $color-textblack */
 }
+
+.env-east-west::before {
+  border-color: #74B1DB;
+}
+
 .env-govcloud .env-specifier,
 .env-govcloud .env-specifier a {
-  color: #056dd4;
+  color: #333; /* $color-textblack */
+}
+
+.env-govcloud::before {
+  border-color: #333; /* $color-textblack */
 }

--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -1,0 +1,28 @@
+.env-block {
+  border-left-width: 3px;
+  border-left-style: solid;
+  padding-left: 12px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  margin-bottom: 1em;
+}
+
+.env-specifier {
+  font-weight: bold;
+  font-size: 0.8em;
+  margin-left: -3px;
+}
+
+.env-east-west {
+  border-left-color: red;
+}
+.env-east-west .env-specifier {
+  color: red;
+}
+
+.env-govcloud {
+  border-left-color: blue;
+}
+.env-govcloud .env-specifier {
+  color: blue;
+}

--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -18,17 +18,22 @@
   font-size: 0.8em;
   font-weight: bold;
 }
+.env-specifier a {
+  text-decoration: underline;
+}
 
 .env-east-west::before {
   border-color: red;
 }
-.env-east-west .env-specifier {
+.env-east-west .env-specifier,
+.env-east-west .env-specifier a {
   color: red;
 }
 
 .env-govcloud::before {
   border-color: blue;
 }
-.env-govcloud .env-specifier {
+.env-govcloud .env-specifier,
+.env-govcloud .env-specifier a {
   color: blue;
 }

--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -1,27 +1,33 @@
 .env-block {
-  border-left-width: 3px;
-  border-left-style: solid;
-  padding-left: 12px;
-  padding-top: 4px;
-  padding-bottom: 4px;
-  margin-bottom: 1em;
+  margin-bottom: 1.5rem;
+  position: relative;
+}
+
+.env-block::before {
+  border-radius: 5px;
+  border-style: solid;
+  border-width: 3px;
+  content: '';
+  height: 100%;
+  left: -1rem;
+  position: absolute;
+  width: 3px;
 }
 
 .env-specifier {
-  font-weight: bold;
   font-size: 0.8em;
-  margin-left: -3px;
+  font-weight: bold;
 }
 
-.env-east-west {
-  border-left-color: red;
+.env-east-west::before {
+  border-color: red;
 }
 .env-east-west .env-specifier {
   color: red;
 }
 
-.env-govcloud {
-  border-left-color: blue;
+.env-govcloud::before {
+  border-color: blue;
 }
 .env-govcloud .env-specifier {
   color: blue;

--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -1,17 +1,17 @@
 .env-block {
   margin-bottom: 1.5rem;
+  margin-top: 1.5rem;
   position: relative;
 }
 
 .env-block::before {
-  border-radius: 5px;
+  border-radius: 3px;
   border-style: solid;
   border-width: 3px;
   content: '';
   height: 100%;
   left: -1rem;
   position: absolute;
-  width: 3px;
 }
 
 .env-specifier {
@@ -22,18 +22,20 @@
   text-decoration: underline;
 }
 
+/* $color-primary-darker from cg-style */
 .env-east-west::before {
-  border-color: red;
+  border-color: #2c3e50;
 }
 .env-east-west .env-specifier,
 .env-east-west .env-specifier a {
-  color: red;
+  color: #2c3e50;
 }
 
+/* $color-blue from cg-style */
 .env-govcloud::before {
-  border-color: blue;
+  border-color: #056dd4;
 }
 .env-govcloud .env-specifier,
 .env-govcloud .env-specifier a {
-  color: blue;
+  color: #056dd4;
 }


### PR DESCRIPTION
Closes https://github.com/18F/cg-site/issues/485.

Uses [Hugo shortcodes](https://gohugo.io/extras/shortcodes/) to accomplish this. This is mostly a proof-of-concept - needs design :heart: I have no strong attachment to _how_ they are visually distinguished...just that we get this in sooner than later, since more and more of our content is split in this way.

![screen shot 2016-11-10 at 1 51 04 am](https://cloud.githubusercontent.com/assets/86842/20167335/cbe39a34-a6e8-11e6-8ffb-572337610a3e.png)

/cc @thisisdano @vz3 @berndverst @jameshupp @msecret @adborden 