### PR TITLE
Document the max number of domains a single cdn-route instance can support

### DIFF
--- a/content/docs/services/cdn-route.md
+++ b/content/docs/services/cdn-route.md
@@ -61,6 +61,8 @@ cf create-service cdn-route cdn-route my-cdn-route \
     -c '{"domain": "my.example.gov,www.my.example.gov"}'
 ```
 
+The maximum number of domains that can be associated with a single cdn-route service is 100.
+
 ### How to set up DNS
 
 Once you create the service instance, you need to retrieve the instructions to set up your DNS. Run the following command, replacing `my-cdn-route` with the service instance name you used in the previous step.


### PR DESCRIPTION
This limitation comes from [lets encrypt]( https://letsencrypt.org/docs/rate-limits/)
> If you have a lot of subdomains, you may want to combine them into a single certificate, up to a limit of 100 Names per Certificate