### PR TITLE
Another error message for logs not accessible

### DIFF
--- a/content/docs/apps/logs.md
+++ b/content/docs/apps/logs.md
@@ -37,7 +37,7 @@ For other helpful cf CLI troubleshooting commands, including `cf events APP-NAME
 ### Error messages
 
 * Errors can sometimes be caused by having an old version of the cf CLI. Try `cf -v` and see if it's older than the [latest version](https://github.com/cloudfoundry/cli/releases). If it is, you can [install the latest version]({{< relref "docs/getting-started/setup.md#set-up-the-command-line" >}}) and try again.
-* If you get something like the following: `Please ask your Cloud Foundry Operator to check the platform configuration (trafficcontroller endpoint is wss://doppler.fr.cloud.gov:4443)` -- this can happen if your workplace has a firewall that blocks connections to ports other than 80 and 443. You can use the web-based logs interface instead, as described below.
+* If you get something like the following: `timeout connecting to log server, no log will be shown` or `Please ask your Cloud Foundry Operator to check the platform configuration (trafficcontroller endpoint is wss://doppler.fr.cloud.gov:4443)` -- this can happen if your workplace has a firewall that blocks connections to ports other than 80 and 443. You can use the web-based logs interface instead, as described below.
 
 ## Web-based logs with historic log data
 


### PR DESCRIPTION
For cloud.gov teammates: this might help other people avoid the issue at https://cloud-gov.zendesk.com/agent/tickets/256.

Related card about logs ports, to be prioritized in the future: https://favro.com/card/1e11108a2da81e3bd7153a7a/18F-2995

Not a time-sensitive change, just an improvement.