### PR TITLE
Add info about vulnerability disclosure policy to site

### DIFF
--- a/content/docs/ops/repos.md
+++ b/content/docs/ops/repos.md
@@ -9,7 +9,11 @@ aliases:
   - /intro/security/auditing-contributing-security
 ---
 
-cloud.gov is built and maintained by 18F, which has an [open source policy](https://18f.gsa.gov/open-source-policy/) that guides our work: we use and develop open source software, and we encourage you to reuse and adapt our work. cloud.gov is an open source project based on [Cloud Foundry](https://www.cloudfoundry.org/) with additional components built by our team and other community members. We welcome you to audit our security or contribute to it — or to make any other kind of contribution, from documentation to design.
+cloud.gov is built and maintained by 18F, which has an [open source policy](https://18f.gsa.gov/open-source-policy/) that guides our work: we use and develop open source software, and we encourage you to reuse and adapt our work.
+
+cloud.gov is an open source project based on [Cloud Foundry](https://www.cloudfoundry.org/) with additional components built by our team and other community members. We welcome you to audit our security or contribute to it — or to make any other kind of contribution, from documentation to design.
+
+If you'd like to contribute security research, see our [vulnerability disclosure policy](https://18f.gsa.gov/vulnerability-disclosure-policy/).
 
 If you're interested in contributing to cloud.gov but not sure where to start, or if you have questions about contributing, feel free to join the [18F DevOps or open source chat channels](https://chat.18f.gov/) and explain your question. You can also open an issue with your question in a relevant repository.
 

--- a/content/docs/ops/security-ir.md
+++ b/content/docs/ops/security-ir.md
@@ -10,7 +10,7 @@ This document outlines cloud.gov's internal process for responding to security i
 
 *If you're responding to an incident, [here's our IR checklist]({{< relref "security-ir-checklist.md" >}}) as a short, actionable companion to this guide.*
 
-(If you're outside 18F: if you notice something that may be a security problem, please email <a href="mailto:cloud-gov-support@gsa.gov">cloud-gov-support@gsa.gov</a>. Thanks!)
+(If you're a member of the public who has noticed something in cloud.gov that may be a security problem, please see [our vulnerability disclosure policy and reporting process](https://18f.gsa.gov/vulnerability-disclosure-policy/). As it explains, we want security researchers to feel comfortable reporting vulnerabilities they’ve discovered, as set out in that policy, so that we can fix them and keep our information safe.)
 
 ## Overview
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,13 +2,13 @@
     <section class="grid-width-6">
       <ul class="footer-links">
         <li>
-          <a href="https://cloud.gov">cloud.gov home</a>
+          <a href="/">cloud.gov home</a>
         </li>
         <li>
-          <a href="https://cloud.gov/docs/help/">Contact</a>
+          <a href="/docs/help/">Contact</a>
         </li>
         <li>
-          <a href="https://cloud.gov/docs/ops/repos/">Contribute to cloud.gov</a>
+          <a href="https://18f.gsa.gov">Built and maintained by 18F</a>
         </li>
       </ul>
     </section>
@@ -18,10 +18,10 @@
           A United States government platform
         </li>
         <li>
-          <a href="https://cloud.gov/docs/ops/repos/">Open source</a> and in the public domain
+          <a href="/docs/ops/repos/">Open source and in the public domain</a>
         </li>
         <li>
-          Built and maintained by <a href="https://18f.gsa.gov">18F</a>
+          <a href="https://18f.gsa.gov/vulnerability-disclosure-policy/">Vulnerability disclosure policy</a>
         </li>
       </ul>
     </section>


### PR DESCRIPTION
**Update** - ready to review and merge.

We're in the official policy at https://github.com/18F/vulnerability-disclosure-policy/blob/master/vulnerability-disclosure-policy.md but it should be copied to https://18f.gsa.gov/vulnerability-disclosure-policy/ for nice formatting before we link it. (Waiting on the PR at https://github.com/18F/18f.gsa.gov/pull/2253)

This updates the footer, open source contributing page, and IR guide to guide people to our vulnerability disclosure policy. The footer previously had two similar links to the repos page, so I replaced one with a link to this policy.

New footer:
![screen shot 2017-02-02 at 3 47 34 pm](https://cloud.githubusercontent.com/assets/391313/22573674/f468a086-e95e-11e6-85b9-968ce0249aa7.png)

Old footer:
![screen shot 2017-02-02 at 3 48 00 pm](https://cloud.githubusercontent.com/assets/391313/22573691/01b8173a-e95f-11e6-82fa-b5ce9bdcff77.png)

FYI the dashboard footer will become out of sync if this gets merged - I didn't put in a PR there since https://github.com/18F/cg-dashboard/blob/master/static_src/skins/cg/index.js is a bit more complex to change than just rearranging list items. I noted this in #cloud-gov-navigator so the dashboard squad can assess the best way to change this. :)