### PR TITLE
Update explanations of buildpack support + clarify other minor things

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -42,12 +42,12 @@ publishdir = "public"
     weight = -100
 
 [[menu.docs]]
-    name = "Getting Started"
+    name = "Getting started"
     identifier = "getting-started"
     pre = "<i class='fa fa-road fa-fw'></i>"
     weight = -120
 [[menu.docs]]
-    name = "Deploying Apps"
+    name = "Deploying apps"
     identifier = "apps"
     pre = "<i class='fa fa-file-text fa-fw'></i>"
     weight = -110
@@ -57,12 +57,12 @@ publishdir = "public"
     pre = "<i class='fa fa-fw fa-database'></i>"
     weight = -100
 [[menu.docs]]
-    name = "Advanced"
+    name = "Managing apps"
     identifier = "advanced"
     pre = "<i class='fa fa-rocket fa-fw'></i>"
     weight = -100
 [[menu.docs]]
-    name = "Experimental Features"
+    name = "Experimental features"
     identifier = "experimental"
     pre = "<i class='fa fa-flask fa-fw'></i>"
     weight = -90

--- a/content/docs/apps/deployment.md
+++ b/content/docs/apps/deployment.md
@@ -28,7 +28,7 @@ The command to create a new app and to push a new version of an existing one are
     cf push <APPNAME>
     ```
 
-The app should now be live at `APPNAME.18f.gov`.
+The app should now be live at `APPNAME.app.cloud.gov`.
 
 ## Caveats
 
@@ -58,15 +58,3 @@ A couple of important points on the `.cfignore`:
 
 1. if you have a more advanced app setup and have apps with a `path` other than the project root (where you run `cf push` from), you will need an additional `.cfignore` file located in each app `path`;
 2. also note that more advanced `.gitignore` syntax, such as the `**` recursive subdirectory wildcard, are _not_ supported by `.cfignore`.
-
-## Deployment notifications
-
-If you would like to be notified about deployments in your Slack channel, follow [these instructions](https://github.com/18F/hubot-cf-notifications#adding-applications), and add the [configuration](https://github.com/18F/hubot-cf-notifications#configuration) to [Charlie](https://github.com/18F/18f-bot/blob/master/cf_config.json).
-
-## Cloud.Gov related guides:
-
-* Connecting to a [service]({{< relref "docs/apps/managed-services.md" >}})
-* Rollback
-    * Just `checkout` the old version and `cf-push`
-* [Running one-off commands]({{< relref "docs/getting-started/one-off-tasks.md" >}})
-* Deleting an application (`cf delete`)

--- a/content/docs/apps/experimental/custom-buildpacks.md
+++ b/content/docs/apps/experimental/custom-buildpacks.md
@@ -10,7 +10,7 @@ aliases:
 title: Custom buildpacks
 ---
 
-[**This is an experimental feature.**]({{< relref "docs/apps/experimental/experimental.md" >}})
+[**This is an experimental feature.**]({{< relref "docs/apps/experimental/experimental.md" >}}) In this case, this means: we offer long-term support for the *ability* to have custom buildpacks, but you are responsible for maintaining your custom buildpack.
 
 Cloud Foundry (the underlying open source project behind cloud.gov) uses [buildpacks]({{< relref "docs/getting-started/concepts.md">}}#buildpacks) to allow your applications to be deployed.
 

--- a/content/docs/apps/experimental/experimental-services.md
+++ b/content/docs/apps/experimental/experimental-services.md
@@ -10,7 +10,7 @@ slug: services
 
 Some services in the cloud.gov platform are experimental but can provide value to your applications.
 
-To enable any of these services, email cloud-gov-support@gsa.gov. Use them at your own risk.
+To enable any of these services, [ask support]({{< relref "docs/help.md" >}}). Use them at your own risk.
 
 ### Elasticsearch and Redis
 

--- a/content/docs/apps/experimental/experimental.md
+++ b/content/docs/apps/experimental/experimental.md
@@ -2,11 +2,11 @@
 menu:
   docs:
     parent: experimental
-title: What is an experimental feature?
+title: About experimental features
 weight: -1
 slug: features
 ---
-We've designed cloud.gov to provide you with the easiest path to compliance and the best possible platform for most government applications. We [provide a set of building blocks](/intro/pricing/whats-included/) that are fully supported by the cloud.gov team.
+We've designed cloud.gov to provide you with the easiest path to compliance and the best possible platform for most government applications. We [provide a set of building blocks]({{< relref "overview/pricing/whats-included.md" >}}) that are fully supported by the cloud.gov team.
 
 Based on requests from users, we've also developed and released a few experimental features. We haven't thoroughly completed or tested these features.
 

--- a/content/docs/getting-started/concepts.md
+++ b/content/docs/getting-started/concepts.md
@@ -71,9 +71,9 @@ cf target -o ORGNAME -s SPACENAME
 
 ## Buildpacks
 
-All apps need to use a "buildpack" specific to their language, which sets up dependencies for their language stack. There are [standard buildpacks for most languages](https://docs.cloudfoundry.org/buildpacks/), and they will usually be auto-detected and auto-applied by Cloud Foundry when you deploy an app. We strongly encourage you to use the standard buildpacks. cloud.gov supports these standard buildpacks and provides security updates for them.
+All apps need to use a "buildpack" specific to their language, which sets up dependencies for their language stack. There are [standard buildpacks for most languages](https://docs.cloudfoundry.org/buildpacks/), and Cloud Foundry usually auto-detects and auto-applies the appropriate one when you deploy an app (one exception is that it doesn't auto-apply the special [binary buildpack](https://docs.cloudfoundry.org/buildpacks/binary/index.html)). We strongly encourage you to use the standard buildpacks. cloud.gov supports these standard buildpacks and provides security updates for them. (You're responsible for supporting and security-patching the applications you deploy with these standard buildpacks, and you'll also need to redeploy or restage your application to pick up buildpack updates.)
 
-In the rare case where the buildpack does not get auto-detected correctly, or to use a [custom buildpack]({{< relref "docs/apps/experimental/custom-buildpacks.md">}}), you can specify a buildpack in the manifest (as below) or with the `-b` flag. To reference it, use either the buildpack name:
+In the rare case where Cloud Foundry doesn't correctly auto-detect the buildpack, or if you want to use a binary buildpack or [custom buildpack]({{< relref "docs/apps/experimental/custom-buildpacks.md">}}), you can specify a buildpack in the manifest (as below) or with the `-b` flag. To reference it, use either the buildpack name:
 
     buildpack: python_buildpack
 
@@ -87,7 +87,7 @@ Or a URL:
 * To run multiple long-running processes, run them as separate applications.
 * To build static assets on cloud.gov, [build assets on CI]({{< relref "assets.md#build-assets-on-ci" >}}).
 
-**Custom buildpacks:** If your application can't use a standard buildpack, you can use a [custom buildpack]({{< relref "docs/apps/experimental/custom-buildpacks.md">}}), which is an experimental feature. If you use a custom buildpack, ensure you understand [your responsibilities]({{< relref "overview/technology/responsibilities.md">}}), which include keeping your buildpack up-to-date and patching known vulnerabilities.
+**Custom buildpacks:** If your application can't use a standard buildpack, you can use a [custom buildpack]({{< relref "docs/apps/experimental/custom-buildpacks.md">}}), which are unsupported. This means that if you use a custom buildpack, you're responsible for keeping your buildpack up-to-date and patching vulnerabilities in it. See [this chart illustrating your responsibilities]({{< relref "overview/technology/responsibilities.md">}}) for more detail.
 
 ### Buildpack Release Schedule
 


### PR DESCRIPTION
Buildpack info updates:
* Explain what we mean by custom buildpacks being "experimental" (that we plan to retain the ability to do this, but _using_ it is unsupported)
* Mention binary buildpack

cc @NoahKunin on the above, since that supports recent SSP clarifications.

We eventually (maybe soonish) need to clearly mark P-ATO boundaries in our docs (https://github.com/18F/cg-product/issues/551), but we can improve on that later.

Other updates that snuck in:
* Rename "Advanced" docs category to "Managing apps" so that it has a more meaningful name
* Remove some outdated and/or 18F-specific advice from "general tips" page