### PR TITLE
Organize ops docs and update some titles

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -68,7 +68,7 @@ publishdir = "public"
     weight = -90
 
 [[menu.docs]]
-    name = "Contributing"
+    name = "cloud.gov team docs"
     identifier = "ops"
     pre = "<i class='fa fa-fw fa-wrench'></i>"
 [[menu.docs]]
@@ -76,10 +76,14 @@ publishdir = "public"
     identifier = "deployment"
     parent = "ops"
 [[menu.docs]]
-    name = "Tenants"
+    name = "Tenant support"
     identifier = "tenants"
     parent = "ops"
 [[menu.docs]]
     name = "Operations"
     identifier = "operations"
+    parent = "ops"
+[[menu.docs]]
+    name = "Plans and policies"
+    identifier = "policies"
     parent = "ops"

--- a/content/docs/ops/configuration-management.md
+++ b/content/docs/ops/configuration-management.md
@@ -1,7 +1,7 @@
 ---
 menu:
   docs:
-    parent: operations
+    parent: policies
 title: Configuration management
 ---
 

--- a/content/docs/ops/contingency-plan.md
+++ b/content/docs/ops/contingency-plan.md
@@ -1,7 +1,7 @@
 ---
 menu:
   docs:
-    parent: operations
+    parent: policies
 title: Contingency plan
 ---
 

--- a/content/docs/ops/continuous-monitoring.md
+++ b/content/docs/ops/continuous-monitoring.md
@@ -1,7 +1,7 @@
 ---
 menu:
   docs:
-    parent: operations
+    parent: policies
 title: Continuous monitoring strategy
 ---
 
@@ -14,6 +14,7 @@ This page documents policies and procedures related to cloud.gov continuous moni
 Within the FedRAMP Security Assessment Framework, once an authorization has been granted, cloud.gov’s security posture is monitored according to the assessment and authorization process.  Monitoring security controls is part of the overall risk management framework for information security and is a requirement for cloud.gov to maintain a security authorization that meets the FedRAMP requirements.  
 
 Traditionally, this process has been referred to as “Continuous Monitoring” as noted in *NIST SP 800-137 Information Security Continuous Monitoring for Federal Information Systems and Organizations*.  Other NIST documents such as NIST SP 800-37, Revision 1 refer to “ongoing assessment of security controls”.  It is important to note that both the terms “Continuous Monitoring” and “Ongoing Security Assessments” mean essentially the same thing and should be interpreted as such.  
+
 Performing ongoing security assessments determines whether the set of deployed security controls in a cloud information system remains effective in light of new exploits and attacks, and planned and unplanned changes that occur in the system and its environment over time.  To maintain an authorization that meets the FedRAMP requirements, cloud.gov must monitor their security controls, assess them on a regular basis, and demonstrate that the security posture of their service offering is continuously acceptable.  
 
 Ongoing assessment of security controls results in greater control over the security posture of the cloud.gov system and enables timely risk-management decisions.  Security-related information collected through continuous monitoring is used to make recurring updates to the security assessment package.  Ongoing due diligence and review of security controls enables the security authorization package to remain current which allows agencies to make informed risk management decisions as they use cloud services.  
@@ -85,7 +86,6 @@ In order to be effective in this role, 3PAOs are responsible for ensuring that t
 ### Team responsibilities
 
 The cloud.gov team is responsible for implementing, verifying, and validating the cloud.gov continuous monitoring strategy.
-
 
 The cloud.gov Program Manager coordinates the tasks needed for the continuous monitoring strategy. They guide the team in assigning necessary tasks to team members in an agile way, including individuals on the Cloud Operations sub-team. 
 

--- a/content/docs/ops/federated-identity.md
+++ b/content/docs/ops/federated-identity.md
@@ -1,7 +1,7 @@
 ---
 menu:
   docs:
-    parent: operations
+    parent: tenants
 title: Federated Identity
 weight: 10
 ---

--- a/content/docs/ops/quotas.md
+++ b/content/docs/ops/quotas.md
@@ -1,7 +1,7 @@
 ---
 menu:
   docs:
-    parent: operations
+    parent: tenants
 title: Managing quotas
 ---
 

--- a/content/docs/ops/repos.md
+++ b/content/docs/ops/repos.md
@@ -2,7 +2,8 @@
 menu:
   docs:
     parent: ops
-title: Github repos
+title: GitHub repositories
+weight: -100
 ---
 
 Here are the repos with the tools and configuration for the platform:

--- a/content/docs/ops/security-ir-checklist.md
+++ b/content/docs/ops/security-ir-checklist.md
@@ -1,7 +1,7 @@
 ---
 menu:
   docs:
-    parent: operations
+    parent: policies
 title: Security Incident Response checklist
 linktitle: Security IR checklist
 ---

--- a/content/docs/ops/security-ir.md
+++ b/content/docs/ops/security-ir.md
@@ -1,7 +1,7 @@
 ---
 menu:
   docs:
-    parent: operations
+    parent: policies
 title: Security Incident Response Guide
 linktitle: Security IR Guide
 ---

--- a/content/docs/ops/set-up-custom-domains.md
+++ b/content/docs/ops/set-up-custom-domains.md
@@ -1,7 +1,7 @@
 ---
 menu:
   docs:
-    parent: operations
+    parent: tenants
 title: How to set up custom domains for users
 linktitle: Custom domains for users
 ---

--- a/content/docs/ops/working-with-authentications.md
+++ b/content/docs/ops/working-with-authentications.md
@@ -1,7 +1,7 @@
 ---
 menu:
   docs:
-    parent: operations
+    parent: tenants
 title: Working with cloud.gov authentication
 ---
 


### PR DESCRIPTION
Changes to ops docs to hopefully improve usability for the team and the public:

* Rename "Contributing" to "cloud.gov team docs" to be clear about the purpose of the ops docs category (it's not super helpful to external contributors)
* Rename "Github repos" to "GitHub repositories" and move it to the top of "cloud.gov team docs" since it's likely the most interesting page to curious visitors clicking this category
* Rename "Tenants" to "Tenant support" for clarity
* Move "How to set up custom domains for users" and "Working with cloud.gov authentication" to "Tenant support"
* Make new sub-category called "Policies and plans" and move the following to it: Configuration management, Contingency plan, Continuous monitoring strategy, Security Incident Response Guide, and Security Incident Response checklist