### PR TITLE
[WIP] Update homepage content to address user needs

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,8 +13,8 @@
     id="main">
   <div class="usa-grid section-bg-parent">
     <div class="usa-width-whole billboard  section-bg">
-      <h1 class="billboard-display_text">A Platform as a Service designed for your government team</h1>
-      <h2 class="billboard-second_text">Focus on your applications. We manage the security, compliance, and maintenance of the underlying virtual machines and servers.</h1>
+      <h1 class="billboard-display_text">A Platform as a Service for government teams</h1>
+      <h2 class="billboard-second_text">Focus on developing your applications. We manage the security, compliance, and maintenance of the virtual machines and servers.</h1>
     </div>
   </div>
 </section>
@@ -23,15 +23,15 @@
   <a name="about"></a>
   <div class="usa-grid">
     <div class="section-content usa-content">
-      <h1>Deploying applications that serve the public shouldn’t be slow and difficult.</h1>
+      <h1>Deploying applications that serve the public shouldn’t be slow or hard.</h1>
       <p>
-        cloud.gov gives government teams access to cloud deployment with fewer hassles. Now you can:
+        cloud.gov gives government teams access to modern cloud deployment with fewer hassles. Now you can:
       </p>
       <ul>
-        <li>Quickly deploy applications on a technology stack that complies with federal policies, without needing to manage and update your own infrastructure.</li>
-        <li>Run modern cloud-native applications. cloud.gov is a platform that provides services on top of Amazon Web Services (GovCloud), so you can use many AWS services as well.</li>
+        <li>Quickly deploy applications that comply with federal policies &mdash; without needing to manage infrastructure.</li>
+        <li>Run scalable cloud-native applications. cloud.gov provides services on top of Amazon Web Services (GovCloud), so you can use AWS services.</li>
         <li>Try experiments: build and test prototypes without adding extra expense.</li>
-        <li>Shorten the path to ATO (Authority to Operate) for each new or updated application from your team, because after your agency gives cloud.gov ATO, only your application needs to be evaluated for security and compliance.</li>
+        <li>Shorten the path to ATO (Authority to Operate) for each new or updated application, because after your agency gives cloud.gov ATO, only your application needs to be evaluated for security and compliance.</li>
       </ul>
     </div>
   </div>
@@ -47,9 +47,12 @@
 <section class="usa-content section section-cream">
   <div class="usa-grid">
     <div class="section-content usa-content">
-      <h1>We’re a government team, and we designed cloud.gov to address development challenges.</h1>
+      <h1>We’re a government team, and we designed cloud.gov to handle real challenges.</h1>
       <p>
-        cloud.gov is built by 18F in GSA’s Technology Transformation Service (TTS), where our mission is to help agencies build, buy, and share technology that allows them to better serve the public. We found that the more apps we built, the more cloud operations and ATOs slowed down deployments. Instead of trying to provide infrastructure support for every product, our cloud ops staff designed a platform that every team could use. Now we’re making it available to other government teams as part of our mission.
+        cloud.gov is built by 18F in GSA’s Technology Transformation Service (TTS), where our mission is to help agencies build, buy, and share technology that helps them better serve the public. We found that the more apps we built, the more cloud operations and ATOs slowed down deployments.
+      </p>
+      <p>
+        Instead of trying to provide infrastructure support for every product, our cloud ops staff designed a platform that every team could use. Now we’re making it available to other government teams as part of our mission.
       </p>
     </div>
   </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,8 +13,8 @@
     id="main">
   <div class="usa-grid section-bg-parent">
     <div class="usa-width-whole billboard  section-bg">
-      <h1 class="billboard-display_text">The Government Innovation Platform</h1>
-      <h2 class="billboard-second_text">A platform by government developers, for government developers.</h1>
+      <h1 class="billboard-display_text">A Platform as a Service designed for your government team</h1>
+      <h2 class="billboard-second_text">Focus on your applications. We manage the security, compliance, and maintenance of the underlying virtual machines and servers.</h1>
     </div>
   </div>
 </section>
@@ -23,10 +23,16 @@
   <a name="about"></a>
   <div class="usa-grid">
     <div class="section-content usa-content">
-      <h1>Cloud deployment is better. But that doesn’t make it easy.</h1>
+      <h1>Deploying applications that serve the public shouldn’t be slow and difficult.</h1>
       <p>
-        Any federal agency deploying an app has to follow regulations, manage an ATO process, and design a robust service infrastructure. Cloud hosting saves one hassle — managing data centers — and creates another: operating cloud infrastructure and keeping it compliant. It requires a different set of skills that isn’t widely available in government yet.
+        cloud.gov gives government teams access to cloud deployment with fewer hassles. Now you can:
       </p>
+      <ul>
+        <li>Quickly deploy applications on a technology stack that complies with federal policies, without needing to manage and update your own infrastructure.</li>
+        <li>Run modern cloud-native applications. cloud.gov is a platform that provides services on top of Amazon Web Services (GovCloud), so you can use many AWS services as well.</li>
+        <li>Try experiments: build and test prototypes without adding extra expense.</li>
+        <li>Shorten the path to ATO (Authority to Operate) for each new or updated application from your team, because after your agency gives cloud.gov ATO, only your application needs to be evaluated for security and compliance.</li>
+      </ul>
     </div>
   </div>
   <!--
@@ -41,9 +47,9 @@
 <section class="usa-content section section-cream">
   <div class="usa-grid">
     <div class="section-content usa-content">
-      <h1>We’re familiar with the challenges of government cloud&nbsp;ops.</h1>
+      <h1>We’re a government team, and we designed cloud.gov to address development challenges.</h1>
       <p>
-        18F is a team within the General Services Administration that builds applications for the federal government, rapidly and iteratively. So as we scaled up the number of teams deploying applications, we couldn’t let cloud operations talent become the kind of bottleneck that slows down development for many federal teams. Instead of working on infrastructure support for every individual product, our cloud ops staff focused on how they could give all our development teams a better way to work.
+        cloud.gov is built by 18F in GSA’s Technology Transformation Service (TTS), where our mission is to help agencies build, buy, and share technology that allows them to better serve the public. We found that the more apps we built, the more cloud operations and ATOs slowed down deployments. Instead of trying to provide infrastructure support for every product, our cloud ops staff designed a platform that every team could use. Now we’re making it available to other government teams as part of our mission.
       </p>
     </div>
   </div>
@@ -61,7 +67,7 @@
     <div class="section-content usa-content">
       <h1>This is why we built cloud.gov.</h1>
       <p>
-        Cloud.gov is 18F’s cloud-hosting product line for federal teams. It addresses baseline security and scalability concerns consistently, right up front, without requiring a huge number of cloud operations experts. Instead, digital service teams can use these tools to focus on delivering quality products.
+        cloud.gov is 18F’s cloud-hosting product line for federal teams. It addresses baseline security and scalability concerns consistently, right up front, without requiring a huge number of cloud operations experts. Instead, digital service teams can use these tools to focus on delivering quality products.
       </p>
     </div>
     <div class="three_up">


### PR DESCRIPTION
@jameshupp and I spent about an hour revising the first few sections of the website homepage to reflect what we've learned about the needs of prospective users.

Here's a work in progress to show what we came up with:

* Revise headline and subtitle to be more specific about what cloud.gov is. This puts "Platform as a Service" in the headline, with an explanation of "Platform as a Service" in the subtitle.
* Revise first chunk to provide a list of value propositions up front, to explain that our value is broader than just taking care of cloud operations.
* Revise "who we are" chunk to mention TTS and speak more plainly.

Our goal is simply to suggest something *better* than the current homepage, not to make a perfect homepage in one iteration. (We specifically timeboxed this.) Suggestions welcome!

This is marked [WIP] since it's not ready to merge.

Context: good to look at the [current cloud.gov one-sheet](https://docs.google.com/document/d/12keNo9E9SCxnVHZ6LcIUXXAyt6I5TyBXm_P2lUp6qYs/edit) + [overview](https://cloud.gov/overview/).

[Draft doc](https://docs.google.com/document/d/1VZ6N8Lmb5tg76dV23HEcxDMU4B74bvaARCVTuC_554U/edit#)