### PR TITLE
Add info about resetting password for IDP

### DIFF
--- a/content/docs/getting-started/accounts.md
+++ b/content/docs/getting-started/accounts.md
@@ -31,7 +31,7 @@ Follow [these instructions to log in on the command line (CLI) and web UI (dashb
 
 Your cloud.gov account requires setting up both a password and an authentication application that generates token codes, such as [Google Authenticator](https://support.google.com/accounts/answer/1066447?hl=en) or [Authy](https://www.authy.com/app/mobile). (You can use any authentication application that supports the standard [Time-based One-Time Password algorithm](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm).) When you log into cloud.gov for the first time, follow the instructions to set this up.
 
-To change your password: if you're logged in, you can [change your password here](https://account.fr.cloud.gov/change-password). If you're logged out and forgot your password, you can [reset your password](https://account.fr.cloud.gov/forgot-password).
+To change your password: if you're logged in, you can [change your password here](https://account.fr.cloud.gov/change-password). If you're logged out and forgot your password, you can [reset your password](https://account.fr.cloud.gov/forgot-password) to log in with a temporary password, then [change your password](https://account.fr.cloud.gov/change-password).
 
 #### If you can't access your token codes
 

--- a/content/docs/getting-started/accounts.md
+++ b/content/docs/getting-started/accounts.md
@@ -31,6 +31,8 @@ Follow [these instructions to log in on the command line (CLI) and web UI (dashb
 
 Your cloud.gov account requires setting up both a password and an authentication application that generates token codes, such as [Google Authenticator](https://support.google.com/accounts/answer/1066447?hl=en) or [Authy](https://www.authy.com/app/mobile). (You can use any authentication application that supports the standard [Time-based One-Time Password algorithm](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm).) When you log into cloud.gov for the first time, follow the instructions to set this up.
 
+To change your password: if you're logged in, you can [change your password here](https://account.fr.cloud.gov/change-password). If you're logged out and forgot your password, you can [reset your password](https://account.fr.cloud.gov/forgot-password).
+
 #### If you can't access your token codes
 
 If you lose access to your authentication application (such as if you lose your phone), email [cloud.gov support](/help/) so that we can allow you to set up a new one. We'll follow this process to mitigate the risk of requests from compromised email addresses:


### PR DESCRIPTION
In the same line as the effort at https://github.com/18F/cg-uaa-extras/pull/95 to clarify the password reset process. These two PRs don't depend on each other; you can merge one without the other.