### PR TITLE
Removing Compliance Toolkit description

### DIFF
--- a/content/overview/overview/what-is-cloudgov.md
+++ b/content/overview/overview/what-is-cloudgov.md
@@ -25,8 +25,3 @@ cloud.gov runs on top of industry-provided infrastructure ([currently Amazon Web
 
 All the software components of the cloud.gov Platform as a Service are [open source]({{< relref "docs/ops/repos.md" >}}).
 
-## cloud.gov provides a compliance toolkit
-
-cloud.gov provides tools for customers to create the security documentation and continuing assurance necessary for federal services to comply with FISMA regulations and agency-specific “Authority to Operate” (ATO) requirements.
-
-We call these tools the Compliance Toolkit, including [Compliance Masonry](https://github.com/opencontrol/compliance-masonry). We created them to support cloud.gov's ATO and the ATOs of customer applications, and they're all open source. Other teams, including agencies and industry teams, can also use these tools for unrelated projects that have similar needs.


### PR DESCRIPTION
Edit intended to shift focus of this page to only the services that we are actively offering to customers. 

 When discussing the toolkit, it would be more accurate to describe this as separate from our main offering, and something that the open control community maintains (rather than something that we maintain ourselves).