### PR TITLE
New homepage layouts/copy [FOR REVIEW]

### DIFF
--- a/content/docs/services/s3.md
+++ b/content/docs/services/s3.md
@@ -153,7 +153,7 @@ aws s3api put-bucket-cors --bucket $BUCKET_NAME --cors-configuration file://cors
 You can add additional method types along with HEAD and GET (such as PUT, POST, and DELETE) as needed.
 
 ### Backup and Retention
-By default, S3 data will stay where it is. You must [empty the bucket](http://docs.aws.amazon.com/AmazonS3/latest/dev/delete-or-empty-bucket.html#empty-bucket-awscli) before `cf delete-service`can be run on the `<APP_NAME>-s3` service.  This however is not a substitute for backups, and it provides no protection from users accidentally deleting the contents.
+By default, S3 data will stay where it is. You must [empty the bucket](http://docs.aws.amazon.com/AmazonS3/latest/dev/delete-or-empty-bucket.html#empty-bucket-awscli) before `cf delete-service` can be run on the `<APP_NAME>-s3` service.  This however is not a substitute for backups, and it provides no protection from users accidentally deleting the contents.
 
 You can implement a backup scheme by storing your buckets under /data/year/month/day and keeping multiple copies in S3, using the AWS CLI. Your Org Manager can create a space called "backups", and your team can run the process above again to create backup buckets.
 

--- a/content/docs/services/s3.md
+++ b/content/docs/services/s3.md
@@ -153,10 +153,10 @@ aws s3api put-bucket-cors --bucket $BUCKET_NAME --cors-configuration file://cors
 You can add additional method types along with HEAD and GET (such as PUT, POST, and DELETE) as needed.
 
 ### Backup and Retention
-By default, S3 data will stay where it is until `cf delete-service` is run on the `<APP_NAME>-s3` service.  This however is not a substitute for backups, and it provides no protection from users accidentally deleting the contents.
+By default, S3 data will stay where it is. You must [empty the bucket](http://docs.aws.amazon.com/AmazonS3/latest/dev/delete-or-empty-bucket.html#empty-bucket-awscli) before `cf delete-service`can be run on the `<APP_NAME>-s3` service.  This however is not a substitute for backups, and it provides no protection from users accidentally deleting the contents.
 
 You can implement a backup scheme by storing your buckets under /data/year/month/day and keeping multiple copies in S3, using the AWS CLI. Your Org Manager can create a space called "backups", and your team can run the process above again to create backup buckets.
 
 ### The broker in GitHub
 
-You can find the broker here: [https://github.com/cloudfoundry-community/s3-cf-service-broker](https://github.com/cloudfoundry-community/s3-cf-service-broker).
+You can find the broker here: [https://github.com/cloudfoundry-community/s3-broker](https://github.com/cloudfoundry-community/s3-broker).

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,7 +14,7 @@
   <div class="usa-grid section-bg-parent">
     <div class="usa-width-whole billboard  section-bg">
       <h1 class="billboard-display_text">A Platform as a Service for government teams</h1>
-      <h2 class="billboard-second_text">Focus on the things you want to build. cloud.gov gives you a powerful environment to build them in.</h1>
+      <h2 class="billboard-second_text">Focus on what you want to build: faster, simpler, and more secure.</h1>
     </div>
   </div>
 </section>
@@ -23,11 +23,9 @@
   <a name="about"></a>
   <div class="usa-grid">
     <div class="section-content usa-content">
-      <h1>cloud.gov is a Platform as a Service built specifically for government work.</h1>
-      <p>
-        It’s a secure, fully compliant cloud environment where your team can build, manage and
-        release digital applications. And because all of cloud.gov’s security controls are
-        documented in an open source and software-friendly way, it’s Compliance as a Service, too.
+      <h1 class="section-title">We understand the compliance requirements necessary for ATO.</h1>
+      <p class="section-displaytext">
+        The cloud.gov platform’s flexible, machine-readable, always up-to-date compliance documentation automates huge parts of the ATO process. Imagine a secure cloud environment where your team can build, manage and release digital applications — with platform compliance built in. This is cloud.gov.
       </p>
     </div>
   </div>
@@ -43,7 +41,7 @@
 <section class="usa-content section-middle section-cream">
   <div class="usa-grid">
     <div class="section-content usa-content">
-      <h1>Is cloud.gov right for you?</h1>
+      <h1 class="section-title">Is cloud.gov right for you?</h1>
         <h2>
           cloud.gov lets you build more of what you want to build, faster and more securely.
         </h2>
@@ -87,7 +85,7 @@
         <i class="hex_icon hex_icon-alt"
           style="height: 5.625rem; width: 4.9rem">
           <svg class="icon">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-compass"/>
+            <use xlink:href="assets/img/cloudgov-sprite.svg#i-locked"/>
           </svg>
         </i>
         <h3>Take advantage of centrally-managed security.</h3>
@@ -114,7 +112,7 @@
 <section class="usa-content section section-dark section-chevron-alt">
   <div class="usa-grid">
     <div class="section-content usa-content">
-      <h1>Are you right for cloud.gov?</h1>
+      <h1 class="section-title">Are you right for cloud.gov?</h1>
       <p>cloud.gov was built by a government team for government teams. Here’s who we’re looking
         for:</p>
         <ul>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -41,7 +41,7 @@
 <section class="usa-content section-middle section-cream">
   <div class="usa-grid">
     <div class="three_up">
-      <div class="three_up-part b-blue bt2px">
+      <div class="three_up-part part-1">
         <h3 class="section-coltitle">Build great things in the cloud with the expertise you already have.</h3>
         <p>
           To get the benefits of cloud hosting, like scalability and savings, you need cloud
@@ -52,7 +52,7 @@
           the applications you’re responsible for.
         </p>
       </div>
-      <div class="three_up-part b-green bt2px">
+      <div class="three_up-part part-2">
         <h3 class="section-coltitle">Make compliance easier. Give your team their time back.</h3>
         <p>
           Launching digital applications for a federal agency requires lengthy documentation
@@ -63,7 +63,7 @@
           Just document what you build on top of the platform. Could your team use the extra time?
         </p>
       </div>
-      <div class="three_up-part b-red bt2px">
+      <div class="three_up-part part-3">
         <h3 class="section-coltitle">Take advantage of centrally-managed security.</h3>
         <p>
           Because cloud.gov enforces a consistent environment, no other team using the platform

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -41,7 +41,7 @@
 <section class="usa-content section-middle section-cream">
   <div class="usa-grid">
     <div class="three_up">
-      <div class="three_up-part part-1">
+      <div class="three_up-part three_up-part-1">
         <h3 class="section-coltitle">Build great things in the cloud with the expertise you already have.</h3>
         <p>
           To get the benefits of cloud hosting, like scalability and savings, you need cloud
@@ -52,7 +52,7 @@
           the applications you’re responsible for.
         </p>
       </div>
-      <div class="three_up-part part-2">
+      <div class="three_up-part three_up-part-2">
         <h3 class="section-coltitle">Make compliance easier. Give your team their time back.</h3>
         <p>
           Launching digital applications for a federal agency requires lengthy documentation
@@ -63,7 +63,7 @@
           Just document what you build on top of the platform. Could your team use the extra time?
         </p>
       </div>
-      <div class="three_up-part part-3">
+      <div class="three_up-part three_up-part-3">
         <h3 class="section-coltitle">Take advantage of centrally-managed security.</h3>
         <p>
           Because cloud.gov enforces a consistent environment, no other team using the platform

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,7 +14,7 @@
   <div class="usa-grid section-bg-parent">
     <div class="usa-width-whole billboard  section-bg">
       <h1 class="billboard-display_text">A Platform as a Service for government teams</h1>
-      <h2 class="billboard-second_text">Focus on what you want to build: faster, simpler, and more secure.</h1>
+      <h2 class="billboard-second_text">Focus on what you want to build — cloud.gov makes it faster, simpler, and more secure.</h1>
     </div>
   </div>
 </section>
@@ -23,9 +23,9 @@
   <a name="about"></a>
   <div class="usa-grid">
     <div class="section-content usa-content">
-      <h1 class="section-title">We understand the compliance requirements necessary for ATO.</h1>
+      <h1 class="section-title">We understand what it takes to get from day one to ATO.</h1>
       <p class="section-displaytext">
-        The cloud.gov platform’s flexible, machine-readable, always up-to-date compliance documentation automates huge parts of the ATO process. Imagine a secure cloud environment where your team can build, manage and release digital applications — with platform compliance built in. This is cloud.gov.
+        The cloud.gov platform’s flexible, machine-readable, always up-to-date compliance documentation automates huge parts of the ATO process. Imagine a secure cloud environment where your team can get up and running in minutes, then build, manage, and release applications — with platform compliance built in. This is cloud.gov.
       </p>
     </div>
   </div>
@@ -40,21 +40,9 @@
 
 <section class="usa-content section-middle section-cream">
   <div class="usa-grid">
-    <div class="section-content usa-content">
-      <h1 class="section-title">Is cloud.gov right for you?</h1>
-        <h2>
-          cloud.gov lets you build more of what you want to build, faster and more securely.
-        </h2>
-    </div>
     <div class="three_up">
-      <div class="three_up-part">
-        <i class="hex_icon hex_icon-primary"
-          style="height: 5.625rem; width: 4.9rem">
-          <svg class="icon">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-shipping"/>
-          </svg>
-        </i>
-        <h3>Build great things in the cloud with the expertise you already have.</h3>
+      <div class="three_up-part b-blue bt2px">
+        <h3 class="section-coltitle">Build great things in the cloud with the expertise you already have.</h3>
         <p>
           To get the benefits of cloud hosting, like scalability and savings, you need cloud
           operations expertise, unless you’re using a Platform as a Service like cloud.gov.
@@ -64,14 +52,8 @@
           the applications you’re responsible for.
         </p>
       </div>
-      <div class="three_up-part">
-        <i class="hex_icon hex_icon-black"
-          style="height: 5.625rem; width: 4.9rem">
-          <svg class="icon">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-paperwork"/>
-          </svg>
-        </i>
-        <h3>Make compliance easier. Give your team their time back.</h3>
+      <div class="three_up-part b-green bt2px">
+        <h3 class="section-coltitle">Make compliance easier. Give your team their time back.</h3>
         <p>
           Launching digital applications for a federal agency requires lengthy documentation
           detailing your compliance with security standards. Creating these docs takes dozens of
@@ -81,14 +63,8 @@
           Just document what you build on top of the platform. Could your team use the extra time?
         </p>
       </div>
-      <div class="three_up-part">
-        <i class="hex_icon hex_icon-alt"
-          style="height: 5.625rem; width: 4.9rem">
-          <svg class="icon">
-            <use xlink:href="assets/img/cloudgov-sprite.svg#i-locked"/>
-          </svg>
-        </i>
-        <h3>Take advantage of centrally-managed security.</h3>
+      <div class="three_up-part b-red bt2px">
+        <h3 class="section-coltitle">Take advantage of centrally-managed security.</h3>
         <p>
           Because cloud.gov enforces a consistent environment, no other team using the platform
           can change the environment in a way that hurts your security or compliance. Because
@@ -113,15 +89,12 @@
   <div class="usa-grid">
     <div class="section-content usa-content">
       <h1 class="section-title">Are you right for cloud.gov?</h1>
-      <p>cloud.gov was built by a government team for government teams. Here’s who we’re looking
+      <p class="section-dek">cloud.gov was built by a government team for government teams. Here’s who we’re looking
         for:</p>
-        <ul>
-          <li>You’re in a federal government organization that employs teams — either in-house
-            or on contract — with the power to push applications.</li>
+        <ul class="list-lined">
+          <li>You’re in a federal government organization that employs teams — either in-house or on contract — with the power to push applications.</li>
           <li>You or your teams can can use the IAA/MOU process to pay GSA for cloud.gov.</li>
-          <li>Your applications are FISMA-Moderate or lower, and the engineering approach values
-              clarity (for example, the application listens to a single port and stores
-              configuration in the environment).</li>
+          <li>Your applications are FISMA-Moderate or lower, and the engineering approach values clarity (for example, the application listens to a single port and stores configuration in the environment).</li>
         </ul>
     </div>
   </div>

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -1,4 +1,4 @@
-<section>
+<section class="content-text">
   <a name="contact"></a>
   <h1>Interested in cloud.gov?</h1>
     <h2>Get in touch to get started.</h2>
@@ -13,9 +13,9 @@
     <h2>Other questions?</h2>
     <p>There are a number of <a href="/docs/help/">ways to get in touch</a>, depending on
       what you need.</p>
-      
+
     <h2>Get updates</h2>
-    <p class="section-subhed">Sign up for updates about cloud.gov, including information about new services, features, or requirements.</p>
+    <p>Sign up for updates about cloud.gov, including information about new services, features, or requirements.</p>
     <form action="//gsa.us9.list-manage.com/subscribe/post?u=6f1977de9eff4c384dc8d6527&amp;id=ab90bdad59" method="post" id="contact" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
       <fieldset>
         <div class="text_block">


### PR DESCRIPTION
**A pair with https://github.com/18F/cg-style/pull/237 — they need to update together for everything to work properly**

OK, so I was working from this PR (https://github.com/18F/cg-site/pull/656), trying to work with the new copy and bring the homepage up to current style standards.

In doing so, I updated the style/size of some of the copy elements, which affected their length and presentation. Because I am a dumb idiot who can't keep himself from meddling, I rewrote some of the copy to fit with the new size/flow. (I am truly sorry, but I honestly cannot help myself — I think it's a compulsion.)

Anyhow, I've cleaned up the styles and removed the obvious layout errors. 

Copywise — I hope you can see my meddling as a good-hearted attempt to be helpful, but I understand if you see it otherwise.

![cg-homepage-changes](https://cloud.githubusercontent.com/assets/11464021/21504016/659c65a6-cc10-11e6-8a1e-a5486202d24b.png)
