### PR TITLE
Service -> service instance for consistency

### DIFF
--- a/content/docs/services/cdn-route.md
+++ b/content/docs/services/cdn-route.md
@@ -61,7 +61,7 @@ cf create-service cdn-route cdn-route my-cdn-route \
     -c '{"domain": "my.example.gov,www.my.example.gov"}'
 ```
 
-The maximum number of domains that can be associated with a single cdn-route service is 100.
+The maximum number of domains that can be associated with a single cdn-route service instance is 100.
 
 ### How to set up DNS
 


### PR DESCRIPTION
Tiny followup on https://github.com/18F/cg-site/pull/816 - suggest this should be "service instance" instead of "service", for consistency with the other phrasing in this docs page - the command is `cf create-service`, but "service instance" helps distinguish this thing from the concept of the CDN service itself.