### PR TITLE
Add Missing X-Content-Type-Options Header

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -39,6 +39,7 @@ http {
       index index.html index.htm Default.htm;
 
       add_header Cache-Control max-age=300;
+      add_header X-Content-Type-Options nosniff;
     }
   }
 }


### PR DESCRIPTION
# What 

Compliance request `V17-CM-6` requires https://landing.fr.cloud.gov/ to fix the vulnerability for `X-Content-Type-Options Header Missing`.