### PR TITLE
improving the "what it is" homepage section

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -81,9 +81,12 @@
             <use xlink:href="assets/img/cloudgov-sprite.svg#i-shipping"/>
           </svg>
         </i>
-        <h3>Platform-as-a-service</h3>
+        <h3>Platform as a Service</h3>
         <p>
-          We remove the complexity of the cloud infrastructure and give you a usable interface that you can use to deploy secure apps quickly. This is Platform as a Service, or PaaS.
+          cloud.gov removes the complexity of the cloud infrastructure and give you a usable
+          interface that you can use to build, launch, and host apps securely and quickly. Less
+          time managing the development environment, more time building great products. This is
+          Platform as a Service.
         </p>
       </div>
       <div class="three_up-part">
@@ -93,9 +96,12 @@
             <use xlink:href="assets/img/cloudgov-sprite.svg#i-paperwork"/>
           </svg>
         </i>
-        <h3>Security documentation support</h3>
+        <h3>Compliance as a Service</h3>
         <p>
-          As a byproduct of building the platform, we have open source, software-friendly documentation of cloud.gov’s NIST controls, ready to incorporate into your own FISMA and ATO documentation, however you need it.
+          cloud.gov’s NIST controls are documented in an open source, software-friendly way, ready
+          to incorporate into your own FISMA and ATO documentation, however you need it, any time
+          you need it. No need to document the entire platform from scratch. Just document what
+          you build on top of it. This is Compliance as a Service.
         </p>
       </div>
       <div class="three_up-part">
@@ -105,9 +111,13 @@
             <use xlink:href="assets/img/cloudgov-sprite.svg#i-compass"/>
           </svg>
         </i>
-        <h3>More to come</h3>
+        <h3>Government as a Service</h3>
         <p>
-          Where cloud.gov goes from here will depend on how teams use it today. Already, we are exploring additional products: domain microservices, access to third-party tools, and technologies that may be needed for “government-as-a-service.”
+          Where cloud.gov goes from here will depend on how your team uses it today. Already, we
+          are exploring additional products like domain microservices and access to third-party
+          tools. And because every team can benefit from improvements driven by other teams,
+          cloud.gov is an always-improving economy of scale for government teams. This is Government 
+          as a Service.
         </p>
       </div>
     </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -47,12 +47,16 @@
 <section class="usa-content section section-cream">
   <div class="usa-grid">
     <div class="section-content usa-content">
-      <h1>We’re a government team, and we designed cloud.gov to handle real challenges.</h1>
+      <h1>cloud.gov was designed by a government team to handle real challenges.</h1>
       <p>
-        cloud.gov is built by 18F in GSA’s Technology Transformation Service (TTS), where our mission is to help agencies build, buy, and share technology that helps them better serve the public. We found that the more apps we built, the more cloud operations and ATOs slowed down deployments.
+        cloud.gov is built and maintained by 18F in GSA’s Technology Transformation Service (TTS), where our
+        mission is to help agencies build, buy, and share technology that helps them better serve
+        the public. The more apps 18F built, the more cloud operations and ATOs slowed down deployments.
       </p>
       <p>
-        Instead of trying to provide infrastructure support for every product, our cloud ops staff designed a platform that every team could use. Now we’re making it available to other government teams as part of our mission.
+        Instead of trying to provide infrastructure support for every product, our cloud ops staff
+        designed a platform that every team could use. Now we’re making it available to other
+        government teams as part of our mission.
       </p>
     </div>
   </div>
@@ -68,9 +72,12 @@
 <section class="usa-content section-middle section-light">
   <div class="usa-grid">
     <div class="section-content usa-content">
-      <h1>This is why we built cloud.gov.</h1>
+      <h1>cloud.gov serves the government product teams who serve the public.</h1>
       <p>
-        cloud.gov is 18F’s cloud-hosting product line for federal teams. It addresses baseline security and scalability concerns consistently, right up front, without requiring a huge number of cloud operations experts. Instead, digital service teams can use these tools to focus on delivering quality products.
+        cloud.gov is a cloud-hosting service for federal teams. This platform addresses baseline
+        compliance and scalability concerns consistently, right up front, without requiring a huge
+        number of cloud operations experts. With that taken care of, federal digital service teams
+        can focus on delivering quality products.
       </p>
     </div>
     <div class="three_up">
@@ -116,7 +123,7 @@
           Where cloud.gov goes from here will depend on how your team uses it today. Already, we
           are exploring additional products like domain microservices and access to third-party
           tools. And because every team can benefit from improvements driven by other teams,
-          cloud.gov is an always-improving economy of scale for government teams. This is Government 
+          cloud.gov is an always-improving economy of scale for government teams. This is Government
           as a Service.
         </p>
       </div>
@@ -134,10 +141,7 @@
 <section class="usa-content section section-dark section-chevron_alt">
   <div class="usa-grid">
     <div class="section-content usa-content">
-      <h1>cloud.gov makes deployments easier, faster, and stronger.</h1>
-      <p>
-        We don’t think the challenges we faced are unique. All agencies have a mandate to deploy their services in the cloud, and all cloud deployments require operations support, security, and compliance. We give you that.
-      </p>
+      <h1>The strengths of a centralized open source platform belong to your team.</h1>
     </div>
     <div class="four_up">
       <div class="four_up-part">
@@ -148,7 +152,9 @@
         </div>
         <h3>Usability</h3>
         <p>
-          We use an open source API and tools for teams to take care of environments, services, applications, access points, and billing structures. You use our straightforward UI to deliver a great app.
+          cloud.gov’s open source API and tools for teams take care of environments, services,
+          applications, access points, and billing structures. The straightforward UI lets you
+          focus from day one on delivering a great app.
         </p>
       </div>
       <div class="four_up-part">
@@ -157,9 +163,11 @@
             <use xlink:href="assets/img/cloudgov-sprite.svg#i-double_arrow"/>
           </svg>
         </div>
-        <h3>Scalability</h3>
+        <h3>Economy of scale</h3>
         <p>
-          The cloud.gov support team provides spot support for teams when they encounter issues. We use what we learn from this work to improve cloud.gov, addressing these issues for every team at once.
+          When any team encounters issues or needs additional capabilities that require support,
+          every team gets access to any solutions we deploy. And the open source, publicly documented
+          deployment creates an economy of scale that benefits every app, including yours.
         </p>
       </div>
       <div class="four_up-part">
@@ -170,7 +178,9 @@
         </div>
         <h3>Security</h3>
         <p>
-          We deploy on a hardened operating system. We centrally scan and audit the platform and every application on it. And the open source, publicly documented deployment creates an economy of scale that benefits every app, no matter who owns it.
+          cloud.gov is deployed on a hardened operating system. The platform and every application
+          on it are centrally scanned and audited. Because the platform and its controls are consistent,
+          every security improvement to cloud.gov in turn is a security improvement for your products.
         </p>
       </div>
       <div class="four_up-part">
@@ -181,7 +191,10 @@
         </div>
         <h3>Conformity with federal rules</h3>
         <p>
-          Every NIST control for our platform, infrastructure, and human layers is documented and ready to use in many different contexts, updated automatically as we update the platform. Use our work to shave dozens of hours off the usual app-by-app, copy-and-paste compliance process.
+          Every NIST control for the platform, infrastructure, and human layers of cloud.gov is
+          documented and ready to use in many different contexts. The documentation is updated
+          automatically with every update to the platform, and it’s yours to use to shave dozens
+          of hours off the usual app-by-app, copy-and-paste compliance process.
         </p>
       </div>
     </div>

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -1,7 +1,9 @@
 <section>
   <a name="contact"></a>
   <h1>Contact us</h1>
-  <p class="section-subhed">Sign up for updates about the availability of cloud.gov from 18F</p>
+  <p>Interested in using cloud.gov? Email <a href="mailto: cloud-gov-inquiries@gsa.gov">cloud-gov-inquiries@gsa.gov</a>.</p>
+    <h2>Get updates</h2>
+  <p class="section-subhed">Sign up for updates about cloud.gov, including information about new services, features, or requirements.</p>
     <form action="//gsa.us9.list-manage.com/subscribe/post?u=6f1977de9eff4c384dc8d6527&amp;id=ab90bdad59" method="post" id="contact" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
       <fieldset>
         <div class="text_block">
@@ -35,7 +37,7 @@
           </div>
         </div>
         <div style="margin-top: 1.5rem;">
-            <p>Your privacy and security are important to us; we'll only share your information as described in the <a href="http://www.gsa.gov/portal/content/116609">GSA Privacy and Security Notice</a>.</p>
+            <p>Your privacy and security are important to us; we’ll only share your information as described in the <a href="http://www.gsa.gov/portal/content/116609">GSA Privacy and Security Notice</a>.</p>
         </div>
       </fieldset>
     </form>


### PR DESCRIPTION
## Changes
- shifts the “what it is” section from “this is why we built it” framing to “this product serves you” framing.
- added a section to "Contact us" on sending us email and updated the signup form intro text to differentiate the two.
- refocused the section on why the product works, including shifting "Scalability" to "Economy of scale" to more narrowly describe what it was about. _(added this one after merge, forgot to add before)_


## Notes
- for the moment, still short on the “why the product works” section, but doesn’t seem any reason not to fold in the “what the product is” section.
- calling this WIP, happy to keep working on this branch, but can fold in at any time and just build on it.