### PR TITLE
Minor documentation updates for the new s3 broker

### DIFF
--- a/content/docs/services/s3.md
+++ b/content/docs/services/s3.md
@@ -153,7 +153,7 @@ aws s3api put-bucket-cors --bucket $BUCKET_NAME --cors-configuration file://cors
 You can add additional method types along with HEAD and GET (such as PUT, POST, and DELETE) as needed.
 
 ### Backup and Retention
-By default, S3 data will stay where it is. You must [empty the bucket](http://docs.aws.amazon.com/AmazonS3/latest/dev/delete-or-empty-bucket.html#empty-bucket-awscli) before `cf delete-service`can be run on the `<APP_NAME>-s3` service.  This however is not a substitute for backups, and it provides no protection from users accidentally deleting the contents.
+By default, S3 data will stay where it is. You must [empty the bucket](http://docs.aws.amazon.com/AmazonS3/latest/dev/delete-or-empty-bucket.html#empty-bucket-awscli) before `cf delete-service` can be run on the `<APP_NAME>-s3` service.  This however is not a substitute for backups, and it provides no protection from users accidentally deleting the contents.
 
 You can implement a backup scheme by storing your buckets under /data/year/month/day and keeping multiple copies in S3, using the AWS CLI. Your Org Manager can create a space called "backups", and your team can run the process above again to create backup buckets.
 

--- a/content/docs/services/s3.md
+++ b/content/docs/services/s3.md
@@ -153,10 +153,10 @@ aws s3api put-bucket-cors --bucket $BUCKET_NAME --cors-configuration file://cors
 You can add additional method types along with HEAD and GET (such as PUT, POST, and DELETE) as needed.
 
 ### Backup and Retention
-By default, S3 data will stay where it is until `cf delete-service` is run on the `<APP_NAME>-s3` service.  This however is not a substitute for backups, and it provides no protection from users accidentally deleting the contents.
+By default, S3 data will stay where it is. You must [empty the bucket](http://docs.aws.amazon.com/AmazonS3/latest/dev/delete-or-empty-bucket.html#empty-bucket-awscli) before `cf delete-service`can be run on the `<APP_NAME>-s3` service.  This however is not a substitute for backups, and it provides no protection from users accidentally deleting the contents.
 
 You can implement a backup scheme by storing your buckets under /data/year/month/day and keeping multiple copies in S3, using the AWS CLI. Your Org Manager can create a space called "backups", and your team can run the process above again to create backup buckets.
 
 ### The broker in GitHub
 
-You can find the broker here: [https://github.com/cloudfoundry-community/s3-cf-service-broker](https://github.com/cloudfoundry-community/s3-cf-service-broker).
+You can find the broker here: [https://github.com/cloudfoundry-community/s3-broker](https://github.com/cloudfoundry-community/s3-broker).


### PR DESCRIPTION
Changed link to repo on github.  Mention the user is now required to empty their bucket before they can delete it.