### PR TITLE
Updating title so that header links to the right spot

### DIFF
--- a/content/docs/getting-started/setup.md
+++ b/content/docs/getting-started/setup.md
@@ -74,7 +74,9 @@ cf target -o sandbox-gsa -s harry.truman
 
 Run your version of that command, and then follow [your first deploy]({{< relref "your-first-deploy.md" >}}).
 
-## Quick reference for login
+## Quick reference
+
+<!-- If you change this section title, update /layouts/header.html as well, since this anchor is linked from the cloud.gov header -->
 
 Here's a summary of how to log into cloud.gov. (See above for details.)
 


### PR DESCRIPTION
The header links to https://cloud.gov/docs/getting-started/setup/#quick-reference so this should match (also added an HTML comment noting this for future reference, since amusingly I made this mistake already).