### PR TITLE
Fixing links and directions related to Ops and DevOps

### DIFF
--- a/content/docs/apps/managed-services.md
+++ b/content/docs/apps/managed-services.md
@@ -71,7 +71,7 @@ FAILED
 Server error, status code: 400, error code: 60007, message: The service instance cannot be created because paid service plans are not allowed.
 ```
 
-Please [ask support](/help/) to enable paid services.
+Please [ask support](/help/) to enable [paid services]({{< relref "overview/pricing/quotas.md" >}}).
 
 #### Bind the service instance
 

--- a/content/docs/apps/managed-services.md
+++ b/content/docs/apps/managed-services.md
@@ -71,7 +71,7 @@ FAILED
 Server error, status code: 400, error code: 60007, message: The service instance cannot be created because paid service plans are not allowed.
 ```
 
-Please [ask an administrator](/help/) to [enable paid services](/ops/quotas/).
+Please [ask support](/help/) to enable paid services.
 
 #### Bind the service instance
 

--- a/content/docs/ops/metrics.md
+++ b/content/docs/ops/metrics.md
@@ -19,7 +19,7 @@ In order to export a dashboard:
   * Make sure there are no spaces in the file name and remove the timestamp from the end.
 
 ## Requesting an account on Metrics
-1. Please [create a ticket](https://github.com/18f/devops/issues/new) with the title including `[Metrics Acct Req]`
+1. Please [create a ticket](https://github.com/18f/infrastructure/issues/new) with the title including `[Metrics Acct Req]`
 1. Please indicate if you need an `admin` account or `regular` account.
 
 ## Updating the Metrics containers.

--- a/content/overview/pricing/quotas.md
+++ b/content/overview/pricing/quotas.md
@@ -24,7 +24,7 @@ Quotas limit the following resources:
 - Service instances.  
 - Access to paid plans.  
 
-If a new application `push` would exceed your organization's quota the request will fail with status code `400` and a message describing the limit that would be exceeded.
+If a new application `push` would exceed your organization's quota, the request will fail with status code `400` and a message that describes the limit that would be exceeded.
 
 **Example:**
 
@@ -36,4 +36,4 @@ In this situation you have three options:
 
 1. Delete existing resources with `cf delete`, `delete-service`, `delete-route` or similar.
 2. Reconfigure individual existing [Application Quotas]({{< relref "docs/apps/limits.md" >}}) and redeploy.
-3. Request a quota change by an administrator via a [DevOps issue](https://github.com/18F/DevOps/issues).
+3. Request a quota change by [asking support](/help/).

--- a/content/overview/pricing/quotas.md
+++ b/content/overview/pricing/quotas.md
@@ -22,7 +22,7 @@ Quotas limit the following resources:
 - Application routes.  
 - Application memory.  
 - Service instances.  
-- Access to paid plans.  
+- Access to paid service plans.  
 
 If a new application `push` would exceed your organization's quota, the request will fail with status code `400` and a message that describes the limit that would be exceeded.
 


### PR DESCRIPTION
Changes:

* Link to /ops/quotas was broken. I updated it to link to an overview page instead of an ops page.
* Switch "administrator" to "support".
* Switch link to DevOps repo to Infrastructure repo.