### PR TITLE
Try clarifying ssh environment setup

### DIFF
--- a/content/docs/apps/using-ssh.md
+++ b/content/docs/apps/using-ssh.md
@@ -15,7 +15,7 @@ ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-comma
 command, which lets you securely log in to an application instance where you can
 perform debugging, environment inspection, and other tasks.
 
-Your application environment is not completely setup when you log in. You'll want
+Your application environment is not completely setup when you log in. You'll probably need
 to [configure your session to match your application's
 environment](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-env)
 in order to debug your application.

--- a/content/docs/apps/using-ssh.md
+++ b/content/docs/apps/using-ssh.md
@@ -10,7 +10,15 @@ Here's how to get a SSH shell in the environment where your app is running. You 
 {{% govcloud %}}
 ### CF SSH
 
-You can get a shell via the [`cf ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-command) command, which lets you securely log in to an application instance where you can perform debugging, environment inspection, and other tasks. You'll want to [configure your session to match your application's environment](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-env).
+You can get a shell via the [`cf
+ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-command)
+command, which lets you securely log in to an application instance where you can
+perform debugging, environment inspection, and other tasks.
+
+Your application environment is not completely setup when you log in. You'll want
+to [configure your session to match your application's
+environment](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-env)
+in order to debug your application.
 
 You can interact directly with the services bound to your application via [port-forwarding](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-services.html). This allows you to access those services using native clients on your local machine. The [Service Connect plugin](https://github.com/18F/cf-service-connect#readme) makes this even easier.
 


### PR DESCRIPTION
Debugging an issue with @laurenancona and neither of us picked up on the fact that after logging into an app with `cf ssh` you still need to run some setup commands in order to run your app. This is my weak attempt at trying to make that more clear, short of copy/pasting commands from the Cloud Foundry docs.

Feel free to improve :)