### PR TITLE
Sync help page with homepage contact section

### DIFF
--- a/content/docs/help.md
+++ b/content/docs/help.md
@@ -7,13 +7,15 @@ aliases:
 
 ### I'm interested in using cloud.gov.
 
-Fill out our [contact form](/#contact) for notification when access is widely available.
+Start with our [intake form](https://docs.google.com/forms/d/e/1FAIpQLSevZfuJ_4KE-MZlm9gttYfsXQp0PJL7OR6k6LbZ9XnFn-oA6g/viewform) to tell us a bit about your organization and applications</a>. This will help us move more quickly and provide you the most relevant information about cloud.gov. We’ll get in touch to schedule a call where we can go over needs, options, and questions.
 
-You can also email [cloud-gov-inquiries@gsa.gov](mailto:cloud-gov-inquiries@gsa.gov) to learn more, including to request a [free sandbox account]({{< relref "overview/pricing/rates.md" >}}) (available to anyone with .gov or .mil email).
+You can also email [cloud-gov-inquiries@gsa.gov](mailto:cloud-gov-inquiries@gsa.gov) to learn more, including to request a [free sandbox account]({{< relref "overview/pricing/rates.md" >}}) (available to anyone with a .gov or .mil email address).
+
+If you'd like to get updates about cloud.gov, [sign up here](/#updates) for emails about new services, features, or requirements.
 
 ### I have a cloud.gov account and need help.
 
-Email [cloud-gov-support@gsa.gov](mailto:cloud-gov-support@gsa.gov). We provide support for cloud.gov during typical business hours for the East and West coasts of the U.S. We don't guarantee support for cloud.gov outside those hours, though we're always monitoring for signs of trouble that might affect customers.
+Email [cloud-gov-support@gsa.gov](mailto:cloud-gov-support@gsa.gov). We provide support for cloud.gov during typical business hours for U.S. East and West Coasts. We don't guarantee support for cloud.gov outside those hours, though we're always monitoring for signs of trouble that might affect customers.
 
 ### I'm 18F staff and need help.
 
@@ -25,4 +27,4 @@ Talk to us in [#cloud-gov-support](https://gsa-tts.slack.com/messages/cloud-gov-
 
 ### I'm interested in working on cloud.gov.
 
-Check out [18F's jobs site](https://pages.18f.gov/joining-18f/), and come talk to us in [our #devops-public Slack channel](https://chat.18f.gov/?channel=devops-public).
+Check out [18F's jobs site](https://pages.18f.gov/joining-18f/), and come talk to us in [our DevOps chat channel](https://chat.18f.gov/).

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -14,12 +14,12 @@
     <p>There are a number of <a href="/docs/help/">ways to get in touch</a>, depending on
       what you need.</p>
 
-    <h2>Get updates</h2>
+    <h2 id="updates">Get updates</h2>
     <p>Sign up for updates about cloud.gov, including information about new services, features, or requirements.</p>
-    <form action="//gsa.us9.list-manage.com/subscribe/post?u=6f1977de9eff4c384dc8d6527&amp;id=ab90bdad59" method="post" id="contact" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+    <form action="//gsa.us9.list-manage.com/subscribe/post?u=6f1977de9eff4c384dc8d6527&amp;id=ab90bdad59" method="post" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
       <fieldset>
         <div class="text_block">
-          <label for="mce-EMAIL">Email Address </label>
+          <label for="mce-EMAIL">Email address </label>
           <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
         <label for="mce-FUNCTION">Function </label>
         <select name="FUNCTION" style="line-height: 130%; font-size: 1rem; padding: 0.7rem;" id="mce-FUNCTION">


### PR DESCRIPTION
Changes to help page:

* Update the "I'm interested in using cloud.gov" section of the help page to match the homepage contact section better, including starting with the intake form.
* Clarify phrasing on help page and update the note about chat to match chat.18f.gov.

Changes to homepage:

* We had an `id` and a `name` that were both "contact", which made https://cloud.gov/#contact go to the updates form instead of the whole contact section, so I fixed it to go to the whole contact section.
* I added an `id` for the updates form, so that https://cloud.gov/#updates will go there.