### PR TITLE
Removing outdated sandbox limitation info

### DIFF
--- a/content/docs/apps/managed-services.md
+++ b/content/docs/apps/managed-services.md
@@ -45,17 +45,6 @@ For example, to create an instance of the elasticsearch service using the free p
 
 The note `* These service plans have an associated cost` indicates paid services. [Learn about managed service pricing.]({{< relref "overview/pricing/rates.md#managed-services" >}})
 
-Sandbox accounts (free accounts) can't use paid services. If you have a sandbox account, you'll get an error like this if you try to use them:
-
-```
-% cf create-service <service> <plan> <service_instance>
-Creating service instance <service_instance> in org <org> / space <space> as <user>...
-FAILED
-Server error, status code: 400, error code: 60007, message: The service instance cannot be created because paid service plans are not allowed.
-```
-
-If you get that error and you have a non-sandbox account, [ask support](/help/) to enable paid services.
-
 #### Bind the service instance
 
 A service instance must be bound to the application which will access it. This can be done in a single step by adding a binding to the application's `manifest.yml`.

--- a/content/overview/pricing/free-limited-sandbox.md
+++ b/content/overview/pricing/free-limited-sandbox.md
@@ -39,15 +39,13 @@ You can:
 
 Sandboxes are limited because cloud.gov is a cost-recoverable service. They're a free trial to help you evaluate whether to purchase cloud.gov.
 
-Sandboxes are for testing; they're suitable for information and applications that require no confidentiality, integrity, or availability. (Don't put production applications or production data in sandboxes; that's not what they're for.)
+Sandboxes are for testing; they're suitable for information and applications that require **no confidentiality, integrity, or availability**. (Don't put production applications or production data in sandboxes; that's not what they're for.)
 
 Limitations include:
 
 * Resource usage is capped at 1 GB of memory total, for all the applications in your space combined.
 * Currently sandbox applications may run indefinitely, but **soon we will delete sandbox content once a month**. We will send notice emails to all sandbox users before we implement this.
-* Sandboxes can only use free [managed services]({{< relref "docs/services/index.md" >}}).
 * Sandboxes do not have an "org manager" role available. (You can control access and permissions for your own sandbox space.) If you want to manage an org of prototyping spaces for people at your agency, consider purchasing prototyping-tier access.
-* You can't set up [custom domains]({{< relref "docs/apps/custom-domains.md" >}}) for your applications. By default, your applications receive a `*.app.cloud.gov` domain.
 
 <!--TO DO
 - write user flows and see if they are followable


### PR DESCRIPTION
(For cloud.gov team: [context is here](https://gsa-tts.slack.com/archives/cloud-gov-agent-q/p1489688295528305).)