### PR TITLE
Remove unused attribute from services template

### DIFF
--- a/layouts/docs/services.html
+++ b/layouts/docs/services.html
@@ -13,7 +13,7 @@
   <tbody>
   {{ range $.Site.Data.services }}
     <tr>
-      <td><a href="{{ "/docs/services/" | relLangURL }}{{ .page_name | default .name | urlize }}">{{ .name }}</a></td>
+      <td><a href="{{ "/docs/services/" }}{{ .page_name | default .name | urlize }}">{{ .name }}</a></td>
       <td>{{ .description | markdownify }}</td>
       <td>{{ .status }}</td>
     </tr>


### PR DESCRIPTION
I was getting the following error when building the site locally, which was making the `/docs/services/` page not work for me locally:

`ERROR: 2016/12/28 13:18:10 template.go:472: template: docs/services.html:16: function "relLangURL" not defined`

We're not using this `relLangURL` attribute (explained at https://gohugo.io/templates/functions/#abslangurl-rellangurl), so we don't need this in the template. Removing it resolves the error for me.