### PR TITLE
Update calls to action for people interested in using cloud.gov

### DIFF
--- a/content/docs/help.md
+++ b/content/docs/help.md
@@ -7,13 +7,17 @@ aliases:
 
 ### Want to use cloud.gov?
 
-If you have a U.S. federal government email address, you can get access to a [free sandbox space]({{< relref "free-limited-sandbox.md" >}}) and try cloud.gov right away. You can also email [cloud-gov-inquiries@gsa.gov](mailto:cloud-gov-inquiries@gsa.gov) with questions to help you understand if cloud.gov is right for you. If you're ready to use cloud.gov, use our [interest form](https://docs.google.com/forms/d/e/1FAIpQLSevZfuJ_4KE-MZlm9gttYfsXQp0PJL7OR6k6LbZ9XnFn-oA6g/viewform) to tell us about your organization and applications</a>. We’ll schedule a call where we can go over needs, options, and any remaining questions, then get the [federal Interagency Agreement (IAA/MOU) process]({{< relref "overview/pricing/how-to-purchase.md" >}}) underway. 
+If you're interested in using cloud.gov, [**fill out our interest form**](https://docs.google.com/forms/d/e/1FAIpQLSevZfuJ_4KE-MZlm9gttYfsXQp0PJL7OR6k6LbZ9XnFn-oA6g/viewform) to tell us about your organization and applications. We’ll schedule a call where we can go over needs, options, and any remaining questions, then get the [federal Inter-Agency Agreement (IAA/MOU) process]({{< relref "overview/pricing/how-to-purchase.md" >}}) underway.
 
-To get news about cloud.gov, [sign up for email updates](/#updates).
+If you have a U.S. federal government email address, you can [**get access to a free sandbox space**]({{< relref "overview/pricing/free-limited-sandbox.md" >}}) and try cloud.gov right away. 
+
+You can also email [**cloud-gov-inquiries@gsa.gov**](mailto:cloud-gov-inquiries@gsa.gov) with questions to help you understand whether cloud.gov is right for your team.
+
+To get news about cloud.gov, [**sign up for email updates**](/#updates).
 
 ### Support for people who use cloud.gov
 
-Email [cloud-gov-support@gsa.gov](mailto:cloud-gov-support@gsa.gov). We provide support for cloud.gov during typical business hours for U.S. East and West Coasts. We don't guarantee support for cloud.gov outside those hours, though we're always monitoring for signs of trouble that might affect customers.
+Email [**cloud-gov-support@gsa.gov**](mailto:cloud-gov-support@gsa.gov). We provide support for cloud.gov during typical business hours for U.S. East and West Coasts. We don't guarantee support for cloud.gov outside those hours, though we're always monitoring for signs of trouble that might affect customers.
 
 (If you're GSA TTS staff, you can also talk to us in [#cloud-gov-support](https://gsa-tts.slack.com/messages/cloud-gov-support).)
 


### PR DESCRIPTION
Followup to https://github.com/18F/cg-site/pull/764#discussion_r101586035

Changes:

* Fix broken link to sandbox space info
* Bold the actions people can take
* Start with the interest form, then follow up with the sandbox offer (since they shouldn't feel like they need to try a sandbox before they can tell us they're interested)
* People can fill out the interest form even if they're not sure if they want to purchase