### PR TITLE
Change header dashboard E/W link to a login summary link

### DIFF
--- a/content/docs/getting-started/setup.md
+++ b/content/docs/getting-started/setup.md
@@ -73,3 +73,32 @@ cf target -o sandbox-gsa -s harry.truman
 ```
 
 Run your version of that command, and then follow [your first deploy]({{< relref "your-first-deploy.md" >}}).
+
+## Quick reference for login
+
+Here's a summary of how to log into cloud.gov. (See above for details.)
+
+Command line interface:
+
+{{% govcloud %}}
+
+Everyone: `cf login -a api.fr.cloud.gov --sso` 
+
+{{% /govcloud %}}
+
+{{% eastwest %}}
+GSA and EPA: `cf login -a api.cloud.gov --sso`
+
+Everyone else: `cf login -a api.cloud.gov`
+{{% /eastwest %}}
+
+
+Web interface (dashboard):
+
+{{% govcloud %}}
+[`https://dashboard.fr.cloud.gov/`](https://dashboard.fr.cloud.gov/)
+{{% /govcloud %}}
+
+{{% eastwest %}}
+[`https://dashboard.cloud.gov/`](https://dashboard.cloud.gov/)
+{{% /eastwest %}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -48,7 +48,7 @@
               <a href="https://cloudgov.statuspage.io/">Status</a>
             </li>
             <li class="nav-link">
-              <a href="https://dashboard.cloud.gov/">Dashboard</a>
+              <a href="/docs/getting-started/setup/#quick-reference">Log in</a>
             </li>
             <li class="nav-link">
               <a href="/docs/help/">Contact</a>


### PR DESCRIPTION
Changes:

* At the end of the setup page, add a quick summary of how to log into cloud.gov.
* The header currently has a link that says "Dashboard" that links to the E/W dashboard.cloud.gov. I changed this to "Log in" with a link to the quick summary of login info. This helps people find the right way to log in on both the command line and the web interface, instead of just directing them to one web interface.

This is awkward, but I'm hoping it's better than the current header link, which is likely confusing for people.