### PR TITLE
More information about supported languages for frameworks page

### DIFF
--- a/content/docs/apps/frameworks.md
+++ b/content/docs/apps/frameworks.md
@@ -29,4 +29,4 @@ cloud.gov cannot run applications that use .NET Framework, or application binari
 
 ## Examples
 
-Check out the [Cloud Foundry sample applications](https://github.com/cloudfoundry-samples) for examples of applications in many different languages.
+Check out the [Cloud Foundry sample applications](https://github.com/cloudfoundry-samples) and [cloud.gov's collection of Hello World applications](https://github.com/18F/cf-hello-worlds) for examples of applications in many different languages.

--- a/content/docs/apps/frameworks.md
+++ b/content/docs/apps/frameworks.md
@@ -11,8 +11,22 @@ aliases:
 - /docs/apps/meteor
 ---
 
-cloud.gov supports applications written in Go, Java, Node.js, .NET Core, PHP, Python, and Ruby. cloud.gov also supports applications that rely on a static binary that uses the 64-bit Linux kernel ABI, or that consist of static HTML, CSS, and Javascript assets.
+cloud.gov uses [buildpacks]({{< relref "docs/getting-started/concepts.md#buildpacks" >}}) to support a variety of programming languages and frameworks.
 
-cloud.gov does _not_ support applications that use .NET Framework, or application binaries that require access to Microsoft Windows kernel or system APIs.
+## Supported languages and frameworks
 
-For documentation on deploying applications using common languages and web frameworks to cloud.gov, see the [Cloud Foundry buildpack documentation](http://docs.cloudfoundry.org/buildpacks/) and [Cloud Foundry sample applications](https://github.com/cloudfoundry-samples).
+cloud.gov supports applications written in Go, Java, Node.js, .NET Core, PHP, Python, and Ruby. cloud.gov also supports applications that rely on a static binary that uses the 64-bit Linux kernel ABI, or that consist of static HTML, CSS, and Javascript assets. See the [Cloud Foundry system (supported) buildpacks list](http://docs.cloudfoundry.org/buildpacks/#system-buildpacks) for details.
+
+## Other languages
+
+You can use a custom buildpack to support other languages. See [custom buildpacks]({{< relref "docs/apps/experimental/custom-buildpacks.md" >}}) for more information about this experimental feature.
+
+Cloud Foundry has a list of [community buildpacks](http://docs.cloudfoundry.org/buildpacks/#community-buildpacks) that you can use as custom buildpacks, along with [documentation for building your own custom buildpacks](http://docs.cloudfoundry.org/buildpacks/developing-buildpacks.html).
+
+## Cannot run
+
+cloud.gov cannot run applications that use .NET Framework, or application binaries that require access to Microsoft Windows kernel or system APIs.
+
+## Examples
+
+Check out the [Cloud Foundry sample applications](https://github.com/cloudfoundry-samples) for examples of applications in many different languages.


### PR DESCRIPTION
This is a followup on the small change to the languages/frameworks page at https://github.com/18F/cg-site/pull/811 with a bigger change to this page that I'm not 100% sure is a _great_ idea - but it got into my head, so I wrote it down.

This links to the cloud.gov buildpacks info and duplicates some of it, but I tried to do this from the user-centered terms of "so what can I do? ok I can use buildpacks for that" rather than starting with the concept of buildpacks.