### PR TITLE
Add info to support auth devs/users

### DIFF
--- a/content/docs/apps/leveraging-authentication.md
+++ b/content/docs/apps/leveraging-authentication.md
@@ -7,7 +7,9 @@ title: Leveraging cloud.gov authentication
 
 cloud.gov uses Cloud Foundry's [User Account and Authentication (UAA) server](https://docs.cloudfoundry.org/concepts/architecture/uaa.html) to provide identity management capabilities for the cloud.gov platform.
 
-App developers can also leverage cloud.gov's UAA instance as a backend that brokers authentication with supported identity providers (currently GSA, EPA and FDIC). Essentially, you can (and probably should) use cloud.gov's authentication brokering if the users that you need to authenticate in your application are employees of any of the supported agencies.
+App developers can leverage cloud.gov's UAA instance as a backend that brokers authentication with [supported identity providers]({{< relref "accounts.md#to-get-access-to-cloud-gov" >}}) (currently EPA, FDIC, GSA, and a cloud.gov provider that supports other agencies). You can use cloud.gov's authentication brokering if the users that you need to authenticate in your application are federal employees and contractors who can use those authentication methods.
+
+This service handles only authentication, not authorization -- it's up to your application to manage what they can access within the application. Once you set it up, you can direct your users to the [list of ways to get cloud.gov access]({{< relref "accounts.md#to-get-access-to-cloud-gov" >}}); they don't need any org or space roles, they just need to be able to log into cloud.gov.
 
 ## Using cloud.gov authentication
 
@@ -30,7 +32,7 @@ There are two important cloud.gov URLs you will need to use:
 - `https://uaa.cloud.gov/oauth/token`, which is where you will exchange auth codes for auth tokens
 {{% /eastwest %}}
 
-If you are already familiar with OAuth 2.0, you might know where to go from here. If not, read on for a minimal example of how to do the OAuth dance. Below is the basic gist of it.
+If you are already familiar with OAuth 2.0, you might know where to go from here. If not, read on for a basic example of how to do the OAuth dance.
 
 #### Send your user to login.fr.cloud.gov
 

--- a/content/docs/getting-started/accounts.md
+++ b/content/docs/getting-started/accounts.md
@@ -10,8 +10,8 @@ weight: -100
 
 * **If you're in GSA or EPA:** You automatically have access and can log in using your agency credentials.
 * **If you're in FDIC:** Some FDIC staff automatically have access and can log in using agency credentials. If you try to log in and receive a "status message is null" error, contact the FDIC identity team to be added to the cloud.gov access group.
-* **If you're outside GSA/EPA/FDIC and your team already uses cloud.gov:** Ask a teammate to [invite you]({{< relref "managing-teammates.md" >}}).
-* **Otherwise:** If you have a U.S. federal government email address and would like to try cloud.gov, you can [get access to a sandbox space]({{< relref "overview/pricing/free-limited-sandbox.md" >}}).
+* **If you're in another agency:** If you have a U.S. federal government email address, you can [invite yourself](https://account.fr.cloud.gov/signup). This automatically gives you [a sandbox space]({{< relref "overview/pricing/free-limited-sandbox.md" >}}).
+* **Otherwise:** If your team uses cloud.gov and you don't have a federal government email address (such as if you're a contractor), ask a teammate to [invite you]({{< relref "managing-teammates.md" >}}).
 
 ## To log into cloud.gov
 


### PR DESCRIPTION
This is a followup to @LindsayYoung's excellent point in #cloud-gov-support and https://github.com/18F/cg-site/pull/842 that the instructions for cloud.gov access are confusing for both devs & users who are trying to use the authentication service. This would replace that PR.

Changes on leveraging authentication page:

* Update the intro to the service to include the cloud.gov IDP and accommodate contractors.
* Explain that it's authentication, not authorization.
* Advise developers on how to guide their users.
* Remove an unrelated redundant sentence.

Changes on account setup page:

* Reorganize the instructions for people who aren't in FDIC/EPA/GSA - even if their team already uses cloud.gov, they can just sign up, instead of asking a teammate to invite them.
* Include a direct link to the signup page, with the sandbox info page as a secondary resource, to help people get to the point faster if they know that's what they want.