### PR TITLE
Add link to blog posts from top of Updates page

### DIFF
--- a/layouts/section/updates.html
+++ b/layouts/section/updates.html
@@ -10,6 +10,7 @@
   <div class="header-view">
     <div class="usa-grid">
       <h1>Updates</h1>
+      <p>For blog posts, see <a href="https://18f.gsa.gov/tags/cloud-gov/">cloud.gov on the 18F blog</a>.</p>
     </div>
   </div>
   <div class="usa-grid">


### PR DESCRIPTION
The PR at https://github.com/18F/cg-site/pull/687 will remove the 18F blog link from the footer, which was a bit of an odd place for it. Here's a different place for it - at the top of the Updates page, which is probably where people would look for it.

![screen shot 2017-01-04 at 4 08 52 pm](https://cloud.githubusercontent.com/assets/391313/21663916/0bec0cd0-d298-11e6-91bf-f864cd50a8f8.png)

cc @msecret 