### PR TITLE
Call only one thing a BUCKET_NAME

### DIFF
--- a/content/docs/services/s3.md
+++ b/content/docs/services/s3.md
@@ -26,13 +26,13 @@ First decide if the S3 bucket contents should be private or public. Objects plac
 To create a private bucket use the `basic` plan:
 
 ```bash
-cf create-service s3 basic <BUCKET_NAME>-s3
+cf create-service s3 basic <SERVICE_INSTANCE_NAME>-s3
 ```
 
 To create a public bucket use the `basic-public` plan:
 
 ```bash
-cf create-service s3 basic-public <BUCKET_NAME>-s3
+cf create-service s3 basic-public <SERVICE_INSTANCE_NAME>-s3
 ```
 
 ## More information
@@ -42,7 +42,7 @@ cf create-service s3 basic-public <BUCKET_NAME>-s3
 To make the bucket usable from your application, you must bind it:
 
 ```bash
-cf bind-service <APP_NAME> <BUCKET_NAME>-s3
+cf bind-service <APP_NAME> <SERVICE_INSTANCE_NAME>-s3
 cf restage <APP_NAME>
 ```
 


### PR DESCRIPTION
I believe on this page we're calling two different things a BUCKET_NAME - the service instance nickname and then the environment variable that contains the real S3 bucket name.

That's confusing, so here's an effort to rename the first type of BUCKET_NAME to SERVICE_INSTANCE_NAME.

Any Atlas person is welcome to review this for technical accuracy.