### PR TITLE
Remove vestigial S3 docs

### DIFF
--- a/content/docs/services/s3.md
+++ b/content/docs/services/s3.md
@@ -21,62 +21,32 @@ Plan Name | Description | Price
 
 ## How to create an instance
 
-To create a service instance, run the following command:
-
-```bash
-cf create-service s3 basic my-s3-service
-```
-
-## More information
-
-### Create an application only for S3
-
-If you only need a S3 bucket, you can create a simple Static application:
-
-```bash
-mkdir s3-app
-cd s3-app
-touch Staticfile
-```
-Create a manifest.yml with a name for the app and the least amount of memory to get it running.
-```
----
-applications:
-- name: s3-app
-  memory: 10M
-```
-Save your file.
-
-```
-cf push
-```
-
-### Add S3 to an application
-
-Once an application is running in cloud.gov, the next step is to create and assign S3 to the application:
-
-First decide if the S3 bucket contents should be private or public. Objects placed in a private bucket are only accessible using the bucket credentials unless specifically [shared with others](http://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html). Objects placed in a public bucket are accessible to anyone with the link.
+First decide if the S3 bucket contents should be private or public. Objects placed in a private bucket are only accessible using the bucket credentials unless specifically [shared with others](http://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html). Objects placed in a public bucket are accessible to anyone with the link. 
 
 To create a private bucket use the `basic` plan:
 
 ```bash
-cf create-service s3 basic <APP_NAME>-s3
+cf create-service s3 basic <BUCKET_NAME>-s3
 ```
 
 To create a public bucket use the `basic-public` plan:
 
 ```bash
-cf create-service s3 basic-public <APP_NAME>-s3
+cf create-service s3 basic-public <BUCKET_NAME>-s3
 ```
 
-Then bind the bucket to your application:
+## More information
+
+### Using S3 from your application
+
+To make the bucket usable from your application, you must bind it:
 
 ```bash
-cf bind-service <APP_NAME> <APP_NAME>-s3
+cf bind-service <APP_NAME> <BUCKET_NAME>-s3
 cf restage <APP_NAME>
 ```
 
-This will put the S3 access information in the application's ENVIRONMENT variables, which you can view with `cf env <APP_NAME>`.
+This will put the S3 access information in the application's [environment variables](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html). You can inspect these values with `cf env <APP_NAME>` if necessary.
 
 If you get an error, see the [managed service documentation]({{< relref "docs/apps/managed-services.md#paid-services" >}}).
 


### PR DESCRIPTION
With service-keys, it's no longer necessary to create an application just to get access to a raw bucket.