### PR TITLE
Clarify PagerDuty explanation in contingency plan

### DIFF
--- a/content/docs/ops/contingency-plan.md
+++ b/content/docs/ops/contingency-plan.md
@@ -93,7 +93,7 @@ Cloud Operations will:
 After these steps are complete, updates will be deployed per usual policy using GitLab in place of GitHub.
 
 ### PagerDuty
-If there is a disruption in PagerDuty service, Cloud Operations will configure all alerts to be delivered via email to [cloud-gov-support@gsa.gov](mailto:cloud-gov-support@gsa.gov).
+If there is a disruption in PagerDuty service, all alerts automatically get delivered to the Cloud Operations team via GSA email.
 
 ### New Relic
 There is no direct impact to the platform if a disruption occurs.  When debugging any issues where New Relic would provide insight, the team will use manual investigation to access the same information directly from the affected system(s).


### PR DESCRIPTION
This should be present tense (since the system is already configured to do this), and we don't need to specify the specific email address.