### PR TITLE
Fixed width font awesome icons in sidebar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -65,6 +65,7 @@ publishdir = "public"
 [[menu.docs]]
     name = "Contributing"
     identifier = "ops"
+    pre = "<i class='fa fa-fw fa-wrench'></i>"
 [[menu.docs]]
     name = "Deployment"
     identifier = "deployment"

--- a/config.toml
+++ b/config.toml
@@ -44,22 +44,22 @@ publishdir = "public"
 [[menu.docs]]
     name = "Getting Started"
     identifier = "getting-started"
-    pre = "<i class='fa fa-road'></i>"
+    pre = "<i class='fa fa-fw fa-road'></i>"
     weight = -120
 [[menu.docs]]
     name = "Deploying Apps"
     identifier = "apps"
-    pre = "<i class='fa fa-file-text'></i>"
+    pre = "<i class='fa fa-fw fa-file-text'></i>"
     weight = -110
 [[menu.docs]]
     name = "Advanced"
     identifier = "advanced"
-    pre = "<i class='fa fa-rocket'></i>"
+    pre = "<i class='fa fa-fw fa-rocket'></i>"
     weight = -100
 [[menu.docs]]
     name = "Experimental Features"
     identifier = "experimental"
-    pre = "<i class='fa fa-flask'></i>"
+    pre = "<i class='fa fa-fw fa-flask'></i>"
     weight = -90
 
 [[menu.docs]]

--- a/layouts/partials/docs-menu.html
+++ b/layouts/partials/docs-menu.html
@@ -46,10 +46,10 @@
             </li>
             {{end}}
             <li>
-              <a href="/docs/help/"><i class='fa fa-life-ring'></i> <span>Help</span></a>
+              <a href="/docs/help/"><i class='fa fa-fw fa-life-ring'></i> <span>Help</span></a>
             </li>
             {{ if .IsPage }}
-            {{ $File := .File }}  {{with $File.Path }}<li><a href="https://github.com/18f/cg-site/edit/master/content/{{ $File.Dir }}{{ $File.LogicalName }}" target="blank"><i class='fa fa-edit'></i> Refine this Page</a> </li>{{end}}
+            {{ $File := .File }}  {{with $File.Path }}<li><a href="https://github.com/18f/cg-site/edit/master/content/{{ $File.Dir }}{{ $File.LogicalName }}" target="blank"><i class='fa fa-fw fa-edit'></i> Refine this Page</a> </li>{{end}}
             {{ end }}
   </ul>
 </aside>

--- a/layouts/partials/overview-menu.html
+++ b/layouts/partials/overview-menu.html
@@ -46,7 +46,7 @@
             </li>
             {{end}}
             {{ if .IsPage }}
-            {{ $File := .File }}  {{with $File.Path }}<li><a href="https://github.com/18f/cg-site/edit/master/content/{{ $File.Dir }}{{ $File.LogicalName }}" target="blank"><i class='fa fa-edit'></i> Refine this Page</a> </li>{{end}}
+            {{ $File := .File }}  {{with $File.Path }}<li><a href="https://github.com/18f/cg-site/edit/master/content/{{ $File.Dir }}{{ $File.LogicalName }}" target="blank"><i class='fa fa-fw fa-edit'></i> Refine this Page</a> </li>{{end}}
             {{ end }}
   </ul>
 </aside>


### PR DESCRIPTION
Sometime in the last week or so, the fixed width icons in the sidebar went away. This replaces them.

**before**
![screen shot 2016-11-17 at 7 34 04 am](https://cloud.githubusercontent.com/assets/11464021/20395569/452d040c-ac98-11e6-8306-7fce3f7ac6e6.png)


**after**
![screen shot 2016-11-17 at 7 32 56 am](https://cloud.githubusercontent.com/assets/11464021/20395537/2ec28930-ac98-11e6-80f4-d126bddbe01b.png)
