### PR TITLE
Make one-off tasks easier for all users

### DIFF
--- a/content/docs/getting-started/one-off-tasks.md
+++ b/content/docs/getting-started/one-off-tasks.md
@@ -26,7 +26,9 @@ The most reliable way to do one-off tasks is by deploying a short-lived app. If 
 
 ### How to deploy
 
-The idea here is that we are going to deploy a new application, but running the one-off task, rather than starting a server or whatever it would normally do. Note that this will not work for any command that is interactive.
+The idea here is that we are going to deploy a new application, but running the
+one-off task, rather than starting a server or whatever it would normally do.
+Note that this will not work for any command that is interactive.
 
 1. Make a copy of your application manifest:
 
@@ -43,7 +45,6 @@ The idea here is that we are going to deploy a new application, but running the 
         * `hosts`
         * `instances`
         * `random-route`
-    * Add [`no-route: true`](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#no-route).
     * Set the [`command`](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#start-commands) attribute to be the following:
 
         ```yaml
@@ -52,12 +53,22 @@ The idea here is that we are going to deploy a new application, but running the 
 
 1. Deploy the one-off app, and view the output:
 
+   When deploying the one-off tasks, it's important to disable health-checks and
+   routes in order to prevent deployment issues during the buildpack phase and
+   having multiple applications with the same mapped route respectively. For
+   more information on these options, see the [`--no-route`][cf-no-route] and
+   [`--health-check-type`][cf-health-check] documentation. In order to keep
+   changes to your copied manifest at a minimum, you can provide these
+   configuration options directly on the command-line.
+
     ```bash
-    cf push -f task_manifest.yml -u none
+    cf push -f task_manifest.yml --health-check-type none --no-route
     cf logs --recent task-runner
     ```
-
 1. If needed, use [`cf files`][] to collect any artifacts.
 1. Run `cf delete task-runner` to clean it up.
 
 [`cf files`]: http://cli.cloudfoundry.org/en-US/cf/files.html
+
+[cf-no-route]: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#no-route "CloudFoundry Documentation about --no-route"
+[cf-health-check]: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#health-check-type "CloudFoundry Documentation about --health-check-type"


### PR DESCRIPTION
With a single command, power-users can learn from this documentation to
leverage the command-line more, while new-users can keep changes to
their manifests to a minimum and learn to use the command-line. Curious
users can read the CF documentation to learn even more about the `yaml`
stanzas if they're feeling particularly thirsty. :sweat_drops: