### PR TITLE
Revise setup info and "your first deploy" for easier reading

### DIFF
--- a/content/docs/getting-started/setup.md
+++ b/content/docs/getting-started/setup.md
@@ -6,14 +6,14 @@ title: Set up cloud.gov and log in
 weight: -50
 ---
 
-You need [an account]({{< relref "accounts.md" >}}) before you can get started with this. Then you can log into cloud.gov in two ways: the command line (CLI) with full features, and the web user interface (dashboard) with quick access to common tasks.
+You need [an account]({{< relref "accounts.md" >}}) before you can log in. Then you can log into cloud.gov in the following ways.
 
 ## Set up the command line
 
-cloud.gov is based on Cloud Foundry.
+cloud.gov is based on Cloud Foundry, so cloud.gov uses the Cloud Foundry command line interface (CLI) to give you full access to cloud.gov.
 
-1. Install the Cloud Foundry CLI using the installer for your system: [Windows](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#windows) / [Mac OS X](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#mac) / [Linux](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#linux) 
-  - If your organization restrictions the use of the installer, you can [download the CLI binary and install it manually](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#bin).
+1. Install the Cloud Foundry CLI using the installer for your system: [Windows](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#windows), [Mac OS X](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#mac), or [Linux](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#linux).
+  - If your organization restricts the use of the installer, you can [download the CLI binary and install it manually](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#bin).
 1. Confirm the installation by running `cf -v` -- this should return a version number.
 
 1. Log in with a command as explained below. Select the East/West or GovCloud instructions based on where your spaces are located. If you're not sure which environment to select, GovCloud is the main environment for new sandbox accounts and new teams. You can also ask a teammate or [ask support]({{< relref "docs/help.md" >}}).
@@ -39,7 +39,9 @@ Then it'll say `One Time Code ( Get one at `[`https://login.fr.cloud.gov/passcod
 
 ## Check out the dashboard
 
-Visit your dashboard! It's probably a little empty since you probably haven't deployed any applications yet, but it's good to know it exists:
+cloud.gov also has a dashboard that gives you easy web-based access to common tasks.
+
+Try visiting your dashboard! It's probably a little empty since you probably haven't deployed any applications yet, but it's good to know it exists:
 
 {{% eastwest %}}
 [`https://dashboard.cloud.gov/`](https://dashboard.cloud.gov/)

--- a/content/docs/getting-started/setup.md
+++ b/content/docs/getting-started/setup.md
@@ -6,11 +6,11 @@ title: Set up cloud.gov and log in
 weight: -50
 ---
 
-You need [an account]({{< relref "accounts.md" >}}) before you can log in. Then you can log into cloud.gov in the following ways.
+First get [an account]({{< relref "accounts.md" >}}), and then you can log into cloud.gov in the following ways -- command line and dashboard (web interface).
 
 ## Set up the command line
 
-cloud.gov is based on Cloud Foundry, so cloud.gov uses the Cloud Foundry command line interface (CLI) to give you full access to cloud.gov.
+cloud.gov is based on the Cloud Foundry open source project, so cloud.gov uses the Cloud Foundry command line interface (CLI) to give you full access to cloud.gov.
 
 1. Install the Cloud Foundry CLI using the installer for your system: [Windows](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#windows), [Mac OS X](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#mac), or [Linux](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#linux).
   - If your organization restricts the use of the installer, you can [download the CLI binary and install it manually](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#bin).
@@ -55,7 +55,7 @@ Tip: the `fr` in this URL indicates the GovCloud environment.
 
 ## Play around in your "sandbox"
 
-Here's how to deploy a test app in your sandbox for practice. (Note that **if you log in immediately after your account or organization was created,** you may not see any orgs or spaces to which you have access. Your sandbox space may take up to **5 minutes** to provision.)
+Here's how to deploy a test app in your sandbox for practice, using the CLI. (Note that **if you log in immediately after your account or organization was created,** you may not see any orgs or spaces to which you have access. Your sandbox space may take up to **5 minutes** to provision.)
 
 Start with the following `cf target` command:
 

--- a/content/docs/getting-started/your-first-deploy.md
+++ b/content/docs/getting-started/your-first-deploy.md
@@ -6,19 +6,22 @@ title: Your first deploy
 weight: -30
 ---
 
-cloud.gov is an instance of Cloud Foundry, so [the Cloud Foundry documentation](http://docs.cloudfoundry.org), Stack Overflow questions, etc. should mostly be applicable.
+To get used to cloud.gov, practice by deploying a simple "hello world" application using the cloud.gov command line interface (CLI).
 
-To get used to Cloud Foundry, we recommend that you practice by deploying a simple application before moving into deploying something for production.
+1. First, [go through account setup]({{< relref "setup.md" >}}) (if you haven't already), so that you're logged into the cloud.gov CLI and have targeted your sandbox.
+1. Visit [this collection of "hello world" applications (tiny sample applications)](https://github.com/18F/cf-hello-worlds) and use **Clone or download** to make a copy on your computer. (This is easiest if you have [git](https://git-scm.com/downloads) installed on your computer.) For example, if you use `git` on the command line, enter `git clone https://github.com/18F/cf-hello-worlds.git`
+1. Move into that directory, for example: `cd cf-hello-worlds`
+1. Deploy the application, where `APPNAME` should be something unique like `FRAMEWORK-YOURNAME` (e.g. `nodejs-aidan`). By default on cloud.gov, `APPNAME` is used to construct a route to make your application reachable at https://APPNAME.app.cloud.gov/. Route names must be unique across the platform.
 
 
-## Deploying
+    ```bash
+    cf push <APPNAME>
+    ```
 
-1. [Go through the setup.]({{< relref "setup.md" >}})
-1. [Deploy a "hello world" application.](https://github.com/18F/cf-hello-worlds#readme)
-1. Tweak the app (without committing) and re-`push`.
+1. Try editing the app locally (without committing) and run `cf push <APPNAME>` again to see your changes. The changes will be reflected in Cloud Foundry even without being committed to Git. Cloud Foundry is not Git-aware – it simply deploys whatever is contained in the directory that you `push` from. That being said, you _can_ set up [continuous deployment]({{< relref "docs/apps/continuous-deployment.md" >}}) from a Git repository.
 
-The changes will be reflected in Cloud Foundry even without being committed to Git. Cloud Foundry is not Git-aware – it simply deploys whatever is contained in the directory that you `push` from. That being said, you _can_ set up [continuous deployment]({{< relref "docs/apps/continuous-deployment.md" >}}) from a Git repository.
+1. If you're done, you can delete it by running `cf delete <APPNAME>`
 
-**Be tidy**: When you're done, please `cf delete <APPNAME>`. 
+Tip: cloud.gov is an instance of Cloud Foundry, so in general, the [the Cloud Foundry documentation](http://docs.cloudfoundry.org) and other Cloud Foundry resources online are mostly applicable to cloud.gov.
 
 Next, take a look at the [Concepts]({{< relref "concepts.md" >}}) page. Once you're ready to deploy your own application, head over to the [general deployment tips]({{< relref "docs/apps/deployment.md" >}}).


### PR DESCRIPTION
Changes:

* On setup page, move intro info about the CLI and dashboard into context in the CLI and dashboard sections.
* Copyedits for CLI setup steps (followup on https://github.com/18F/cg-site/pull/740).
* On "Your first deploy", consolidate the instructions so that people don't have to read both the readme and the docs page - they just have to read the docs page. Also add more context for less technical readers.