### PR TITLE
/contact now goes to /docs/help

### DIFF
--- a/content/docs/help.md
+++ b/content/docs/help.md
@@ -2,6 +2,7 @@
 title: Help
 aliases:
   - /help
+  - /contact
 ---
 
 ### I'm interested in using cloud.gov.


### PR DESCRIPTION
Per suggestion from @nikzei 

cc: @brittag 