### PR TITLE
Attempt at defining "system" for readers of the rates page

### DIFF
--- a/content/overview/pricing/pricing-terminology.md
+++ b/content/overview/pricing/pricing-terminology.md
@@ -16,9 +16,11 @@ These terms, among others, define a number of products and services offered by c
 
 ### System
 
-A “System” roughly corresponds to a product or project team, including all the individual spaces, apps, and services necessary to realize their service, across as many environments as needed.
+A “system” roughly corresponds to a product or project team, including all the individual spaces, apps, and services necessary to deliver their product to users.
 
-A system maps to an [“org” in Cloud Foundry](http://docs.cloudfoundry.org/concepts/roles.html#orgs).
+A system maps to an [“org” in cloud.gov and Cloud Foundry](http://docs.cloudfoundry.org/concepts/roles.html#orgs).
+
+Recommendation: If your product needs Authority to Operate (ATO) from your agency, we recommend that your ATO system boundary should align with your cloud.gov system boundary. In other words, your cloud.gov org shouldn't contain two or more things that each need their own ATO, because that would make your compliance process harder. If you have a very complex system with multiple sub-systems, you may choose to build that with multiple cloud.gov orgs. For formal guidance on system boundaries, see [NIST Special Publication 800-18, section 2](http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-18r1.pdf).
 
 ### Support {#support}
 

--- a/content/overview/pricing/pricing-terminology.md
+++ b/content/overview/pricing/pricing-terminology.md
@@ -20,7 +20,7 @@ A “system” roughly corresponds to a product or project team, including all t
 
 A system maps to an [“org” in cloud.gov and Cloud Foundry](http://docs.cloudfoundry.org/concepts/roles.html#orgs).
 
-Recommendation: If your product needs Authority to Operate (ATO) from your agency, we recommend that your ATO system boundary should align with your cloud.gov system boundary. In other words, your cloud.gov org shouldn't contain two or more things that each need their own ATO, because that would make your compliance process harder. If you have a very complex system with multiple sub-systems, you may choose to build that with multiple cloud.gov orgs. For formal guidance on system boundaries, see [NIST Special Publication 800-18, section 2](http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-18r1.pdf).
+*Recommendation:* If your product needs Authority to Operate (ATO) from your agency, we suggest that your cloud.gov “system” should align with your ATO system boundary. (In other words, your cloud.gov org shouldn't contain two or more products that each need their own ATO, because that would make your compliance process more difficult.) If you have a very complex product with multiple sub-systems, you may choose to build that with multiple cloud.gov orgs/“systems”. For formal guidance on system boundaries, see [NIST Special Publication 800-18, section 2](http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-18r1.pdf).
 
 ### Support {#support}
 

--- a/content/overview/pricing/pricing-terminology.md
+++ b/content/overview/pricing/pricing-terminology.md
@@ -20,8 +20,6 @@ A “system” roughly corresponds to a product or project team, including all t
 
 A system maps to an [“org” in cloud.gov and Cloud Foundry](http://docs.cloudfoundry.org/concepts/roles.html#orgs).
 
-*Recommendation:* If your product needs Authority to Operate (ATO) from your agency, we suggest that your cloud.gov “system” should align with your ATO system boundary. (In other words, your cloud.gov org shouldn't contain two or more products that each need their own ATO, because that would make your compliance process more difficult.) If you have a very complex product with multiple sub-systems, you may choose to build that with multiple cloud.gov orgs/“systems”. For formal guidance on system boundaries, see [NIST Special Publication 800-18, section 2](http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-18r1.pdf).
-
 ### Support {#support}
 
 “Support” is support to use the platform as intended, on a best-effort basis. We have no existing service-level agreement. We plan to always publish metrics that give agencies the ability to make an informed choice about whether to use cloud.gov or an alternative PaaS solution based on our actual track record.

--- a/content/overview/pricing/rates.md
+++ b/content/overview/pricing/rates.md
@@ -9,15 +9,15 @@ aliases:
   - /intro/pricing/rates
 ---
 
-cloud.gov costs are broken into three components:
+When you purchase cloud.gov, your monthly cost is made of three components:
 
-- [Access package](#access-package)
-- [Resource usage quota](#resource-usage-quota)
-- [Managed services](#managed-services)
+- [**Access package**](#access-package)
+- [**Resource usage quota**](#resource-usage-quota)
+- [**Managed services**](#managed-services)
+
+The following sections explain the options and pricing for each component. The last section is a summary: [**a table of cost options**](#package-comparison-table).
 
 Agencies pay through [an Interagency Agreement (IAA) with 18F]({{< relref "overview/pricing/how-to-purchase.md" >}}).
-
-What follows is information about each pricing component, as well as a [table to help you compare](#package-comparison-table) the components across packages.
 
 ## Access package
 
@@ -29,11 +29,11 @@ These are the access package options:
 
 - **Prototyping:** Deploying demo applications with a cloud.gov domain, not for production. $15K per year.
 
-- **Open Data:** One system with no confidentiality risk assessed, with custom domain support included. $10K per year.
+- **Open Data:** One [system]({{< relref "overview/pricing/pricing-terminology.md#system" >}}) with no confidentiality risk assessed, with custom domain support included. $10K per year.
 
-- **FISMA Low:** One public-facing FISMA Low system, with custom domain support included. $20K per year.
+- **FISMA Low:** One public-facing FISMA Low [system]({{< relref "overview/pricing/pricing-terminology.md#system" >}}), with custom domain support included. $20K per year.
 
-- **FISMA Moderate:** One public-facing FISMA Moderate system, with custom domain support included. $90K per year.
+- **FISMA Moderate:** One public-facing FISMA Moderate [system]({{< relref "overview/pricing/pricing-terminology.md#system" >}}), with custom domain support included. $90K per year.
 
 See the [package comparison table](#package-comparison-table) below for more details about suitable uses for each package.
 

--- a/content/overview/pricing/rates.md
+++ b/content/overview/pricing/rates.md
@@ -67,9 +67,9 @@ All three pricing components are factored into every access package. Use this ta
 | --- | --- | --- | --- | --- |
 | **Sandbox** | Any user with a `.gov` or `.mil` email address can try out cloud.gov for a limited time with no paperwork required. | Free | Free, **capped at 1GB/month** | Only free services |
 | **Prototyping** | Suitable for many teams to deploy apps, though limited to the `*.app.cloud.gov` domain. Access control can be delegated to teams. No production data allowed. Usually purchased per agency/department. | $15K |  ~$99/GB/month | All\** |
-| **Open Data** | One public-facing Open Data (no confidentiality risk assessed) system, including all the spaces needed and DNS support. | $10K | ~$99/GB/month, **capped at 2GB/month** | All\** (up to $2500/year) |
-| **FISMA Low** | One public-facing FISMA Low system, including all the spaces needed and DNS support. | $20K | ~$99/GB/month | All\** |
-| **FISMA Moderate** | One public-facing FISMA Moderate system, including all the spaces needed and DNS support. Additional support for FISMA Moderate data requirements. | $90K | ~$99/GB/month | All\** |
+| **Open Data** | One public-facing Open Data (no confidentiality risk assessed) [system]({{< relref "overview/pricing/pricing-terminology.md#system" >}}), including all the spaces needed and DNS support. | $10K | ~$99/GB/month, **capped at 2GB/month** | All\** (up to $2500/year) |
+| **FISMA Low** | One public-facing FISMA Low [system]({{< relref "overview/pricing/pricing-terminology.md#system" >}}), including all the spaces needed and DNS support. | $20K | ~$99/GB/month | All\** |
+| **FISMA Moderate** | One public-facing FISMA Moderate [system]({{< relref "overview/pricing/pricing-terminology.md#system" >}}), including all the spaces needed and DNS support. Additional support for FISMA Moderate data requirements. | $90K | ~$99/GB/month | All\** |
 
 \*Access agreements are severable, and the access package fees are invoiced monthly.
 


### PR DESCRIPTION
A customer found the mention of "system" confusing on the rates page, so here's an effort at improving this.

Changes:

* Add links to the system definition from the rates page.
* Try to clarify the "System" definition on the terminology page with more user-centered language. 
* Add compliance info to "System" definition. This may make things _more confusing_ for readers who are working with prototyping orgs or who aren't very familiar with compliance, but it should be helpful for some readers.

For your amusement: I was tempted to go in depth with detailed references about how FISMA defines "information system", but the legal definition is very formal and probably not helpful for this specific context: *a discrete set of information resources organized for the collection, processing, maintenance, use, sharing, dissemination, or disposition of information*.