### PR TITLE
Update docs about multiple instances

### DIFF
--- a/content/docs/apps/multiple-instances.md
+++ b/content/docs/apps/multiple-instances.md
@@ -5,23 +5,25 @@ menu:
     parent: advanced
 title: Running multiple instances
 ---
-## Starting Multiple Instances
-There are three ways to start multiple app instances in Cloud Foundry:
+## Starting multiple instances
+There are three ways to start multiple app instances on cloud.gov:
 
 1.  In the `cf push` command
 2.  In the `manifest.yml`
 3.  Using the `cf scale` command
 
-When you scale your app by running multiple instances, cloud.gov attempts to schedule those instances across availability zones to maximize your app's resiliency.
+When you scale your app by running multiple instances, cloud.gov schedules those instances across availability zones to maximize your app's resiliency. cloud.gov also load-balances access from users by default, so you should set up your instances to share session data (for example using [Redis]({{< relref "docs/services/redis28.md" >}})) to avoid unexpected behavior.
 
-#### Push Command Method
-When pushing an app use the `-i` flag to declare the number of instances. The example below demonstrates pushing an app with 2 instances.
+#### Push command method
+
+When pushing an app, use the `-i` flag to declare the number of instances. The example below demonstrates pushing an app with 2 instances:
 ```bash
 cf push <<APP_NAME>> -i 2
 ```
 
-#### Manifest Method
-The number of instances can also be defined using the `instances` key in the `manifest.yml`.
+#### Manifest method
+
+You can also define the number of instances using the `instances` key in the `manifest.yml`:
 ```yaml
 memory: 512mb
 instances: 2
@@ -30,16 +32,18 @@ applications:
     path: .
 ```
 
-#### Scale Command Method
-The number of instances can be changed for a running app using the [cf-scale](http://docs.cloudfoundry.org/devguide/deploy-apps/cf-scale.html) command.
+#### Scale command method
+
+You can change the number of instances for a running app using the [cf-scale](http://docs.cloudfoundry.org/devguide/deploy-apps/cf-scale.html) command:
 ```bash
 cf scale <<APP_NAME>> -i 2
 ```
 
-#### Managing Multiple Instances with [CF-INSTANCE-INDEX](http://docs.run.pivotal.io/devguide/deploy-apps/environment-variable.html#CF-INSTANCE-INDEX)
-Running multiple instances may sometimes cause scheduled tasks or a data loads to run multiple times. This issues can be prevented by using the [CF-INSTANCE-INDEX](http://docs.run.pivotal.io/devguide/deploy-apps/environment-variable.html#CF-INSTANCE-INDEX) environment variable. This variable denotes the specific instance number.
+#### Managing multiple instances with [CF-INSTANCE-INDEX](http://docs.run.pivotal.io/devguide/deploy-apps/environment-variable.html#CF-INSTANCE-INDEX)
 
-The example below shows a bash load script for a Python project. The commands within the `if` condition are only run when the first app instances is starting.
+Running multiple instances may sometimes cause scheduled tasks or data loads to run multiple times. This issue can be prevented by using the [CF-INSTANCE-INDEX](http://docs.run.pivotal.io/devguide/deploy-apps/environment-variable.html#CF-INSTANCE-INDEX) environment variable. This variable denotes the specific instance number.
+
+The example below shows a bash load script for a Python project. The commands within the `if` condition are only run when the first app instance is starting.
 
 ```bash
 #!/bin/bash

--- a/content/docs/apps/production-ready.md
+++ b/content/docs/apps/production-ready.md
@@ -2,7 +2,7 @@
 menu:
   docs:
     parent: apps
-title: Production ready guide
+title: Production-ready guide
 weight: -90
 ---
 
@@ -15,11 +15,11 @@ To build consistent, healthy, production-ready applications on cloud.gov, incorp
 To ensure consistency and reproducibility, capture your application configuration in version control.
 
 #### How
-* Write an [application manifest](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) that defines your application configuration, such as the application name, or what previously created services to use.
+* Write an [application manifest](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) that defines your application configuration, such as the application name and the previously-created services to use.
 
 ### More than one instance
 It is critical that your production application has more than one instance. Then if
-there are any issues with one of the platform runners where your app instances are assigned, your app will continue to function correctly.
+there are any issues with one of the platform runners where your app instances are assigned, or we upgrade platform components underneath an instance, your app will continue to function correctly (with less risk of downtime).
 
 #### How
 * See [multiple instances]({{< relref "multiple-instances.md" >}}).


### PR DESCRIPTION
* Explain on multiple instances page that you should set up a way to share session data between instances ([to help prevent this kind of problem](https://cloudgov.statuspage.io/incidents/xy5tjhhl7f7y))
* Note in production-ready guide that setting up multiple instances helps prevent downtime/errors caused by platform updates

cc @adborden @jmcarp 