### PR TITLE
Add back "Edit this page" buttons to docs and overview

### DIFF
--- a/layouts/partials/docs-menu.html
+++ b/layouts/partials/docs-menu.html
@@ -48,6 +48,9 @@
             <li>
               <a href="/docs/help/"><i class='fa fa-fw fa-life-ring'></i> <span>Help</span></a>
             </li>
+            {{ if .IsPage }}
+            {{ $File := .File }}  {{with $File.Path }}<li><a href="https://github.com/18f/cg-site/edit/master/content/{{ $File.Dir }}{{ $File.LogicalName }}" target="blank"><i class='fa fa-edit fa-fw'></i> Edit this page</a> </li>{{end}}
+            {{ end }}
             
   </ul>
 </aside>

--- a/layouts/partials/overview-menu.html
+++ b/layouts/partials/overview-menu.html
@@ -45,6 +45,9 @@
               </a>
             </li>
             {{end}}
+            {{ if .IsPage }}
+            {{ $File := .File }}  {{with $File.Path }}<li><a href="https://github.com/18f/cg-site/edit/master/content/{{ $File.Dir }}{{ $File.LogicalName }}" target="blank"><i class='fa fa-edit fa-fw'></i> Edit this page</a> </li>{{end}}
+            {{ end }}
             
   </ul>
 </aside>


### PR DESCRIPTION
These were removed in the PR at https://github.com/18F/cg-site/pull/659 - we still want them, so I put them back. I updated "Refine this Page" to "Edit this page" for plain language and sentence case. I tested this locally, and it seems to work!

cc @line47 and @mogul