### PR TITLE
Update "search documentation" to "search"

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -29,7 +29,7 @@
               <label class="usa-sr-only" for="search-field-small">Search small</label>
               <input id="affiliate" name="affiliate" type="hidden" value="cloud.gov" />
               <input name="utf8" type="hidden" value="&#x2713;" />
-              <input id="search-field" autocomplete="off" type="search" name="query" placeholder="Search documentation">
+              <input id="search-field" autocomplete="off" type="search" name="query" placeholder="Search">
               <button type="submit">
                 <span class="usa-sr-only">Search</span>
               </button>


### PR DESCRIPTION
A while back I filed this as an issue at https://github.com/18F/cg-design/issues/26 - but looking at it again, we can make this incrementally better with this simple change, so here's a PR. Basically: the current search covers /docs/, /overview/, and /updates/, so the "Search documentation" placeholder text is confusing, since our nav only calls /docs/ "Documentation". This updates it to just "Search".