### PR TITLE
Moving Ongoing Platform Maintenance page to right spot

### DIFF
--- a/content/docs/ops/maintenance-list.md
+++ b/content/docs/ops/maintenance-list.md
@@ -1,6 +1,6 @@
 ---
 menu:
-  main:
+  docs:
     parent: operations
 title: Ongoing Platform Maintenance
 ---


### PR DESCRIPTION
Followup to the PR at https://github.com/18F/cg-site/pull/457 - I went to look at this page to check that it got deployed, and it wasn't showing up in the ops docs sidebar - I realized it ended up in the wrong directory. Here's a fix.

cc @jbarnicle @rogeruiz 