### PR TITLE
Adding focus to search text box

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -55,7 +55,7 @@
               <a href="/docs/help/">Contact</a>
             </li>
             <li class="js-search-button-container">
-                  <a class="js-search-button">
+                  <a class="js-search-button" id="js-search-focus">
                     <span>Search</span>
                   </a>
             </li>

--- a/static/assets/js/index.js
+++ b/static/assets/js/index.js
@@ -1,5 +1,14 @@
 (function (document, window, $) {
   $(document).ready(function(){
+    /* Setting search focus */
+    $('#js-search-focus').click(function(){
+        $('#search-field').focus();
+    });
+    $('#search-field').keyup(function(e) {
+      if (e.keyCode == 27) {
+      $("#js-search-focus").focus();
+  }
+});
     ajaxifyContactForm();
   });
 


### PR DESCRIPTION
When the search button was clicked the focus would not jump to the
search text box. This has been updated as well as pressing the escape
key to change the focus to the search close button.