### PR TITLE
Update CDN copy and apps.cloud.gov domain references

### DIFF
--- a/content/docs/apps/custom-domains.md
+++ b/content/docs/apps/custom-domains.md
@@ -81,11 +81,11 @@ cloud.gov offers a managed service that allows you to forward a domain you contr
     $ cf target -o <org> -s <space>
     ```
 
-1. Create a service instance. Replace *my-app.apps.cloud.gov* with the  domain that has been automatically assigned to your app by cloud.gov.
+1. Create a service instance. Replace *my-app.app.cloud.gov* with the  domain that has been automatically assigned to your app by cloud.gov.
 
     ```
     $ cf create-service cdn-route cdn-route my-cdn-route \
-        -c '{"domain": "my.domain.gov", "origin": "my-app.fr.cloud.gov"}'
+        -c '{"domain": "my.domain.gov", "origin": "my-app.app.cloud.gov"}'
 
     Create in progress. Use 'cf services' or 'cf service my-cdn-route' to check operation status.
     ```
@@ -94,7 +94,7 @@ cloud.gov offers a managed service that allows you to forward a domain you contr
 
     ```
     $ cf create-service cdn-route cdn-route my-cdn-route \
-        -c '{"domain": "my.domain.gov,www.my.domain.gov", "origin": "my-app.fr.cloud.gov"}'
+        -c '{"domain": "my.domain.gov,www.my.domain.gov", "origin": "my-app.app.cloud.gov"}'
 
     Create in progress. Use 'cf services' or 'cf service my-cdn-route' to check operation status.
     ```

--- a/content/docs/apps/experimental/experimental-services.md
+++ b/content/docs/apps/experimental/experimental-services.md
@@ -51,7 +51,7 @@ To use it, first create an instance:
 
 Then bind it to a route:
 
-`cf bind-route-service apps.cloud.gov authy --hostname hello`
+`cf bind-route-service app.cloud.gov authy --hostname hello`
 
 After that, your apps will require cloud.gov authentication before proceeding.
 {{% /govcloud %}}

--- a/content/docs/services/cdn-route.md
+++ b/content/docs/services/cdn-route.md
@@ -8,7 +8,7 @@ description: "Custom routes with HTTPS certificates using Amazon CloudFront"
 status: "Production Ready"
 ---
 
-Once your application is ready to move to production you will want a custom URL for it instead of the default cloud.gov one. The CDN Route service provides 3 key elements to support production applications: custom URL, Content Distribution Network (CDN) caching, and free TLS certificates with auto renewal.
+Once your application is ready to move to production, you'll want a custom domain instead of the default cloud.gov one. The CDN Route service provides three key elements to support production applications: a custom domain, Content Distribution Network (CDN) caching, and TLS certificates with auto renewal.
 
 ## Plans
 
@@ -27,16 +27,16 @@ Name | Required | Description | Default
 
 ## How to create an instance
 
-To create a service instance run the following command:
+To create a service instance, run the following command:
 
 ```bash
 cf create-service cdn-route cdn-route my-cdn-route \
-    -c '{"domain": "my.domain.gov", "origin": "my-app.apps.cloud.gov"}'
+    -c '{"domain": "my.domain.gov", "origin": "my-app.app.cloud.gov"}'
 ```
 
 ### How to set up DNS
 
-Once you created the service instance you need to retrieve the instructions to set up your DNS. To do that you need to run the following command, replacing `my-cdn-route` with the service instance name you used in the previous step.
+Once you create the service instance, you need to retrieve the instructions to set up your DNS. Run the following command, replacing `my-cdn-route` with the service instance name you used in the previous step.
 
 ```bash
 $ cf service my-cdn-route
@@ -48,15 +48,15 @@ Message: Provisioning in progress; CNAME domain "my.domain.gov" to "d3kajwa62y9x
 
 In this case, you need to create a CNAME record in your DNS server pointing `my.domain.gov` to `d3kajwa62y9xrp.cloudfront.net.`.
 
-After the record is created, wait up to 30 minutes for the CloudFront distribution to be provisioned and the DNS changes to propagate. Then visit your custom URL, and see that you have a valid certificate (i.e. that visiting your site in a modern browser doesn't give you a certificate warning).
+After the record is created, wait up to 30 minutes for the CloudFront distribution to be provisioned and the DNS changes to propagate. Then visit your custom domain and see whether you have a valid certificate (in other words, that visiting your site in a modern browser doesn't give you a certificate warning).
 
 ## How to update an instance
 
-To update a service instance run the following command:
+To update a service instance, run the following command:
 
 ```bash
 cf update-service my-cdn-route \
-    -c '{"domain": "my.domain.gov", "origin": "my-app.apps.cloud.gov"}'
+    -c '{"domain": "my.domain.gov", "origin": "my-app.app.cloud.gov"}'
 ```
 
 *Replace `my-cdn-route` with the service instance name.*
@@ -72,7 +72,7 @@ shows the old content after the DNS changes propagate.
 ### When to update the DNS
 
 You only need to add a CNAME entry when the `domain`
-field is updated. Refer to the [instructions above](/docs/services/cdn-route/#how-to-set-up-dns) for guidance.
+field is updated. Refer to ["How to set up DNS"](#how-to-set-up-dns) for guidance.
 
 ### The broker in GitHub
 

--- a/content/overview/pricing/rates.md
+++ b/content/overview/pricing/rates.md
@@ -24,7 +24,7 @@ Packages are selected based on the kinds of applications to be hosted. [Find mor
 | Package | What's included? | Base annual fee\* | Application resource usage | Managed services available |
 | --- | --- | --- | --- | --- |
 | **Sandbox** | Any user with a `.gov` or `.mil` email address can try out cloud.gov, no paperwork required. **Application resource usage is capped at 1GB.** | Free | Free | Only free services |
-| **Prototyping** | Suitable for many teams to deploy apps, though limited to the `*.apps.cloud.gov` domain. Access control can be delegated to teams. No production data allowed. Usually purchased per agency/department. | $15K |  ~$99/GB/month | All\** |
+| **Prototyping** | Suitable for many teams to deploy apps, though limited to the `*.app.cloud.gov` domain. Access control can be delegated to teams. No production data allowed. Usually purchased per agency/department. | $15K |  ~$99/GB/month | All\** |
 | **Open Data** | One public-facing Open Data (no confidentiality risk assessed) system, including all the spaces needed and DNS support. **This account is limited to 2GB of memory usage per month.** | $10K | ~$99/GB/month | All\** (up to $2500/year) |
 | **FISMA Low** | One public-facing FISMA Low system, including all the spaces needed and DNS support. | $20K | ~$99/GB/month | All\** |
 | **FISMA Moderate** | One public-facing FISMA Moderate system, including all the spaces needed and DNS support. Additional support for FISMA Moderate data requirements. | $90K | ~$99/GB/month | All\** |


### PR DESCRIPTION
Changes:

* On the CDN route service page, clarify description of the service - for example, that it's about domains and not URLs.
* On several pages including the CDN service page, update sample references like `my-app.fr.cloud.gov` and `my-app.apps.cloud.gov` to `my-app.app.cloud.gov` to reflect our current setup.