### PR TITLE
Revising intro docs (accounts, setup, first deploy)

### DIFF
--- a/content/docs/getting-started/accounts.md
+++ b/content/docs/getting-started/accounts.md
@@ -18,13 +18,13 @@ To start using cloud.gov:
 
 ### Agency single-sign-on accounts
 
-If you have a GSA or EPA email address, sign into cloud.gov using your agency credentials as described above. Here are details about using these accounts. 
+If you have a GSA or EPA email address, sign into cloud.gov using your agency credentials as described above.
 
 ### cloud.gov accounts
 
 If you were invited with an email address that isn't part of an agency with single-sign-on authentication to cloud.gov, you have a cloud.gov account.
 
-#### *GovCloud environment*
+{{% govcloud %}}
 
 In the GovCloud environment, your cloud.gov account requires multi-factor authentication. To log into the system, you need two "factors" -- something you know (your password) and something you have on your person (your smartphone).
 
@@ -35,10 +35,12 @@ When you log in to cloud.gov via a web browser, select the `cloud.gov` provider 
 ##### Managing MFA / TOTP with authentication applications
 
 In order to perform multi-factor authentication with the `cloud.gov` provider, you need an authentication application that generates time-based one-time passwords. We recommend [Google Authenticator](https://support.google.com/accounts/answer/1066447?hl=en) or [Authy](https://www.authy.com/app/mobile). Download the app on your mobile device. When you log into cloud.gov for the first time, follow the instructions to store the `cloud.gov` key in your application.
+{{% /govcloud %}}
 
-#### *East/West environment*
+{{% eastwest %}}
 
 In the East/West environment, your cloud.gov account has a username and password. You can [reset your own password](https://login.cloud.gov/forgot_password).
+{{% /eastwest %}}
 
 ### Deployer accounts
 

--- a/content/docs/getting-started/setup.md
+++ b/content/docs/getting-started/setup.md
@@ -6,49 +6,63 @@ title: Setup
 weight: -50
 ---
 
-## Setting up the command line
-As a user, nearly all of your interactions with Cloud Foundry will be through the command line. To get it set up:
+You can work with cloud.gov in two ways: the command line (CLI) with full features, and the web user interface (dashboard) with quick access to common tasks.
 
-1. [Get an account]({{< relref "accounts.md" >}}).
-1. [Install the CLI](https://docs.cloudfoundry.org/devguide/installcf/install-go-cli.html).
+You need [an account]({{< relref "accounts.md" >}}) before you can get started with this.
+
+## Set up the command line
+
+1. [Install the Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/installcf/install-go-cli.html). (cloud.gov is based on Cloud Foundry.)
 1. Confirm the installation by running
 
     ```bash
     cf -v
     ```
+    
+    This should return a version number.
 
-1. **If you log in using your agency's account system**, log in by running
+1. Log in with a command as explained below:
 
-    ```bash
-    cf login -a api.cloud.gov --sso
-    ```
+{{% eastwest %}}
+**If you log in using your agency's account system:** run `cf login -a api.cloud.gov --sso` -- then follow the link to get your one-time authentication code and enter it to log in.
+    
+**If you log in with a cloud.gov account that has its own password** (including `ORGNAME_deployer` accounts): run `cf login -a api.cloud.gov`
+{{% /eastwest %}}
 
-    *(If you know you should log into [GovCloud]({{< relref "docs/apps/govcloud.md" >}}), use `api.fr.cloud.gov`.)*
+{{% govcloud %}}
+**All accounts:** run `cf login -a api.fr.cloud.gov --sso` -- then follow the link to get your one-time authentication code and enter it to log in.
+{{% /govcloud %}}
 
-    Then follow the link to get your one-time authentication code and enter it to log in.
 
-    **Or if you log in with a cloud.gov account that has its own password** (including `ORGNAME_deployer` accounts), log in by running
+## Check out the dashboard
 
-    ```bash
-    cf login -a api.cloud.gov
-    ```
+Visit your dashboard! It's probably a little empty since you probably haven't deployed any applications yet, but it's good to know it exists:
 
-## Play around in a "sandbox"
+{{% eastwest %}}
+[`https://dashboard.cloud.gov/`](https://dashboard.cloud.gov/)
+{{% /eastwest %}}
 
-If you want to practice deploying, run the following `cf target` command before continuing:
+{{% govcloud %}}
+[`https://dashboard.fr.cloud.gov/`](https://dashboard.fr.cloud.gov/)
+{{% /govcloud %}}
+
+## Play around in your "sandbox"
+
+Here's how to deploy a test app in your sandbox for practice. (Note that **if you log in immediately after your account or organization was created,** you may not see any orgs or spaces to which you have access. Your sandbox space may take up to **5 minutes** to provision.)
+
+Start with the following `cf target` command:
 
 ```bash
 cf target -o <ORG> -s <SPACE>
 ```
 
-Your `ORG` is a Cloud Foundry _organization_ named "sandbox-&lt;agencypart&gt;", where &lt;agencypart&gt; is whatever comes right before `.gov` or `.mil` in your
-e-mail address. For example, `sandbox-gsa` or `sandbox-epa`. Your `SPACE` is probably the part of your email before the `@`, e.g. `firstname.lastname`. Cloud Foundry _spaces_ let applications run independently within an organization.  
+Your `<ORG>` is a Cloud Foundry _organization_ named "sandbox-&lt;agencypart&gt;", where &lt;agencypart&gt; is whatever comes right before `.gov` or `.mil` in your
+e-mail address. For example, this may be `sandbox-gsa` or `sandbox-epa`. In most cases, your `<SPACE>` is the part of your email before the `@`, e.g. `firstname.lastname`. Cloud Foundry _spaces_ let applications run independently within an organization.  
 
 For example:
 
 ```bash
 cf target -o sandbox-gsa -s harry.truman
 ```
-**If you log in immediately after your account or organization was created,** you may not see any orgs or spaces to which you have access. Your sandbox space may take up to **5 minutes** to provision.
 
-**Be tidy**: When you're done, please `cf delete <APPNAME>`. See the walkthrough for [your first deploy]({{< relref "your-first-deploy.md" >}}).
+Run your version of that command, and then follow [your first deploy]({{< relref "your-first-deploy.md" >}}).

--- a/content/docs/getting-started/your-first-deploy.md
+++ b/content/docs/getting-started/your-first-deploy.md
@@ -19,4 +19,6 @@ To get used to Cloud Foundry, we recommend that you practice by deploying a simp
 
 The changes will be reflected in Cloud Foundry even without being committed to Git. Cloud Foundry is not Git-aware – it simply deploys whatever is contained in the directory that you `push` from. That being said, you _can_ set up [continuous deployment]({{< relref "docs/apps/continuous-deployment.md" >}}) from a Git repository.
 
+**Be tidy**: When you're done, please `cf delete <APPNAME>`. 
+
 Next, take a look at the [Concepts]({{< relref "concepts.md" >}}) page. Once you're ready to deploy your own application, head over to the [general deployment tips]({{< relref "docs/apps/deployment.md" >}}).


### PR DESCRIPTION
This PR addresses the points @LinuxBozo brought up at https://github.com/18F/cg-site/pull/578#issuecomment-261544722, and it makes further changes to smooth out the intro experience. Overall changes:

**Accounts**
* Remove stray "Here are details about using these accounts."
* Use @afeld's nice [environment-specific formatting](https://github.com/18F/cg-site#environment-specific-information) for GovCloud and E/W info.

**Setup**
* Add basic information about the dashboard.
* Write out clear GovCloud and E/W instructions.
* Clarify next action after targeting a space.
* Move misplaced action to **Your First Deploy**.