### PR TITLE
Temporary change to email for new sandboxes

### DIFF
--- a/content/overview/pricing/free-limited-sandbox.md
+++ b/content/overview/pricing/free-limited-sandbox.md
@@ -14,7 +14,7 @@ A sandbox is a free, limited way to try cloud.gov and see if it might suit your 
 
 ## Get a sandbox
 
-Anyone with a U.S. federal government email address can <!--[**sign up for a free sandbox space**](https://account.fr.cloud.gov/signup)--> email us at [cloud-gov-inquiries@gsa.gov](mailto:cloud-gov-inquiries@gsa.gov) to request a free sandbox space. No paperwork is required from us. (It's up to you to determine whether you may need permission from your organization.) If you have other questions or comments, see [Contact]({{< relref "docs/help.md" >}}).
+Anyone with a U.S. federal government email address can <!--[**sign up for a free sandbox space**](https://account.fr.cloud.gov/signup)--> **email [cloud-gov-inquiries@gsa.gov](mailto:cloud-gov-inquiries@gsa.gov)** to request a free sandbox space. No paperwork is required from us. (It's up to you to determine whether you may need permission from your organization.) If you have other questions or comments, see [Contact]({{< relref "docs/help.md" >}}).
 
 Then, if you're interested in [purchasing full access]({{< relref "overview/pricing/rates.md" >}}) (whether for **Prototyping** or for production systems at the **Open Data**, **FISMA Low**, or **FISMA Moderate** levels), fill out [this interest form](https://docs.google.com/a/gsa.gov/forms/d/e/1FAIpQLSevZfuJ_4KE-MZlm9gttYfsXQp0PJL7OR6k6LbZ9XnFn-oA6g/viewform) or email us again.
 

--- a/content/overview/pricing/free-limited-sandbox.md
+++ b/content/overview/pricing/free-limited-sandbox.md
@@ -14,7 +14,7 @@ A sandbox is a free, limited way to try cloud.gov and see if it might suit your 
 
 ## Get a sandbox
 
-Anyone with a U.S. federal government email address can [**sign up for a free sandbox space**](https://account.fr.cloud.gov/signup). No paperwork is required from us. (It's up to you to determine whether you may need permission from your organization.) If you have other questions or comments, see [Contact]({{< relref "docs/help.md" >}}).
+Anyone with a U.S. federal government email address can <!--[**sign up for a free sandbox space**](https://account.fr.cloud.gov/signup)--> email us at [cloud-gov-inquiries@gsa.gov](mailto:cloud-gov-inquiries@gsa.gov) to request a free sandbox space. No paperwork is required from us. (It's up to you to determine whether you may need permission from your organization.) If you have other questions or comments, see [Contact]({{< relref "docs/help.md" >}}).
 
 Then, if you're interested in [purchasing full access]({{< relref "overview/pricing/rates.md" >}}) (whether for **Prototyping** or for production systems at the **Open Data**, **FISMA Low**, or **FISMA Moderate** levels), fill out [this interest form](https://docs.google.com/a/gsa.gov/forms/d/e/1FAIpQLSevZfuJ_4KE-MZlm9gttYfsXQp0PJL7OR6k6LbZ9XnFn-oA6g/viewform) or email us again.
 


### PR DESCRIPTION
Currently https://account.fr.cloud.gov/signup is giving an error message, and it's after East coast working hours, so let's set this back to email instead of self-sign-up for now.