### PR TITLE
Clarify info about paid services

### DIFF
--- a/content/docs/apps/managed-services.md
+++ b/content/docs/apps/managed-services.md
@@ -5,9 +5,7 @@ menu:
 title: Managed services
 ---
 
-### Background
-
-Cloud Foundry Managed Services provide applications with on-demand access to services outside of the stateless application environment. Typical managed services include databases, queues, and key-value stores.
+Cloud Foundry managed services provide applications with on-demand access to services outside of the stateless application environment. Typical managed services include databases, queues, and key-value stores.
 
 ### Prerequisites
 
@@ -15,7 +13,7 @@ Verify your [setup is complete]({{< relref "docs/getting-started/setup.md" >}}).
 
 ### Procedure
 
-In order to create a service instance and binding for use with an application, we first need to identify the available services and their respective plans.
+To create a service instance and binding for use with an application, you first need to identify the available services and their respective plans.
 
 #### List services
 
@@ -62,7 +60,9 @@ For example, to create an instance of the elasticsearch service using the free p
 
 ##### Paid services
 
-If you get an error like the following:
+The note `* These service plans have an associated cost` indicates paid services. [Learn about managed service pricing.]({{< relref "overview/pricing/rates.md#managed-services" >}})
+
+Sandbox accounts (free accounts) can't use paid services. If you have a sandbox account, you'll get an error like this if you try to use them:
 
 ```
 % cf create-service <service> <plan> <service_instance>
@@ -71,7 +71,7 @@ FAILED
 Server error, status code: 400, error code: 60007, message: The service instance cannot be created because paid service plans are not allowed.
 ```
 
-Please [ask support](/help/) to enable [paid services]({{< relref "overview/pricing/quotas.md" >}}).
+If you get that error and you have a non-sandbox account, [ask support](/help/) to enable paid services.
 
 #### Bind the service instance
 

--- a/content/overview/pricing/rates.md
+++ b/content/overview/pricing/rates.md
@@ -33,8 +33,6 @@ Packages are selected based on the kinds of applications to be hosted. [Find mor
 
 \*\*We aren't yet charging for paid services. See the [managed services](#managed-services) section for details.
 
----
-
 ## Resource usage
 
 You will be charged for the **quota** you set for your resource usage. This is only based on the memory, in MB of RAM, your reserve for your applications.
@@ -48,11 +46,9 @@ We require your resource usage quota to **be set in advance**. This helps you co
 
 [Find more about setting quotas and resource usage.]({{< relref "overview/pricing/quotas.md" >}})
 
----
-
 ## Managed services
 
-[Managed services]({{< relref "docs/apps/managed-services.md" >}}) are those which cloud.gov will spin up quickly and run on your behalf (databases, storage, caching, etc.). You can see the services and plans offered for each by [running `cf marketplace`]({{< relref "docs/apps/managed-services.md" >}}). *We'll include more details on this page in the future.*
+[Managed services]({{< relref "docs/apps/managed-services.md" >}}) are those which cloud.gov will spin up quickly and run on your behalf (databases, storage, caching, etc.). You can see the services and plans offered for each by [running `cf marketplace`]({{< relref "docs/apps/managed-services.md" >}}).
 
 While we aren't currently charging for these, we plan to charge for them in the future, to account for the resources they consume and our efforts to provide them as a service. The pricing for each service will be different. 18F provided services will be billed by the service instance, invoiced per month, and will be severable. We will ensure users of those services are aware of the rates when they are set, and they will not be charged before then.
 

--- a/content/overview/terminology/pricing-terminology.md
+++ b/content/overview/terminology/pricing-terminology.md
@@ -41,8 +41,4 @@ Agencies can purchase reserved capacity via 18F as well, which is understood to 
 
 ### Managed services
 
-"Managed services" are commodity services (databases, caches, message queues, storage, etc.) which cloud.gov will spin up (or down) instantly on your behalf. These services reduce the ops responsibility for your application team so they can concentrate on their application rather than plumbing.
-
-Each managed service incurs some resource usage and platform support overhead. The managed service fees ensure we can cover our costs to provide them to you. The fee varies among services. In some cases managed services include alternative “plans” can be selected that reflect resilience, performance, and cost trade-offs.
-
-In many cases, the pricing for managed services is not yet available. This is because we are measuring their initial usage to determine what we will need to charge. We are doing more analysis of the costs we’re observing (both the cost of the IaaS layer and the cost of our support), and aim to set explicit prices for all managed services soon.
+See [**managed services**]({{< relref "overview/pricing/rates.md#managed-services" >}}).


### PR DESCRIPTION
A support email reply by @berndverst today (thanks Bernd!) made me realize that some bits of our docs could say more about paid services, so I tried making a few improvements:

* Update Managed Services page to explain that sandbox accounts can't use paid services, and link to Rates page to explain further.
* Remove unnecessary "under construction" note from Rates page (and a few extra words from other pages).
* Remove redundant Managed Services definition from Terminology page. This definition was similar to the one on the Rates page, so I just linked to that one instead.

The two similar explanations:

![screen shot 2016-11-15 at 6 08 52 pm](https://cloud.githubusercontent.com/assets/391313/20332303/af511344-ab5f-11e6-9bdd-6b3155fc8d20.png)

![screen shot 2016-11-15 at 6 08 56 pm](https://cloud.githubusercontent.com/assets/391313/20332305/b070a62c-ab5f-11e6-92bf-d8cabe3a4554.png)

I chopped the first one and linked it to the second one.