### PR TITLE
Make help page and login info easier to navigate for new users

### DIFF
--- a/content/docs/getting-started/accounts.md
+++ b/content/docs/getting-started/accounts.md
@@ -17,24 +17,21 @@ weight: -100
 
 ### Agency single-sign-on accounts
 
-If you have a GSA, EPA, or FDIC email address, you'll sign into cloud.gov using your agency credentials. When you log in using the web UI (dashboard), click the button labeled with your agency name.
-
-Follow [these instructions to log in on the command line (CLI) and web UI (dashboard)]({{< relref "setup.md" >}}).
+If you have a GSA, EPA, or FDIC email address, you'll sign into cloud.gov using your agency credentials. Follow [these instructions to log in on the command line (CLI) and web UI (dashboard)]({{< relref "setup.md" >}}).
 
 ### cloud.gov accounts
 
 If you were invited with an email address that isn't part of an agency with single-sign-on authentication to cloud.gov, you have a cloud.gov account.
 
 {{% govcloud %}}
-Your cloud.gov account requires multi-factor authentication. To log into the system, you need two "factors" -- something you know (your password) and something you have on your person (your smartphone).
 
 Follow [these instructions to log in on the command line (CLI) and web UI (dashboard)]({{< relref "setup.md" >}}). When you log in to cloud.gov via a web browser, select the `cloud.gov` provider as shown here:
 
 ![cloud.gov provider button on login page highlighted in blue](/img/cloud-gov-idp-button-cropped.png "cloud.gov provider button to login page is highlighted in blue")
 
-##### Managing MFA / TOTP with authentication applications
+Your cloud.gov account requires multi-factor authentication. To log into the system, you need two "factors" -- something you know (your password) and something you have on your person (your smartphone).
 
-In order to perform multi-factor authentication with the `cloud.gov` provider, you need an authentication application that generates time-based one-time passwords. We recommend [Google Authenticator](https://support.google.com/accounts/answer/1066447?hl=en) or [Authy](https://www.authy.com/app/mobile). Download the app on your mobile device. When you log into cloud.gov for the first time, follow the instructions to store the `cloud.gov` key in your application.
+In order to perform multi-factor authentication, you need an authentication application that generates time-based one-time passcodes. We recommend [Google Authenticator](https://support.google.com/accounts/answer/1066447?hl=en) or [Authy](https://www.authy.com/app/mobile). Download the app on your mobile device. When you log into cloud.gov for the first time, follow the instructions to store the `cloud.gov` key in your application.
 {{% /govcloud %}}
 
 {{% eastwest %}}

--- a/content/docs/getting-started/setup.md
+++ b/content/docs/getting-started/setup.md
@@ -2,35 +2,33 @@
 menu:
   docs:
     parent: getting-started
-title: Setup
+title: Set up cloud.gov and log in
 weight: -50
 ---
 
-You can work with cloud.gov in two ways: the command line (CLI) with full features, and the web user interface (dashboard) with quick access to common tasks.
-
-You need [an account]({{< relref "accounts.md" >}}) before you can get started with this.
+You need [an account]({{< relref "accounts.md" >}}) before you can get started with this. Then you can log into cloud.gov in two ways: the command line (CLI) with full features, and the web user interface (dashboard) with quick access to common tasks.
 
 ## Set up the command line
 
 1. [Install the Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/installcf/install-go-cli.html). (cloud.gov is based on Cloud Foundry.)
-1. Confirm the installation by running
+1. Confirm the installation by running `cf -v` -- this should return a version number.
 
-    ```bash
-    cf -v
-    ```
-    
-    This should return a version number.
-
-1. Log in with a command as explained below:
+1. Log in with a command as explained below. Select the East/West or GovCloud instructions based on where your applications are located. If you're not sure which environment to select, ask a teammate or [ask support]({{< relref "docs/help.md" >}}).
 
 {{% eastwest %}}
-**If you log in using your agency's account system:** run `cf login -a api.cloud.gov --sso` -- then follow the link to get your one-time authentication code and enter it to log in.
+**If you're at GSA or EPA and you log in with your agency account:** 
+
+Run `cf login -a api.cloud.gov --sso`
+
+Then follow the link to get your one-time authentication code and enter it.
     
 **If you log in with a cloud.gov account that has its own password** (including `ORGNAME_deployer` accounts): run `cf login -a api.cloud.gov`
 {{% /eastwest %}}
 
 {{% govcloud %}}
-**All accounts:** run `cf login -a api.fr.cloud.gov --sso` -- then follow the link to get your one-time authentication code and enter it to log in.
+Run `cf login -a api.fr.cloud.gov --sso` 
+
+Then follow the link to get your one-time authentication code and enter it.
 {{% /govcloud %}}
 
 
@@ -44,6 +42,8 @@ Visit your dashboard! It's probably a little empty since you probably haven't de
 
 {{% govcloud %}}
 [`https://dashboard.fr.cloud.gov/`](https://dashboard.fr.cloud.gov/)
+
+Tip: the `fr` in this URL indicates the GovCloud environment.
 {{% /govcloud %}}
 
 ## Play around in your "sandbox"

--- a/content/docs/help.md
+++ b/content/docs/help.md
@@ -1,30 +1,26 @@
 ---
-title: Help
+title: Contact
 aliases:
   - /help
   - /contact
 ---
 
-### I'm interested in using cloud.gov.
+### Want to use cloud.gov?
 
-Start with our [intake form](https://docs.google.com/forms/d/e/1FAIpQLSevZfuJ_4KE-MZlm9gttYfsXQp0PJL7OR6k6LbZ9XnFn-oA6g/viewform) to tell us a bit about your organization and applications</a>. This will help us move more quickly and provide you the most relevant information about cloud.gov. We’ll get in touch to schedule a call where we can go over needs, options, and questions.
+Start with our [intake form](https://docs.google.com/forms/d/e/1FAIpQLSevZfuJ_4KE-MZlm9gttYfsXQp0PJL7OR6k6LbZ9XnFn-oA6g/viewform) to tell us about your organization and applications</a>. We’ll schedule a call where we can go over needs, options, and questions. You can also email [cloud-gov-inquiries@gsa.gov](mailto:cloud-gov-inquiries@gsa.gov), including to request a [free sandbox account]({{< relref "overview/pricing/rates.md" >}}) (available to anyone with a .gov or .mil email address).
 
-You can also email [cloud-gov-inquiries@gsa.gov](mailto:cloud-gov-inquiries@gsa.gov) to learn more, including to request a [free sandbox account]({{< relref "overview/pricing/rates.md" >}}) (available to anyone with a .gov or .mil email address).
+To get news about cloud.gov, [sign up for email updates](/#updates).
 
-If you'd like to get updates about cloud.gov, [sign up here](/#updates) for emails about new services, features, or requirements.
-
-### I have a cloud.gov account and need help.
+### Support for people who use cloud.gov
 
 Email [cloud-gov-support@gsa.gov](mailto:cloud-gov-support@gsa.gov). We provide support for cloud.gov during typical business hours for U.S. East and West Coasts. We don't guarantee support for cloud.gov outside those hours, though we're always monitoring for signs of trouble that might affect customers.
 
-### I'm 18F staff and need help.
+(If you're TTS/18F staff, you can also talk to us in [#cloud-gov-support](https://gsa-tts.slack.com/messages/cloud-gov-support).)
 
-Talk to us in [#cloud-gov-support](https://gsa-tts.slack.com/messages/cloud-gov-support).
+### Do you have a suggestion for this site?
 
-### I found a problem or want to suggest an improvement in the documentation.
+This is an open source website, and we welcome your ideas and corrections for the documentation and other content here. [Open an issue on GitHub.](https://github.com/18F/cg-site/issues/new) (Requires a free GitHub account.)
 
-[Open an issue on GitHub](https://github.com/18F/cg-site/issues/new).
+### Are you interested in working on cloud.gov?
 
-### I'm interested in working on cloud.gov.
-
-Check out [18F's jobs site](https://pages.18f.gov/joining-18f/), and come talk to us in [our DevOps chat channel](https://chat.18f.gov/).
+Check out [Joining 18F](https://pages.18f.gov/joining-18f/), and talk to us in [18F's public DevOps chat channel](https://chat.18f.gov/).


### PR DESCRIPTION
Here are a few changes to try to help newcomers get started more smoothly.

Changes to login info:
* Trim redundant words in the Account page, so that people get to the meat faster.
* Make instructions on Setup page more explicit.

Changes to help page:
* Change title to "Contact", since the page content is broader than "Help".
* Shorten the first inquiries section so that users who need help see the support email address faster.
* Be consistent about speaking to the reader as "you" (not switching between "I" and "you").