### PR TITLE
Use RFC 5737 addresses in documentation

### DIFF
--- a/content/docs/apps/managed-services.md
+++ b/content/docs/apps/managed-services.md
@@ -89,12 +89,12 @@ Use `cf env APPLICATION` to display the application environment variables, inclu
   "elasticsearch-swarm-1.7.1": [
     {
       "credentials": {
-        "host": "10.10.3.129",
-        "hostname": "10.10.3.129",
+        "host": "192.0.2.129",
+        "hostname": "192.0.2.129",
         "name": "elasticsearch-UUID-A",
         "password": "UUID-B",
         "port": 45001,
-        "url": "http://UUID-C:UUID-B@10.10.3.129:45001",
+        "url": "http://UUID-C:UUID-B@192.0.2.129:45001",
         "username": "UUID-C"
       },
       "label": "elasticsearch-swarm-1.7.1",

--- a/content/docs/ops/creating-a-development-environment-with-bosh-lite.md
+++ b/content/docs/ops/creating-a-development-environment-with-bosh-lite.md
@@ -194,18 +194,18 @@ When complete, use bosh vms to have a look at the resulting environment.
 	+------------------------------------+---------+---------------+--------------+
 	| Job/index                          | State   | Resource Pool | IPs          |
 	+------------------------------------+---------+---------------+--------------+
-	| api_z1/0                           | running | large_z1      | 10.244.0.138 |
-	| etcd_z1/0                          | running | medium_z1     | 10.244.0.42  |
-	| ha_proxy_z1/0                      | running | router_z1     | 10.244.0.34  |
-	| hm9000_z1/0                        | running | medium_z1     | 10.244.0.142 |
-	| loggregator_trafficcontroller_z1/0 | running | small_z1      | 10.244.0.150 |
-	| loggregator_z1/0                   | running | medium_z1     | 10.244.0.146 |
-	| login_z1/0                         | running | medium_z1     | 10.244.0.134 |
-	| nats_z1/0                          | running | medium_z1     | 10.244.0.6   |
-	| postgres_z1/0                      | running | medium_z1     | 10.244.0.30  |
-	| router_z1/0                        | running | router_z1     | 10.244.0.22  |
-	| runner_z1/0                        | running | runner_z1     | 10.244.0.26  |
-	| uaa_z1/0                           | running | medium_z1     | 10.244.0.130 |
+	| api_z1/0                           | running | large_z1      | 192.0.2.138 |
+	| etcd_z1/0                          | running | medium_z1     | 192.0.2.42  |
+	| ha_proxy_z1/0                      | running | router_z1     | 192.0.2.34  |
+	| hm9000_z1/0                        | running | medium_z1     | 192.0.2.142 |
+	| loggregator_trafficcontroller_z1/0 | running | small_z1      | 192.0.2.150 |
+	| loggregator_z1/0                   | running | medium_z1     | 192.0.2.146 |
+	| login_z1/0                         | running | medium_z1     | 192.0.2.134 |
+	| nats_z1/0                          | running | medium_z1     | 192.0.2.6   |
+	| postgres_z1/0                      | running | medium_z1     | 192.0.2.30  |
+	| router_z1/0                        | running | router_z1     | 192.0.2.22  |
+	| runner_z1/0                        | running | runner_z1     | 192.0.2.26  |
+	| uaa_z1/0                           | running | medium_z1     | 192.0.2.130 |
 	+------------------------------------+---------+---------------+--------------+
 
 	VMs total: 12

--- a/content/docs/ops/creating-a-local-dev-environment-in-Virtual-Box.md
+++ b/content/docs/ops/creating-a-local-dev-environment-in-Virtual-Box.md
@@ -59,5 +59,4 @@ Verify deployment
 
 	vagrant destroy
 	vagrant up
-	bosh target 192.168.50.4 lite
 	bosh deploy

--- a/content/docs/ops/deploying-the-docker-broker.md
+++ b/content/docs/ops/deploying-the-docker-broker.md
@@ -255,7 +255,7 @@ System-Provided:
   "es": [
    {
     "credentials": {
-     "hostname": "10.10.10.100",
+     "hostname": "192.0.2.100",
      "password": "639ec1d00ecdb218321964008646c561",
      "port": "32781",
      "ports": {


### PR DESCRIPTION
In order to avoid Private IP disclosure false positives when scanning this site we should use TEST-NET addresses in our docs where appropriate.

cc: @brittag 