### PR TITLE
Fix for /updates layout regression

### DIFF
--- a/layouts/updates/li.html
+++ b/layouts/updates/li.html
@@ -1,5 +1,5 @@
 
-   <div class="usa-width-two-thirds usa-end-row panel-new content-text">
+   <div class="usa-width-two-thirds usa-end-row panel content-text">
       <span class="panel-new-date">{{ .Date.Format "January 2, 2006" }}</span>
       <h2><a class="link-textblack" href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
       {{ .Content }}

--- a/layouts/updates/single.html
+++ b/layouts/updates/single.html
@@ -15,7 +15,7 @@
 
     <main class="usa-content">
       <div class="usa-grid">
-        <div class="usa-width-two-thirds panel-new content-text">
+        <div class="usa-width-two-thirds panel content-text">
           <header class="post-header">
             <span class="panel-new-date">{{ .Date.Format "Jan 2, 2006" }}{{ if .Params.author }} • {{ .Params.author }}{{ end }}{{ if .Params.meta }} • {{ .Params.meta }}{{ end }}</span>
           </header>


### PR DESCRIPTION
Some cg-style work this week unexpectedly changed some layout on
the updates page. This is a fix for the strange spacing issues
between and above articles.

The fix is to change the `panel-new` class to just the `panel` class
as the `panel-new` class was deprecated and mistakenly removed in
cg-style. There isn't actually a large difference between the two classes,
just some spacing differences:

```
- .panel-new {
-   background-color: $color-white;
-   margin-top: $grid-4;
-   padding: $grid-4;
- }
```

```
.panel {
   background-color: $color-white;
   margin-bottom: $grid-4;
   padding: $grid-3 $grid-3 $grid-4;
}
```

I'm of the opinion that the difference between the two doesn't warrant
having a second class anyway.

Another change will have to come next week when the `panel-new-date`
class is removed from cg-style (expecting this change soon).

![image](https://cloud.githubusercontent.com/assets/1701077/22815162/5d5174b0-ef0e-11e6-98c4-cdf35ec9ba5c.png)


![image](https://cloud.githubusercontent.com/assets/1701077/22815171/6aa724fc-ef0e-11e6-9aa8-d619d000b0ce.png)
