### PR TITLE
Remove extra "read more" links on services intro page

### DIFF
--- a/layouts/docs/services.html
+++ b/layouts/docs/services.html
@@ -8,7 +8,6 @@
       <th>Service Name</th>
       <th>Description</th>
       <th>Support Status</th>
-      <th>Read More</th>
     </tr>
   </thead>
   <tbody>
@@ -17,7 +16,6 @@
       <td><a href="{{ "/docs/services/" | relLangURL }}{{ .page_name | default .name | urlize }}">{{ .name }}</a></td>
       <td>{{ .description | markdownify }}</td>
       <td>{{ .status }}</td>
-      <td>More</td>
     </tr>
   {{ end }}
   </tbody>


### PR DESCRIPTION
This should fix the minor issue identified at https://github.com/18F/cg-site/issues/625 - although something about my local setup made this difficult to test locally (the services intro page just doesn't show up).