### PR TITLE
Add more info to first deploy page, including dashboard and status notifications

### DIFF
--- a/content/docs/getting-started/your-first-deploy.md
+++ b/content/docs/getting-started/your-first-deploy.md
@@ -27,7 +27,7 @@ To get used to cloud.gov, practice by deploying a simple "hello world" applicati
 
 Check out [**Status**](https://cloudgov.statuspage.io/), which tells you about cloud.gov service disruptions. You can use **Subscribe to Updates** in the upper right corner to get email or SMS notifications about platform problems that may affect cloud.gov users.
 
-cloud.gov is an instance of Cloud Foundry, so in general, the [the Cloud Foundry documentation](http://docs.cloudfoundry.org) and other Cloud Foundry resources mostly apply to cloud.gov. For example, you can also try deploying the [sample apps maintained by the Cloud Foundry community](https://github.com/cloudfoundry-samples).
+cloud.gov is based on Cloud Foundry, so in general, the [the Cloud Foundry documentation](http://docs.cloudfoundry.org) and other Cloud Foundry resources mostly apply to cloud.gov. For example, you can also try deploying the [sample apps maintained by the Cloud Foundry community](https://github.com/cloudfoundry-samples).
 
 ## Next steps
 

--- a/content/docs/getting-started/your-first-deploy.md
+++ b/content/docs/getting-started/your-first-deploy.md
@@ -9,7 +9,7 @@ weight: -30
 To get used to cloud.gov, practice by deploying a simple "hello world" application using the cloud.gov command line interface (CLI).
 
 1. First, [go through account setup]({{< relref "setup.md" >}}) (if you haven't already), so that you're logged into the cloud.gov CLI and have targeted your sandbox.
-1. Visit [this collection of "hello world" applications (tiny sample applications)](https://github.com/18F/cf-hello-worlds) and use **Clone or download** to make a copy on your computer. (This is easiest if you have [Git](https://git-scm.com/downloads) installed on your computer.) For example, if you use `git` on the command line, enter `git clone https://github.com/18F/cf-hello-worlds.git`
+1. Visit [this collection of "hello world" applications (tiny sample applications)](https://github.com/18F/cf-hello-worlds) and use **Clone or download** to make a copy on your computer. You can download the zip file provided there, or if you use [`git`](https://git-scm.com/) on the command line, you can enter `git clone https://github.com/18F/cf-hello-worlds.git`
 1. Move into that directory, for example: `cd cf-hello-worlds`
 1. Look at the collection of tiny apps, and `cd` into the directory for the language/framework you feel most comfortable with. For example: `cd python-flask`
 1. Deploy the application, where `APPNAME` should be something unique like `FRAMEWORK-YOURNAME` (e.g. `nodejs-aidan`). By default on cloud.gov, `APPNAME` is used to construct a route to make your application reachable at https://APPNAME.app.cloud.gov/. Route names must be unique across the platform.
@@ -20,9 +20,15 @@ To get used to cloud.gov, practice by deploying a simple "hello world" applicati
     ```
 1. Visit it at https://APPNAME.app.cloud.gov/
 1. Try editing the app locally (without committing) and run `cf push <APPNAME>` again to see your changes. The changes will be reflected even without being committed to Git. cloud.gov is not Git-aware – it simply deploys whatever is contained in the directory that you `push` from. You can set up [continuous deployment]({{< relref "docs/apps/continuous-deployment.md" >}}) from a Git repository.
-
+1. Visit the dashboard ([`https://dashboard.fr.cloud.gov/`](https://dashboard.fr.cloud.gov/)) to see your options for managing your application with the dashboard.
 1. If you're done, you can delete your app by running `cf delete <APPNAME>`
 
-Tip: cloud.gov is an instance of Cloud Foundry, so in general, the [the Cloud Foundry documentation](http://docs.cloudfoundry.org) and other Cloud Foundry resources online are mostly applicable to cloud.gov. For example, you can also try deploying the [sample apps maintained by the Cloud Foundry community](https://github.com/cloudfoundry-samples).
+## Good to know
+
+Check out [**Status**](https://cloudgov.statuspage.io/), which tells you about cloud.gov service disruptions. You can use **Subscribe to Updates** in the upper right corner to get email or SMS notifications about platform problems that may affect cloud.gov users.
+
+cloud.gov is an instance of Cloud Foundry, so in general, the [the Cloud Foundry documentation](http://docs.cloudfoundry.org) and other Cloud Foundry resources mostly apply to cloud.gov. For example, you can also try deploying the [sample apps maintained by the Cloud Foundry community](https://github.com/cloudfoundry-samples).
+
+## Next steps
 
 Next, take a look at the [Concepts]({{< relref "concepts.md" >}}) page. Once you're ready to deploy your own application, head over to the [general deployment tips]({{< relref "docs/apps/deployment.md" >}}).

--- a/content/docs/getting-started/your-first-deploy.md
+++ b/content/docs/getting-started/your-first-deploy.md
@@ -20,7 +20,7 @@ To get used to cloud.gov, practice by deploying a simple "hello world" applicati
     ```
 1. Visit it at https://APPNAME.app.cloud.gov/
 1. Try editing the app locally (without committing) and run `cf push <APPNAME>` again to see your changes. The changes will be reflected even without being committed to Git. cloud.gov is not Git-aware – it simply deploys whatever is contained in the directory that you `push` from. You can set up [continuous deployment]({{< relref "docs/apps/continuous-deployment.md" >}}) from a Git repository.
-1. Visit the dashboard ([`https://dashboard.fr.cloud.gov/`](https://dashboard.fr.cloud.gov/)) to see your options for managing your application with the dashboard.
+1. Visit the dashboard ([`https://dashboard.fr.cloud.gov/`](https://dashboard.fr.cloud.gov/)) to see your options for managing your application via your browser.
 1. If you're done, you can delete your app by running `cf delete <APPNAME>`
 
 ## Good to know


### PR DESCRIPTION
These changes encourage new users to:

* Download the sample apps as a zip file if they don't use git.
* Look at the dashboard after they deploy an app.
* Sign up for Status Page notifications.