### PR TITLE
Fix capitalization of page titles + rearrange order of pricing pages

### DIFF
--- a/content/docs/apps/frameworks.md
+++ b/content/docs/apps/frameworks.md
@@ -2,7 +2,7 @@
 menu:
   docs:
     parent: apps
-title: Languages and Frameworks
+title: Languages and frameworks
 aliases:
 - /docs/apps/django
 - /docs/apps/flask

--- a/content/docs/ops/aws-accounts.md
+++ b/content/docs/ops/aws-accounts.md
@@ -2,7 +2,7 @@
 menu:
   docs:
     parent: operations
-title: AWS Accounts
+title: AWS accounts
 ---
 
 cloud.gov currently (October 2016) uses 3+ AWS accounts:
@@ -11,4 +11,4 @@ cloud.gov currently (October 2016) uses 3+ AWS accounts:
 1. GovCloud cloud.gov main account: this is the "new" AWS account where BOSH/CF API and most services live. This account is where we are migrating tenants to.
 1. cloud.gov E/W: We only use this for CloudFront right now since it is not available in GovCloud. **This account is linked to the GovCloud one so any support tickets should be filled here**.
 
-Note: DNS for `cloud.gov` is managed through [https://github.com/18f/dns](https://github.com/18f/dns), which is deployed to a Route53 service in yet another account. cloud.gov does not have access to that account.
+Note: DNS for `cloud.gov` is managed through [https://github.com/18f/dns](https://github.com/18f/dns), which is deployed to a Route 53 service in yet another account. cloud.gov does not have access to that account.

--- a/content/docs/ops/aws-onboarding.md
+++ b/content/docs/ops/aws-onboarding.md
@@ -2,7 +2,7 @@
 menu:
   docs:
     parent: operations
-title: AWS Onboarding
+title: AWS onboarding
 ---
 
 ### Levels of access

--- a/content/docs/ops/federated-identity.md
+++ b/content/docs/ops/federated-identity.md
@@ -2,11 +2,11 @@
 menu:
   docs:
     parent: tenants
-title: Federated Identity
+title: Federated identity
 weight: 10
 ---
 
-Federated Identity in cloud.gov is supported via [SAML 2.0](https://en.wikipedia.org/wiki/SAML_2.0).  UAA acts as a SAML service provider (SP) to authenticate with trusted identity providers (IdP).
+Federated identity in cloud.gov is supported via [SAML 2.0](https://en.wikipedia.org/wiki/SAML_2.0).  UAA acts as a SAML service provider (SP) to authenticate with trusted identity providers (IdP).
 
 Approval from the Program Manager is required before adding a new trusted identity provider.
 

--- a/content/docs/ops/maintenance-list.md
+++ b/content/docs/ops/maintenance-list.md
@@ -2,7 +2,7 @@
 menu:
   docs:
     parent: operations
-title: Ongoing Platform Maintenance
+title: Ongoing platform maintenance
 ---
 
 ## Regular maintenance task list

--- a/content/docs/services/cdn-route.md
+++ b/content/docs/services/cdn-route.md
@@ -2,7 +2,7 @@
 menu:
   docs:
     parent: services
-title: CDN Service
+title: CDN service
 name: "cdn-route"
 description: "Custom routes with HTTPS certificates using Amazon CloudFront"
 status: "Production Ready"

--- a/content/docs/services/deployer-account.md
+++ b/content/docs/services/deployer-account.md
@@ -2,13 +2,13 @@
 menu:
   docs:
     parent: services
-title: Deployer Account
+title: Deployer account
 name: "deployer-account"
 description: "Create deployer accounts for to use in automated deployment systems"
 status: "Beta"
 ---
 
-To set up your application to be deployed with an automated system you will need a deployer account that has access to push your application.
+To set up your application to be deployed with an automated system, you need a deployer account that has access to push your application.
 
 ## Plans
 
@@ -24,9 +24,9 @@ To create a service instance run the following command:
 cf create-service deployer-account deployer-account my-deployer-account
 ```
 
-## More Information
+## More information
 
-To read more details on how to use this service see the [Continuous Deployment]({{< relref "docs/apps/continuous-deployment.md" >}}).
+To use this service, see [continuous deployment]({{< relref "docs/apps/continuous-deployment.md" >}}).
 
 
 ### The broker in GitHub

--- a/content/docs/services/relational-database.md
+++ b/content/docs/services/relational-database.md
@@ -2,12 +2,12 @@
 menu:
   docs:
     parent: services
-title: Relational Databases (aws-rds)
+title: Relational databases (aws-rds)
 aliases:
   - /docs/apps/databases
 ---
 
-If your application uses relational databases for storage, you can use the cloud.gov AWS RDS service to create a database instance.
+If your application uses relational databases for storage, you can use the AWS RDS service to create a database instance.
 
 ## Plans
 
@@ -24,11 +24,11 @@ Plan Name | Description | Price
 `large-mysql`            | Dedicated Large RDS MySQL DB Instance               | $0.220 / hr + storage
 `large-mysql-redundant`  | Dedicated Redundant Large RDS MySQL DB Instance     | $0.440 / hr + storage
 
-### Storage Pricing:
+### Storage pricing:
 
-- Shared Instance: Free
-- Simple Instance: $0.138 per GB per month
-- Redundant Instance: $0.276 per GB per month
+- Shared instance: Free
+- Simple instance: $0.138 per GB per month
+- Redundant instance: $0.276 per GB per month
 
 ## Options
 

--- a/content/overview/overview.md
+++ b/content/overview/overview.md
@@ -2,11 +2,11 @@
 type: index
 ---
 
-### Platform as a Service (PaaS) for Government developers
+### Platform as a Service (PaaS) for government developers
 
 cloud.gov allows your development team to focus on what matters: your applications. As a Platform as a Service (PaaS), cloud.gov **eliminates the need to manage infrastructure such as virtual machines and servers**. This enables your development team to rapidly iterate and quickly launch your application to ensure mission success. Because cloud.gov is based on **open-source technologies**, it provides portability to other cloud providers or your existing on-premise solution.
 
-cloud.gov is developed **by the Government, for the Government**. 18F, housed within the General Services Administration’s Technology Transformation Service, develops and operates cloud.gov.
+cloud.gov is developed **by the government, for the government**. 18F, housed within the General Services Administration’s Technology Transformation Service, develops and operates cloud.gov.
 
 [Learn more about cloud.gov.]({{< relref "overview/overview/what-is-cloudgov.md" >}})
 
@@ -14,7 +14,7 @@ cloud.gov is developed **by the Government, for the Government**. 18F, housed wi
 
 cloud.gov was designed with **FISMA compliance** in mind. cloud.gov is currently designated as FedRAMP Ready, and the **FedRAMP Moderate** JAB P-ATO assessment process is underway.  The vast majority of FISMA Moderate controls are managed for you.
 
-### Free Sandbox Accounts
+### Free sandbox accounts
 
 Anyone with a .gov or .mil email address can try out cloud.gov for free by [signing up for a sandbox account]({{< relref "docs/help.md" >}}). **No paperwork required**.
 

--- a/content/overview/pricing/pricing-model.md
+++ b/content/overview/pricing/pricing-model.md
@@ -3,25 +3,16 @@ menu:
   overview:
     parent: pricing
 title: How the pricing model is managed
-weight: 10
+weight: 30
 aliases:
   - /docs/intro/pricing/pricing-model
   - /intro/pricing/pricing-model
 ---
 
-cloud.gov services are available to other agencies on a _full_ cost-recovery model.
+cloud.gov services are available to other agencies on a full cost-recovery model.
 
----
+The current cloud.gov pricing model has three components: **access package**, **resource usage**, and **managed services**. Find out more about each component via our [pricing terminology page]({{< relref "overview/terminology/pricing-terminology.md" >}}) or see the [dedicated page with our rates]({{< relref "overview/pricing/rates.md" >}}).
 
-The current cloud.gov pricing model has three components:
-
-- Access package
-- Resource usage
-- Managed services
-
-Find out more about each component via our [pricing terminology page]({{< relref "overview/terminology/pricing-terminology.md" >}}) or see the [dedicated page with our rates]({{< relref "overview/pricing/rates.md" >}}).
-
----
 Our mission is broader than making it easier for government agencies to adopt cloud deployment. The mission of cloud.gov is to enable agencies to deliver services to the public as fast as they can develop them while applying best practices in security and compliance with minimal effort.
 
 Comparing cloud.gov’s pricing model to private Platform as a Service (PaaS) providers is difficult, as it is not an apples to apples comparison. A price comparison would include the up-front and opportunity costs of procurement, operations, security, and compliance teams in obtaining a solution. These costs can be difficult to isolate, especially if they are covered by various working capital funds in your agency.

--- a/content/overview/pricing/quotas.md
+++ b/content/overview/pricing/quotas.md
@@ -3,19 +3,19 @@ menu:
   overview:
     parent: pricing
 title: Quotas
-weight: -10
+weight: -5
 aliases:
   - /docs/intro/pricing/quotas
   - /intro/pricing/quotas
 ---
 
-Cloud Foundry capacity is billed by quota. Quotas provide a not-to-exceed reservation of memory, compute, application routes and service instances. Quotas are associated with and billed to a project IAA number or equivalent billing tag. Quota capacity is a hard limit; unused capacity does not ‘roll over’ month to month.
+cloud.gov capacity is billed by quota. Quotas provide a not-to-exceed reservation of memory, compute, application routes and service instances. Quotas are associated with and billed to a project IAA number or equivalent billing tag. Quota capacity is a hard limit; unused capacity does not "roll over" month to month.
 
-## Quota Billing:
+## Quota billing
 
 Quotas are billed by the amount of memory reserved and tallied daily. A monthly bill might include 9 days at 1 GB of RAM, 11 days at 2 GB of RAM and 10 days at 4 GB of RAM.
 
-## Quota Limits:
+## Quota limits
 
 Quotas limit the following resources:  
 

--- a/content/overview/pricing/rates.md
+++ b/content/overview/pricing/rates.md
@@ -3,7 +3,7 @@ menu:
   overview:
     parent: pricing
 title: Rates
-weight: 10
+weight: -10
 aliases:
   - /docs/intro/pricing/rates
   - /intro/pricing/rates
@@ -15,9 +15,9 @@ cloud.gov fees are broken into three components:
 - Resource usage quota
 - Managed services
 
-Find out [more about this pricing model]({{< relref "overview/pricing/pricing-model.md" >}}) and [how we define these terms]({{< relref "overview/terminology/pricing-terminology.md" >}})
+Find out [more about this pricing model]({{< relref "overview/pricing/pricing-model.md" >}}) and [how we define these terms]({{< relref "overview/terminology/pricing-terminology.md" >}}).
 
-## Access Package
+## Access package
 
 Packages are selected based on the kinds of applications to be hosted. [Find more about what's included in all access packages.]({{< relref "overview/pricing/whats-included.md" >}})
 


### PR DESCRIPTION
* Minor style edits for many pages, mostly converting titles to sentence case or fixing missing commas.
* Rearrange the order of pages in the pricing section to make more sense for a new reader - start with the prices (the rates page), then explain the details of how the rates work (quotas, more about the pricing model, clown cars, etc.)

Before:
<img width="318" alt="screen shot 2016-12-29 at 5 51 28 pm" src="https://cloud.githubusercontent.com/assets/391313/21558486/98edc478-cdef-11e6-9751-28b3db3c78c0.png">

After:
<img width="306" alt="screen shot 2016-12-29 at 5 51 40 pm" src="https://cloud.githubusercontent.com/assets/391313/21558482/925d3648-cdef-11e6-9b05-e140fb8fca3d.png">
