### PR TITLE
Update Rules of Behavior for cloud.gov accounts

### DIFF
--- a/content/docs/getting-started/accounts.md
+++ b/content/docs/getting-started/accounts.md
@@ -60,16 +60,20 @@ Acceptable uses of cloud.gov include:
 In order to help us keep cloud.gov secure, we require that you use your account appropriately. When you use cloud.gov, you agree that you'll respect these rules of behavior:
 
 - Conduct only authorized business on the system.
-- Maintain the confidentiality of your authentication credentials; a cloud.gov operator should never ask you to reveal them. We recommend the user of a password manager and strong credentials whenever possible.
-- Log out when session access is no longer needed. Never leave your computer unattended while logged into cloud.gov.
+- Maintain the confidentiality of your authentication credentials; a cloud.gov operator should never ask you to reveal them. We recommend using a password manager and strong credentials.
+- Log out when you no longer need session access. Never leave your computer unattended while logged into cloud.gov.
 - Report all security incidents or suspected incidents (such as improper or suspicious acts) related to cloud.gov systems and networks to [cloud.gov support](/help/).
 - Safeguard system resources against waste, loss, abuse, unauthorized use or disclosure, and misappropriation.
 - Don't process U.S. classified national security information on the system.
-- Don't browse, search or reveal information hosted by cloud.gov except in accordance with that which is required to perform your legitimate tasks or assigned duties.
+- Don't browse, search or reveal information hosted by cloud.gov except as required to perform your legitimate tasks or assigned duties.
 - Don't retrieve information, or in any other way disclose information, for someone who does not have authority to access that information.
 - Don't intentionally use a client that makes use of obsolete or insecure encryption algorithms.
 - Don't configure your browser to ignore security warnings which may involve your connection with cloud.gov; report warnings that you can't explain to [cloud.gov support](/help/).
-- If you believe you're being granted access that is more than necessary to perform your legitimate tasks or assigned duties, immediately notify [cloud.gov support](/help/).
+- If you believe you've been granted more access than necessary to perform your legitimate tasks or assigned duties, immediately notify [cloud.gov support](/help/).
+
+If you use a cloud.gov account (instead of using an agency single-sign-on account), you have an additional rule of behavior:
+
+- Don't share your account with another person or create anonymous or group accounts. Your account is just for you.
 
 Access to systems and networks owned by cloud.gov is governed by, and subject to, all federal laws, including, but not limited to, the Privacy Act, 5 U.S.C. 552a, if the applicable cloud.gov system maintains individual Privacy Act information. Access to cloud.gov systems constitutes consent to the retrieval and disclosure of the information within the scope of your authorized access, subject to the Privacy Act, and applicable state and federal laws.
 


### PR DESCRIPTION
To help us meet the requirements of AC-2 (9), this PR adds a rule for holders of cloud.gov-provided accounts - don't share your account.

I also included some copyedits for the other rules, for clarity and directness.