### PR TITLE
Update explanations of compliance materials

### DIFF
--- a/content/overview/overview.md
+++ b/content/overview/overview.md
@@ -12,7 +12,7 @@ cloud.gov is developed **by the Government, for the Government**. 18F, housed wi
 
 ### Compliance
 
-cloud.gov was designed with **FISMA compliance** in mind. cloud.gov is currently designated as FedRAMP Ready, and the **FedRAMP Moderate** JAB P-ATO assessment process is underway.  The vast majority of FISMA Moderate controls are managed for you. The included compliance toolkit provides assistance with generating compliance documentation, so that even small agency teams can have a quick path to ATO.
+cloud.gov was designed with **FISMA compliance** in mind. cloud.gov is currently designated as FedRAMP Ready, and the **FedRAMP Moderate** JAB P-ATO assessment process is underway.  The vast majority of FISMA Moderate controls are managed for you.
 
 ### Free Sandbox Accounts
 

--- a/content/overview/overview/what-is-cloudgov.md
+++ b/content/overview/overview/what-is-cloudgov.md
@@ -25,8 +25,6 @@ cloud.gov gives teams working for federal government a secure, fully compliant f
 
 cloud.gov is built and maintained by [18F](https://18f.gsa.gov/) as part of the U.S. General Services Administration’s [Technology Transformation Service](http://www.gsa.gov/portal/category/25729) portfolio. cloud.gov is a cost-recoverable service funded by charging a fee to the teams that use it.
 
-## cloud.gov provides a compliance toolkit
+## cloud.gov provides Compliance as a Service
 
-cloud.gov provides tools for customers to create the security documentation and continuing assurance necessary for federal services to comply with FISMA regulations and agency-specific “Authority to Operate” (ATO) requirements.
-
-These tools are the Compliance Toolkit, including [Compliance Masonry](https://github.com/opencontrol/compliance-masonry). The Compliance Toolkit supports cloud.gov's ATO and the ATOs of customer applications, and they’re all open source. Other teams, including agencies and industry teams, can also use these tools for unrelated projects with similar needs.
+cloud.gov's built-in compliance support helps customers create the security documentation and continuing assurance necessary for federal services to comply with FISMA regulations and agency-specific “Authority to Operate” (ATO) requirements.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -25,7 +25,7 @@
     <div class="section-content usa-content">
       <h1 class="section-title">We understand what it takes to get from day one to ATO.</h1>
       <p class="section-displaytext">
-        The cloud.gov platform’s flexible, machine-readable, always up-to-date compliance documentation automates huge parts of the ATO process. Imagine a secure cloud environment where your team can get up and running in minutes, then build, manage, and release applications — with platform compliance built in. This is cloud.gov.
+        The cloud.gov platform’s built-in compliance automates huge parts of the ATO process. Imagine a secure cloud environment where your team can get up and running in minutes, then build, manage, and release applications with a radically shortened compliance review process. This is cloud.gov.
       </p>
     </div>
   </div>
@@ -58,8 +58,7 @@
           Launching digital applications for a federal agency requires lengthy documentation
           detailing your compliance with security standards. Creating these docs takes dozens of
           hours from developers, hours they can’t spend building features your users need. But
-          with cloud.gov, you get Compliance as a Service, too. Use the platform’s flexible,
-          machine-readable, always up-to-date documentation to automate huge parts of the process.
+          with cloud.gov, you get Compliance as a Service, too. Use the platform’s compliance to automate huge parts of the process.
           Just document what you build on top of the platform. Could your team use the extra time?
         </p>
       </div>
@@ -94,7 +93,7 @@
         <ul class="list-lined">
           <li>You’re in a federal government organization that employs teams — either in-house or on contract — with the power to push applications.</li>
           <li>You or your teams can use the IAA/MOU process to pay GSA for cloud.gov.</li>
-          <li>Your applications are FISMA-Moderate or lower.</li>
+          <li>Your applications are FISMA Moderate or lower.</li>
           <li>Your engineering approach values clarity (for example, the application listens to a single port and stores configuration in the environment).</li>
         </ul>
     </div>


### PR DESCRIPTION
This is a followup on the earlier PR at https://github.com/18F/cg-site/pull/616 that updates our explanations of the current compliance materials we provide and believe customers will find helpful:

* On overview page, remove bit about generating compliance documentation
* On "what is cloud.gov", use the "Compliance as a Service" phrase instead of "compliance toolkit", to match the homepage; remove explanation of Compliance Masonry
* On homepage, emphasize our platform compliance instead of our compliance documentation (currently our compliance documentation isn't machine-readable)