### PR TITLE
Make help/contact info a little easier to find

### DIFF
--- a/content/docs/help.md
+++ b/content/docs/help.md
@@ -3,24 +3,25 @@ title: Help
 aliases:
   - /help
 ---
-There are several avenues to get help with cloud.gov:
 
-#### I am interested in using cloud.gov.
+### I'm interested in using cloud.gov.
 
-Fill out our [contact form](https://cloud.gov/#contact) for a notification when access is widely available.
+Fill out our [contact form](/#contact) for notification when access is widely available.
 
-#### I have a cloud.gov account and need help.
+You can also email [cloud-gov-inquiries@gsa.gov](cloud-gov-inquiries@gsa.gov) to learn more, including to request a [free sandbox account]({{< relref "overview/pricing/rates.md" >}}) (available to anyone with .gov or .mil email).
+
+### I have a cloud.gov account and need help.
 
 Email [cloud-gov-support@gsa.gov](mailto:cloud-gov-support@gsa.gov).
 
-#### I am 18F staff and need help.
+### I'm 18F staff and need help.
 
 Talk to us in [#cloud-gov-support](https://18f.slack.com/messages/cloud-gov-support).
 
-#### I found a problem or want to suggest an improvement in the documentation.
+### I found a problem or want to suggest an improvement in the documentation.
 
 [Open an issue on GitHub](https://github.com/18F/cg-site/issues/new).
 
-#### I'm interested in working on cloud.gov.
+### I'm interested in working on cloud.gov.
 
 Check out [18F's jobs site](https://pages.18f.gov/joining-18f/), and come talk to us in [our #devops-public Slack channel](https://chat.18f.gov/?channel=devops-public).

--- a/content/overview/overview.md
+++ b/content/overview/overview.md
@@ -16,6 +16,6 @@ cloud.gov was designed with **FISMA compliance** in mind. cloud.gov is currently
 
 ### Free Sandbox Accounts
 
-Anyone with a .gov or .mil email address can try out cloud.gov for free by signing up for a sandbox account. **No paperwork required**.
+Anyone with a .gov or .mil email address can try out cloud.gov for free by [signing up for a sandbox account]({{< relref "docs/help.md" >}}). **No paperwork required**.
 
 

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -35,7 +35,7 @@
           </div>
         </div>
         <div style="margin-top: 1.5rem;">
-            <p>Your privacy and security are important to us; we'll only share your information as described in the <a href="http://www.gsa.gov/portal/content/116609">GSA Privacy and Security Notice</a></p>
+            <p>Your privacy and security are important to us; we'll only share your information as described in the <a href="http://www.gsa.gov/portal/content/116609">GSA Privacy and Security Notice</a>.</p>
         </div>
       </fieldset>
     </form>

--- a/layouts/partials/docs-header.html
+++ b/layouts/partials/docs-header.html
@@ -69,10 +69,10 @@
                   <a href="https://cloudgov.statuspage.io/">Status</a>
                 </li>
                 <li class="nav-link">
-                  <a href="/#contact">Contact</a>
+                  <a href="https://dashboard.cloud.gov/">Dashboard</a>
                 </li>
                 <li class="nav-link">
-                  <a href="https://dashboard.cloud.gov/">Dashboard</a>
+                  <a href="/docs/help/">Contact</a>
                 </li>
                 <li class="js-search-button-container">
                   <a class="js-search-button">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,7 @@
        <nav class="usa-footer-nav usa-width-two-thirds">
          <ul class="usa-unstyled-list">
            <li class="usa-width-one-fourth usa-footer-primary-content">
-             <a class="usa-footer-primary-link" href="https://docs.cloud.gov/help/">cloud.gov help</a>
+             <a class="usa-footer-primary-link" href="/docs/help/">cloud.gov help</a>
            </li>
            <li class="usa-width-one-fourth usa-footer-primary-content">
              <a class="usa-footer-primary-link" href="https://github.com/18F/cg-site">Edit this page</a>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -52,7 +52,7 @@
               <a href="https://dashboard.cloud.gov/">Dashboard</a>
             </li>
             <li class="nav-link">
-              <a href="/#contact">Contact</a>
+              <a href="/docs/help/">Contact</a>
             </li>
           </ul>
         </div> <!-- .nav-secondary -->

--- a/layouts/partials/overview-header.html
+++ b/layouts/partials/overview-header.html
@@ -69,10 +69,10 @@
                   <a href="https://cloudgov.statuspage.io/">Status</a>
                 </li>
                 <li class="nav-link">
-                  <a href="/#contact">Contact</a>
+                  <a href="https://dashboard.cloud.gov/">Dashboard</a>
                 </li>
                 <li class="nav-link">
-                  <a href="https://dashboard.cloud.gov/">Dashboard</a>
+                  <a href="/docs/help/">Contact</a>
                 </li>
                 <li class="js-search-button-container">
                   <a class="js-search-button">


### PR DESCRIPTION
Here are a few incremental changes to help readers contact us, inspired by @jameshupp explaining a user journey recently (related to https://github.com/18F/cg-product/issues/346#issuecomment-251869834):

* Add inquiries email address to Help page (and mention sandbox access there)
* Switch header levels on Help page for readability
* On Overview page, link to Help page for sandbox access
* In landing, docs, and overview header nav, switch "Contact" link to go to Help page (dashboard nav will also need to be updated), since Help has useful options beyond the contact form.
* In docs and overview header nav, switch "Contact" and "Dashboard" positions to be consistent with the landing page header nav.
* Tiny copyedits

cc @berndverst @nikzei 