### PR TITLE
Update service broker descriptions

### DIFF
--- a/content/docs/services/elasticsearch24.md
+++ b/content/docs/services/elasticsearch24.md
@@ -14,9 +14,10 @@ cloud.gov offers [Elasticsearch](https://www.elastic.co/) 2.4 as a service. **Th
 
 Plan Name | Description | Price
 --------- | ----------- | -----
-`1x` | Elasticsearch instance with 1GB of RAM and 1 slice of CPU | Free in Alpha
-`3x` | Elasticsearch instance with 3GB of RAM and 3 slices of CPU | Free in Alpha
-`6x` | Elasticsearch instance with 6GB of RAM and 6 slices of CPU | Free in Alpha
+`1x`  | Elasticsearch instance with 1GB of RAM and 1 slice of CPU   | Free in Alpha
+`3x`  | Elasticsearch instance with 3GB of RAM and 1 slice of CPU   | Free in Alpha
+`6x`  | Elasticsearch instance with 6GB of RAM and 1 slice of CPU   | Free in Alpha
+`12x` | Elasticsearch instance with 12GB of RAM and 2 slices of CPU | Free in Alpha
 
 ## How to create an instance
 

--- a/data/services/elasticsearch17.toml
+++ b/data/services/elasticsearch17.toml
@@ -1,3 +1,3 @@
 name = "elasticsearch17"
-description = "[Elasticsearch](https://www.elastic.co/products/elasticsearch) version 1.7 a distributed, RESTful search and analytics engine"
+description = "[Elasticsearch](https://www.elastic.co/products/elasticsearch) version 1.7: a distributed, RESTful search and analytics engine"
 status = "Alpha"

--- a/data/services/elasticsearch23.toml
+++ b/data/services/elasticsearch23.toml
@@ -1,3 +1,3 @@
 name = "elasticsearch23"
-description = "[Elasticsearch](https://www.elastic.co/products/elasticsearch) version 2.3 a distributed, RESTful search and analytics engine"
+description = "[Elasticsearch](https://www.elastic.co/products/elasticsearch) version 2.3: a distributed, RESTful search and analytics engine"
 status = "Alpha"

--- a/data/services/elasticsearch24.toml
+++ b/data/services/elasticsearch24.toml
@@ -1,3 +1,3 @@
 name = "elasticsearch24"
-description = "[Elasticsearch](https://www.elastic.co/products/elasticsearch) version 2.4 a distributed, RESTful search and analytics engine"
+description = "[Elasticsearch](https://www.elastic.co/products/elasticsearch) version 2.4: a distributed, RESTful search and analytics engine"
 status = "Alpha"

--- a/data/services/redis28.toml
+++ b/data/services/redis28.toml
@@ -1,3 +1,3 @@
 name = "redis28"
-description = "[Redis](https://redis.io/) version 2.8 an in-memory data structure store"
+description = "[Redis](https://redis.io/) version 2.8: an in-memory data structure store"
 status = "Alpha"


### PR DESCRIPTION
One more update for the service descriptions. Forgot the colons in the page metadata to match the services index table. Also found that elasticsearch2.4 is configured differently than the others, so updated the descriptions to match. This will probably change in the future.