### PR TITLE
Remove outdated alpha note from header of site

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,7 +4,6 @@
     <span class="usa-disclaimer-official">An official website of the United States government
       <img alt="US flag signifying that this is a United States federal government website" src="/assets/img/us_flag_small.png">
     </span>
-    <span class="usa-disclaimer-stage">This site is currently in alpha. <a href="https://18f.gsa.gov/dashboard/stages/#alpha">Learn more.</a></span>
   </div>
 </div>
 <header class="header">


### PR DESCRIPTION
The definition at https://18f.gsa.gov/dashboard/stages/#alpha no longer applies, and "beta" doesn't really either, so here's a PR to remove that bit of the website header. The left-aligned "official website" note matches the other ones on 18F websites (such as https://18f.gsa.gov/); no need to change that part.