### PR TITLE
Update docs homepage and related starter materials

### DIFF
--- a/content/docs/apps/deployment.md
+++ b/content/docs/apps/deployment.md
@@ -2,8 +2,7 @@
 menu:
   docs:
     parent: apps
-title: General deployment tips
-linktitle: General tips
+title: Basic deployment tips
 weight: -100
 ---
 
@@ -36,11 +35,11 @@ The app should now be live at `APPNAME.app.cloud.gov`.
 * Instances will be restarted if they exceed [memory limits]({{< relref "docs/apps/limits.md" >}})
 * Proper [logging]({{< relref "docs/apps/logs.md" >}}) might require special libraries/configuration for your app
 
-## Twelve-Factor Apps
+## Twelve-factor apps
 
 In general, applications will be easiest to deploy to Cloud Foundry if they follow the [Twelve Factor App](http://12factor.net/) guidelines.
 
-## Setting Environment Variables
+## Setting environment variables
 
 See Cloud Foundry's [documentation on environment variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html).
 

--- a/content/docs/apps/production-ready.md
+++ b/content/docs/apps/production-ready.md
@@ -1,9 +1,9 @@
 ---
-date: 2015-08-28T10:32:59-04:00
 menu:
   docs:
     parent: apps
 title: Production Ready guide
+weight: -90
 ---
 
 This is your guide to building production-ready apps on cloud.gov. Read this early and often, especially when you’re starting to consider a future project. It explains things you can do for reliable and responsive applications deployed on cloud.gov.

--- a/content/docs/docs-index.md
+++ b/content/docs/docs-index.md
@@ -2,14 +2,19 @@
 type: index
 ---
 
-### Introduction to cloud.gov
+Learn how to deploy and manage your applications, so you can deliver your digital services to the people who need them.
 
-cloud.gov gives teams working for federal government a secure, fully compliant foundation, integrated with private sector infrastructure providers, on which to build and release products and updates quickly. [Learn more about cloud.gov.]({{< relref "overview/overview/what-is-cloudgov.md" >}})
+### Learning and reference
 
-### Usage: developing and deploying apps
+New here? Start with the top of the sidebar and work your way down. The docs include both guides and reference material for you.
 
-cloud.gov is a Platform as a Service with a compliance toolkit. [Get started with building and deploying applications.]({{< relref "docs/getting-started/accounts.md" >}})
+| Shortcuts to common tasks |
+| --- |
+| [Set up the command line]({{< relref "docs/getting-started/setup.md#set-up-the-command-line" >}}) |
+| [Basic deployment tips]({{< relref "docs/apps/deployment.md" >}}) |
+| [Custom domains]({{< relref "docs/apps/custom-domains.md" >}}) |
+| [Managing teammates]({{< relref "docs/apps/managing-teammates.md" >}}) |
 
-### Contributing
+### cloud.gov team docs
 
-cloud.gov is an open source project, based on the Cloud Foundry project with additional components built by 18F and other community members. Our contributing documentation is for cloud.gov operations staff, and we invite others to [learn how we run the platform and contribute to it]({{< relref "docs/ops/repos.md" >}}).
+cloud.gov is an open source project based on [Cloud Foundry](https://www.cloudfoundry.org/) with additional components built by our team and other community members. We maintain our code and team documentation publicly here, and we invite you to read it, contribute to it, and adapt it for other projects. See [our list of repositories]({{< relref "docs/ops/repos.md" >}}).


### PR DESCRIPTION
The docs homepage was a pretty outdated placeholder, so here's a new placeholder that attempts to anticipate what people want when they go to this page:
* Confirmation that they're in the right place
* One-click skipping to pages with commands they need to copy-paste frequently
* Better explanation of our team docs at the bottom of the docs list

I also updated the vague "General tips" page name to "Basic deployment tips", and I moved the Production Ready Guide underneath it. This inches toward a coherent initial narrative for a reader's first journey through the docs.