### PR TITLE
Don't assume apps end up at appname.app.cloud.gov

### DIFF
--- a/content/docs/apps/deployment.md
+++ b/content/docs/apps/deployment.md
@@ -21,7 +21,7 @@ The command to create a new app and to push a new version of an existing one are
     ```
 1. Deploy the application: `cf push <APPNAME>`
 
-The app should now be live at `APPNAME.app.cloud.gov`.
+Check the resulting `cf` command line messages for the route for your app, usually `APPNAME.app.cloud.gov` or similar.
 
 ## Application architecture principles
 

--- a/content/docs/getting-started/your-first-deploy.md
+++ b/content/docs/getting-started/your-first-deploy.md
@@ -12,23 +12,22 @@ To get used to cloud.gov, practice by deploying a simple "hello world" applicati
 1. Visit [this collection of "hello world" applications (tiny sample applications)](https://github.com/18F/cf-hello-worlds) and use **Clone or download** to make a copy on your computer. You can download the zip file provided there, or if you use [`git`](https://git-scm.com/) on the command line, you can enter `git clone https://github.com/18F/cf-hello-worlds.git`
 1. Move into that directory, for example: `cd cf-hello-worlds`
 1. Look at the collection of tiny apps, and `cd` into the directory for the language/framework you feel most comfortable with. For example: `cd python-flask`
-1. Deploy the application, where `APPNAME` should be something unique like `FRAMEWORK-YOURNAME` (e.g. `nodejs-aidan`). By default on cloud.gov, `APPNAME` is used to construct a route to make your application reachable at https://APPNAME.app.cloud.gov/. Route names must be unique across the platform.
-
+1. Deploy the application, where `APPNAME` should be something unique like `FRAMEWORK-YOURNAME` (e.g. `nodejs-aidan`). By default, your `APPNAME` will become part of the route to make your application publicly reachable, usually `https://APPNAME.app.cloud.gov/` or similar, and route names must be unique across the platform.
 
     ```bash
-    cf push <APPNAME>
+    cf push APPNAME
     ```
-1. Visit it at https://APPNAME.app.cloud.gov/
+1. You'll see a series of messages noting the stages of creating the app. When complete, it'll say "App started" and give information about your app. Use the `urls` line (`urls: [ROUTENAME].app.cloud.gov`) to visit your app on the web.
 1. Try editing the app locally (without committing) and run `cf push <APPNAME>` again to see your changes. The changes will be reflected even without being committed to Git. cloud.gov is not Git-aware – it simply deploys whatever is contained in the directory that you `push` from. You can set up [continuous deployment]({{< relref "docs/apps/continuous-deployment.md" >}}) from a Git repository.
 1. Visit the dashboard ([`https://dashboard.fr.cloud.gov/`](https://dashboard.fr.cloud.gov/)) to see your options for managing your application via your browser.
 1. If you're done, you can delete your app by running `cf delete <APPNAME>`
 
 ## Good to know
 
-Check out [**Status**](https://cloudgov.statuspage.io/), which tells you about cloud.gov service disruptions. You can use **Subscribe to Updates** in the upper right corner to get email or SMS notifications about platform problems that may affect cloud.gov users.
+Check out [Status](https://cloudgov.statuspage.io/), which tells you about cloud.gov service disruptions. You can use "Subscribe to Updates" in the upper right corner to get email or SMS notifications about platform problems that may affect cloud.gov users.
 
 cloud.gov is based on Cloud Foundry, so in general, the [the Cloud Foundry documentation](http://docs.cloudfoundry.org) and other Cloud Foundry resources mostly apply to cloud.gov. For example, you can also try deploying the [sample apps maintained by the Cloud Foundry community](https://github.com/cloudfoundry-samples).
 
 ## Next steps
 
-Next, check out [Concepts]({{< relref "concepts.md" >}}) for an overview of cloud.gov terms and architecture. Then, head over to [general deployment instructions]({{< relref "docs/apps/deployment.md" >}}) for an introduction to deploying your own applications on cloud.gov.
+Next, check out [Concepts]({{< relref "concepts.md" >}}) for an overview of cloud.gov terms and architecture. Then, head over to [**deployment instructions and architecture principles**]({{< relref "docs/apps/deployment.md" >}}) for an introduction to deploying your own applications on cloud.gov.


### PR DESCRIPTION
The main change here is to ask readers to check their `cf push` command results to find the route for their app, instead of assuming it'll end up at `appname.app.cloud.gov`.

This is because there are various cases where `appname.app.cloud.gov` doesn't happen. Examples:
* A user ran into the behavior that periods in an app name get converted to dashes in the route (for the cloud.gov team, [here's the support ticket](https://cloud-gov.zendesk.com/agent/tickets/416)).
* Some apps have [`random-route: true` in the manifest](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#random-route) (like [this sample app](https://github.com/cloudfoundry-samples/cf-sample-app-nodejs/blob/master/manifest.yml)), which means that if you do `cf push nodesample`, you'll get a couple random words added to your route, like `nodesample-tressured-philhellene.app.cloud.gov`.
* You can do other things with your route in your manifest, such as [no-route](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#no-route), [routes](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#routes), etc.

I also made minor formatting changes to the next steps at the bottom of "your first deploy" to help direct people toward learning about application architecture.