### PR TITLE
Be consistent about "access" vs "account"

### DIFF
--- a/content/docs/getting-started/setup.md
+++ b/content/docs/getting-started/setup.md
@@ -6,7 +6,7 @@ title: Set up cloud.gov and log in
 weight: -50
 ---
 
-First get [an account]({{< relref "accounts.md" >}}), and then you can log into cloud.gov in the following ways -- command line and dashboard (web interface).
+If you have set up your [access to cloud.gov]({{< relref "accounts.md" >}}), you can log into cloud.gov in the following ways -- command line and dashboard (web interface).
 
 ## Set up the command line
 


### PR DESCRIPTION
We're trying to be consistent overall about "cloud.gov account" (using the cloud.gov IdP) and "cloud.gov access" (which can be through your agency identity provider), so this is a small edit to help with that.