### PR TITLE
Fix footers in docs and overview sections

### DIFF
--- a/layouts/docs/services.html
+++ b/layouts/docs/services.html
@@ -28,5 +28,6 @@
   <li><strong>Alpha</strong>: The service is under development and some downtime or data loss can occur.</li>
 </ul>
 
+{{ partial "docs-footer.html" . }}
 {{ partial "footer.html" . }}
 {{ partial "javascript.html" . }}

--- a/layouts/overview/single.html
+++ b/layouts/overview/single.html
@@ -1,4 +1,5 @@
 {{ partial "overview-header.html" . }}
 {{ .Content }}
+{{ partial "overview-footer.html" . }}
 {{ partial "footer.html" . }}
 {{ partial "javascript.html" . }}


### PR DESCRIPTION
This should make the footers of pages such as https://cloud.gov/docs/services/ and https://cloud.gov/overview/overview/what-is-cloudgov/ consistent with the rest of the site - see https://github.com/18F/cg-design/issues/25#issuecomment-269403642 for context.

cc @line47 - up for review by anyone.