### PR TITLE
Add documentation for ElasticSearch 2.4 in GovCloud

### DIFF
--- a/content/docs/apps/experimental/experimental-services.md
+++ b/content/docs/apps/experimental/experimental-services.md
@@ -30,7 +30,7 @@ cf create-service redis28-swarm standard myredis
 
 {{% govcloud %}}
 ```sh
-cf create-service elasticsearch23 1x mysearch
+cf create-service elasticsearch24 1x mysearch
 ```
 
 or

--- a/content/docs/apps/govcloud.md
+++ b/content/docs/apps/govcloud.md
@@ -38,7 +38,7 @@ GovCloud-specific information
 
 - To run [one-off tasks]({{< relref "docs/getting-started/one-off-tasks.md" >}}), [`cf-ssh`]({{< relref "docs/apps/using-ssh.md#east-west-environment-cf-ssh" >}}) is not available in GovCloud. Instead, you can use [`cf ssh`]({{< relref "docs/apps/using-ssh.md#govcloud-environment-cf-ssh" >}}) (note the space instead of the `-`), which is more flexible than `cf-ssh`.
 - To set up custom domains, you can use the [managed service method]({{< relref "docs/apps/custom-domains.md#managed-service-method" >}}).
-- Elasticsearch 2.3 is available.
+- Elasticsearch 2.4 is available.
     - If you're using 1.7, it's recommended that you upgrade, since 1.7 hits [end of life](https://www.elastic.co/support/eol) on January 6, 2017. [Read about the breaking changes.](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/breaking-changes-2.0.html)
 
 #### Experimental new features

--- a/content/docs/services/elasticsearch17.md
+++ b/content/docs/services/elasticsearch17.md
@@ -30,7 +30,7 @@ cf create-service elasticsearch17 1x my-elastic-service
 
 ### Deprecation of Elasticsearch 1.7
 
-Elasticsearch 1.x is deprecated, we recommend that you use [Elasticsearch 2.3]({{< relref "docs/services/elasticsearch23.md" >}}). Also, please see the [Elastic guide for moving from 1.x to 2.x](https://www.elastic.co/blog/key-point-to-be-aware-of-when-upgrading-from-elasticsearch-1-to-2).
+Elasticsearch 1.x is deprecated, we recommend that you use [Elasticsearch 2.4]({{< relref "docs/services/elasticsearch24.md" >}}). Also, please see the [Elastic guide for moving from 1.x to 2.x](https://www.elastic.co/blog/key-point-to-be-aware-of-when-upgrading-from-elasticsearch-1-to-2).
 
 ### The broker in GitHub
 

--- a/content/docs/services/elasticsearch24.md
+++ b/content/docs/services/elasticsearch24.md
@@ -2,13 +2,13 @@
 menu:
   docs:
     parent: services
-title: Elasticsearch 2.3
-name: "elasticsearch23"
-description: "[ElasticSearch](https://www.elastic.co/) 2.3"
+title: Elasticsearch 2.4
+name: "elasticsearch24"
+description: "[ElasticSearch](https://www.elastic.co/) 2.4"
 status: "Alpha"
 ---
 
-cloud.gov offers [Elasticsearch](https://www.elastic.co/) 2.3 as a service. **This service is still in Alpha mode**: downtime and data loss is possible.
+cloud.gov offers [Elasticsearch](https://www.elastic.co/) 2.4 as a service. **This service is still in Alpha mode**: downtime and data loss is possible.
 
 ## Plans
 
@@ -23,15 +23,15 @@ Plan Name | Description | Price
 To create a service instance run the following command:
 
 ```bash
-cf create-service elasticsearch23 1x my-elastic-service
+cf create-service elasticsearch24 1x my-elastic-service
 ```
-
-## More Information
-
-### Deprecation of Elasticsearch 2.3
-
-We recommend that you use [Elasticsearch 2.4]({{< relref "docs/services/elasticsearch24.md" >}}) instead of ElasticSearch 2.3.
 
 ### The broker in GitHub
 
 You can find the broker here: [https://github.com/18F/kubernetes-broker](https://github.com/18F/kubernetes-broker).
+
+### Additional Notes
+
+ElasticSearch 2.4 allows for dots in field names. This is a feature that existed
+pre-ElasticSearch 2.0 but was disabled in versions 2.0 to 2.3. Learn more about
+that [here](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/dots-in-names.html).

--- a/data/services/elasticsearch24.toml
+++ b/data/services/elasticsearch24.toml
@@ -1,0 +1,3 @@
+name = "elasticsearch24"
+description = "[Elasticsearch](https://www.elastic.co/) 2.4"
+status = "Alpha"


### PR DESCRIPTION
ES 2.4.1 is enabled via
https://github.com/18F/kubernetes-broker/pull/32
and
https://github.com/18F/cg-deploy-kubernetes/pull/55
This patch adds the documentation for it.

Related to https://github.com/18F/cg-migration/issues/27