### PR TITLE
blockquote styling

### DIFF
--- a/content/docs/apps/govcloud.md
+++ b/content/docs/apps/govcloud.md
@@ -81,7 +81,6 @@ Any labor involved from your project team is the responsibility of your project.
     * Specify that the org should be created in `GovCloud`.
     * An admin will confirm the information, and [create the org]({{< relref "docs/ops/create-org.md#non-sandboxes" >}}) for you.
 1. Install the [CF Targets plugin](https://github.com/guidowb/cf-targets-plugin).
-1. [Set up the spaces.]({{< relref "docs/apps/production-ready.md#space-per-environment" >}})
 1. [Give permissions to the appropriate people.]({{< relref "docs/apps/managing-teammates.md" >}})
 1. Deploy the application to the GovCloud environment.
     * This is a good time to ensure that you are following [deployment best practices]({{< relref "docs/apps/production-ready.md" >}}).

--- a/content/docs/ops/create-org.md
+++ b/content/docs/ops/create-org.md
@@ -1,7 +1,7 @@
 ---
 menu:
   docs:
-    parent: operations
+    parent: tenants
 title: Creating organizations
 ---
 

--- a/content/docs/ops/create-org.md
+++ b/content/docs/ops/create-org.md
@@ -15,7 +15,7 @@ Non-sandbox organizations need to be created by hand. To do so:
 
 1. The [organization request form](https://docs.google.com/a/gsa.gov/forms/d/e/1FAIpQLSd4HmcGfJW3EBnpewTFDD-urRFPp1LN0DcwNB_FxZgUn8ho9g/viewform?c=0&w=1) should be filled out by you or the tenant.
 1. Run the [`cf-create-org`](https://github.com/18F/cg-scripts/blob/master/cf-create-org.sh) script. You will need the following information, some of which is in the [form output](https://docs.google.com/spreadsheets/d/1Bdzl9n2E1MXWV4elXvZ-nYuZmmEj4PEU-u5aZlNGZF4/edit#gid=131031416) (consult the script itself for how to pass in the arguments):
-   * **Agency**: the requesting agency, column B of the form output. 
+   * **Agency**: the requesting agency, column B of the form output.
    * **Note**: currently provided by first-tier support.
    * **Memory**: 4G by default; this should be set to a reasonable initial cap for the systems expected to live in that quota so that clients aren't shocked at their first bill. They can ask for increases as needed.
    * **System name**: the agency's system, column C of the form output.
@@ -24,6 +24,7 @@ NOTE: We don't yet have a standard convention for what to put in the note field.
 1. [Make the primary (technical) point of contact an `OrgManager`.]({{< relref "docs/apps/managing-teammates.md#give-roles-to-a-teammate" >}})
     * They can grant themselves and others additional access using those same instructions.
 1. Notify the `OrgManager` that the organization is created. Here's a template:
+
     > Your organization has been created in the [East/West or GovCloud] environment. After signing in (https://cloud.gov/docs/getting-started/setup/), you can target it with
     >
     >     $ cf target -o [org name]

--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -1,3 +1,4 @@
+blockquote,
 .env-block {
   margin-bottom: 24px; /* $grid-3 */
   margin-left: 16px; /* $grid-3 */
@@ -5,6 +6,7 @@
   position: relative;
 }
 
+blockquote::before,
 .env-block::before {
   border-radius: 3px;
   border-style: solid;
@@ -54,4 +56,8 @@
 
 .env-govcloud::before {
   border-color: #333; /* $color-textblack */
+}
+
+blockquote::before {
+  border-color: #8e8e8e; /* $color-mediumgray */
 }

--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -17,6 +17,16 @@ blockquote::before,
   position: absolute;
 }
 
+blockquote p,
+blockquote li,
+/* specificity for override */
+.content-text blockquote li {
+  font-family: '18Franklin-webfont', system, -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif; /* $font-sans */
+  font-size: 1rem; /* $sans-s5 */
+  font-weight: 400;
+  line-height: 1.6;
+}
+
 .env-specifier {
   color: #333; /* $color-textblack */
   font-family: '18Franklin-webfont', system, -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif; /* $font-sans */
@@ -59,5 +69,5 @@ blockquote::before,
 }
 
 blockquote::before {
-  border-color: #8e8e8e; /* $color-mediumgray */
+  border-color: #d3d3d3; /* $color-mediumgray */
 }


### PR DESCRIPTION
Leveraged the environment specifier styling to give a vertical bar next to `<blockquote>`s.

![screen shot 2016-11-21 at 4 29 50 pm](https://cloud.githubusercontent.com/assets/86842/20501520/362660d4-b008-11e6-820b-ebc0c5be64da.png)

Once again, I have zero attachment to the color. Also made a couple of rendering tweaks to the org creation steps.

/cc @thisisdano @msecret @brittag 