### PR TITLE
Update GovCloud migration process info for outside-TTS use

### DIFF
--- a/content/docs/apps/govcloud.md
+++ b/content/docs/apps/govcloud.md
@@ -56,13 +56,11 @@ GovCloud-specific information
 
 ### Migration
 
-_This section is a work in progress._
-
-As part of [cloud.gov achieving FedRAMP authorization](https://18f.gsa.gov/2016/07/18/cloud-gov-full-steam-ahead-fedramp-assessment-process/), all tenants in the AWS East/West will need to move to the new GovCloud environment.
+As part of [cloud.gov achieving FedRAMP authorization](https://18f.gsa.gov/2016/07/18/cloud-gov-full-steam-ahead-fedramp-assessment-process/), all tenants in the AWS East/West will need to move to the new GovCloud environment. **March 15th is the deadline** for moving to the new GovCloud environment.
 
 #### Who this affects
 
-Any systems running in the AWS East/West version of cloud.gov. To find all of the apps you have access to, visit https://dashboard.cloud.gov. All apps that aren't moved by [TODO] will be deleted, so make sure that you or someone on your team [coordinates]({{< relref "docs/help.md" >}}) with the cloud.gov team to ensure your migration is completed as smoothly as possible.
+Any systems running in the AWS East/West version of cloud.gov. To find all of the apps you have access to, visit https://dashboard.cloud.gov. All apps that aren't moved by March 15th **will be deleted,** so make sure that you or someone on your team [coordinates]({{< relref "docs/help.md" >}}) with the cloud.gov team to ensure your migration is completed as smoothly as possible.
 
 #### Costs
 

--- a/content/docs/apps/govcloud.md
+++ b/content/docs/apps/govcloud.md
@@ -84,7 +84,7 @@ Any labor involved from your project team is the responsibility of your project.
 1. [Get access to the GovCloud environment](https://account.fr.cloud.gov/signup).
 1. Request the creation of your org in the GovCloud environment:
     * If you are in 18F/TTS at GSA, fill out the [organization request form](https://docs.google.com/a/gsa.gov/forms/d/e/1FAIpQLSd4HmcGfJW3EBnpewTFDD-urRFPp1LN0DcwNB_FxZgUn8ho9g/viewform?c=0&w=1). Specify that the org should be created in `GovCloud`. An admin will confirm the information, [create the org]({{< relref "docs/ops/create-org.md#non-sandboxes" >}}) for you, and notify you. This should happen within one business day.
-    * For everyone else, one of your org managers should email [cloud-gov-support@gsa.gov](mailto:cloud-gov-support@gsa.gov) to request the creation of your org in GovCloud. Include the name of your East/West org so that we can create the new org with the appropriate org name.
+    * For everyone else, one of your org managers should email [cloud-gov-support@gsa.gov](mailto:cloud-gov-support@gsa.gov?subject=[GovCloud Org Request]) to request the creation of your org in GovCloud. Please include "[GovCloud Org Request]" in the subject heading and specify the name of your current East/West org.
 1. Install the [CF Targets plugin](https://github.com/guidowb/cf-targets-plugin).
 1. [Give permissions to the appropriate people.]({{< relref "docs/apps/managing-teammates.md" >}})
 1. Deploy the application to the GovCloud environment.

--- a/content/docs/apps/govcloud.md
+++ b/content/docs/apps/govcloud.md
@@ -83,18 +83,15 @@ Any labor involved from your project team is the responsibility of your project.
 
 #### Process
 
-1. Fill out the [organization request form](https://docs.google.com/a/gsa.gov/forms/d/e/1FAIpQLSd4HmcGfJW3EBnpewTFDD-urRFPp1LN0DcwNB_FxZgUn8ho9g/viewform?c=0&w=1).
-    * Specify that the org should be created in `GovCloud`.
-    * An admin will confirm the information, and [create the org]({{< relref "docs/ops/create-org.md#non-sandboxes" >}}) for you.
+1. [Get access to the GovCloud environment] **SELF-INVITATION LINK TBD**.
+1. Request the creation of your org in the GovCloud environment:
+    * If you are in 18F/TTS at GSA, fill out the [organization request form](https://docs.google.com/a/gsa.gov/forms/d/e/1FAIpQLSd4HmcGfJW3EBnpewTFDD-urRFPp1LN0DcwNB_FxZgUn8ho9g/viewform?c=0&w=1). Specify that the org should be created in `GovCloud`. An admin will confirm the information, [create the org]({{< relref "docs/ops/create-org.md#non-sandboxes" >}}) for you, and notify you. This should happen within one business day.
+    * For everyone else, one of your org managers should email [cloud-gov-support@gsa.gov](mailto:cloud-gov-support@gsa.gov) to request the creation of your org in GovCloud. Include the name of your East/West org so that we can create the new org with the appropriate org name.
 1. Install the [CF Targets plugin](https://github.com/guidowb/cf-targets-plugin).
 1. [Give permissions to the appropriate people.]({{< relref "docs/apps/managing-teammates.md" >}})
 1. Deploy the application to the GovCloud environment.
     * This is a good time to ensure that you are following [deployment best practices]({{< relref "docs/apps/production-ready.md" >}}).
-1. If you are using a data store provided by cloud.gov, migrate the data. More information for each [service]({{< relref "docs/apps/managed-services.md" >}}):
-    * [Elasticsearch](https://github.com/18F/cg-product/issues/233)
-    * [Redis](https://github.com/18F/cg-product/issues/234)
-    * [S3](https://github.com/18F/cg-product/issues/235)
-    * [MySQL and PostgreSQL, via the cg-migrate-db plugin]({{< relref "docs/services/relational-database.md#cg-migrate-db-plugin" >}})
+1. If you are using a data store provided by cloud.gov, migrate the data. See the [services documentation]({{< relref "docs/apps/managed-services.md" >}}). For MySQL and PostgreSQL, you can use [the cg-migrate-db plugin]({{< relref "docs/services/relational-database.md#cg-migrate-db-plugin" >}}).
 1. If you are [leveraging cloud.gov's User Account and Authentication (UAA) server]({{< relref "docs/apps/leveraging-authentication.md" >}})
    you must [register your application with the GovCloud UAA server]({{< relref "docs/apps/leveraging-authentication.md#register-your-application-instances" >}}), [update your integration to use the GovCloud endpoints]({{< relref "docs/apps/leveraging-authentication.md#integrate-with-your-application" >}}) and make sure to use your newly issued `client_secret`.
 1. Test the new deployment(s) thoroughly.
@@ -107,13 +104,3 @@ Any labor involved from your project team is the responsibility of your project.
     * [RDS](https://aws.amazon.com/rds/) instances
     * [Route 53](https://aws.amazon.com/route53/) entries
     * [S3](https://aws.amazon.com/s3/) buckets
-
-#### Unresolved details
-
-The cloud.gov team is still working through details on the following:
-
-* More explicit instructions for the steps above
-* Timeline/[deadlines](https://github.com/18F/cg-product/issues/403) for completing the migration
-* The support arrangement that the cloud.gov team will provide for migration assistance
-
-All affected tenants will be notified as more information is available.

--- a/content/docs/apps/govcloud.md
+++ b/content/docs/apps/govcloud.md
@@ -81,7 +81,7 @@ Any labor involved from your project team is the responsibility of your project.
 
 #### Process
 
-1. [Get access to the GovCloud environment] **SELF-INVITATION LINK TBD**.
+1. [Get access to the GovCloud environment](https://account.fr.cloud.gov/signup).
 1. Request the creation of your org in the GovCloud environment:
     * If you are in 18F/TTS at GSA, fill out the [organization request form](https://docs.google.com/a/gsa.gov/forms/d/e/1FAIpQLSd4HmcGfJW3EBnpewTFDD-urRFPp1LN0DcwNB_FxZgUn8ho9g/viewform?c=0&w=1). Specify that the org should be created in `GovCloud`. An admin will confirm the information, [create the org]({{< relref "docs/ops/create-org.md#non-sandboxes" >}}) for you, and notify you. This should happen within one business day.
     * For everyone else, one of your org managers should email [cloud-gov-support@gsa.gov](mailto:cloud-gov-support@gsa.gov) to request the creation of your org in GovCloud. Include the name of your East/West org so that we can create the new org with the appropriate org name.

--- a/content/docs/apps/govcloud.md
+++ b/content/docs/apps/govcloud.md
@@ -84,7 +84,7 @@ Any labor involved from your project team is the responsibility of your project.
 1. [Get access to the GovCloud environment](https://account.fr.cloud.gov/signup).
 1. Request the creation of your org in the GovCloud environment:
     * If you are in 18F/TTS at GSA, fill out the [organization request form](https://docs.google.com/a/gsa.gov/forms/d/e/1FAIpQLSd4HmcGfJW3EBnpewTFDD-urRFPp1LN0DcwNB_FxZgUn8ho9g/viewform?c=0&w=1). Specify that the org should be created in `GovCloud`. An admin will confirm the information, [create the org]({{< relref "docs/ops/create-org.md#non-sandboxes" >}}) for you, and notify you. This should happen within one business day.
-    * For everyone else, one of your org managers should email [cloud-gov-support@gsa.gov](mailto:cloud-gov-support@gsa.gov?subject=[GovCloud Org Request]) to request the creation of your org in GovCloud. Please include "[GovCloud Org Request]" in the subject heading and specify the name of your current East/West org.
+    * For everyone else, one of your org managers should email [cloud-gov-support@gsa.gov](mailto:cloud-gov-support@gsa.gov?subject=[GovCloud%20Org%20Request]?body=The%20name%20of%20my%20East/West%20org%20is:) to request the creation of your org in GovCloud. Please include "[GovCloud Org Request]" in the subject heading and specify the name of your current East/West org.
 1. Install the [CF Targets plugin](https://github.com/guidowb/cf-targets-plugin).
 1. [Give permissions to the appropriate people.]({{< relref "docs/apps/managing-teammates.md" >}})
 1. Deploy the application to the GovCloud environment.


### PR DESCRIPTION
**Don't merge yet.** This needs to be updated with the upcoming link to self-invitation for GovCloud access.

These changes are meant to help non-18F people migrate their orgs to GovCloud, to support [this message](https://docs.google.com/document/d/1l-akEeE2cRxML_svuQTmo__naN80sN-Jj_n6Jqt9DoE/edit#heading=h.jgcxtjglazl) and related messaging. Feel free to add more improvements to this WIP branch - this is just a start to help.

Changes:

* Start with getting access to GovCloud.
* Provide alternative to org request form for people outside TTS.
* Remove links to incomplete info about service migration.
* Remove "unresolved details" chunk.
* Include the updated text from https://github.com/18F/cg-site/pull/763 to avoid merge conflicts.