### PR TITLE
Add note about escaping Travis passwords to Continous Deployment

### DIFF
--- a/content/docs/apps/continuous-deployment.md
+++ b/content/docs/apps/continuous-deployment.md
@@ -8,7 +8,7 @@ title: Continuous deployment
 Setting up continuous deployment allows you to automatically upload your
 changes to your desired environment.
 
-Make sure that you've previously looked at the [Production Ready Guide]({{< relref "production-ready.md" >}}) and followed best practices.
+Before setting this up, go through the [Production Ready Guide]({{< relref "production-ready.md" >}}) and make sure you're following those core best practices.
 
 ## Provisioning deployment credentials
 
@@ -60,11 +60,11 @@ Ask [cloud.gov support]({{< relref "docs/help.md" >}}) to set up a "deployer" us
 
 ## Continuous integration services
 
-Depending on your CI system the setup is going to be a bit different. **For all cases you will need a `manifest.yml` file.**
+To set up any of these services, your application needs a `manifest.yml` file.
 
 ### Travis
 
-See [the Travis documentation](http://docs.travis-ci.com/user/deployment/cloudfoundry/), using `api: https://api.cloud.gov` and encrypting the password.
+See [the Travis documentation](http://docs.travis-ci.com/user/deployment/cloudfoundry/), using `api: https://api.cloud.gov` for East/West and `api: https://api.fr.cloud.gov` for GovCloud. You must encrypt the password, and you must [**escape any symbol characters in the password**](https://docs.travis-ci.com/user/encryption-keys#Note-on-escaping-certain-symbols), to prevent possible situations where Travis could dump an error message that contains passwords or environment variables.
 
 #### Using Conditional Deployments
 


### PR DESCRIPTION
Changes:

* Add a note to the Travis setup info to help prevent the issue identified at https://github.com/18F/cg-product/issues/517 - we may need to do additional work to more systemically help prevent this, but doing the easy thing first. Thanks @konklone and @jseppi for pointing that out, and I'm sorry we didn't have a proper note about that before; please feel free to comment if this is phrased wrong or in the wrong place.
* Minor copyedits to make the page speak more directly to the reader.