### PR TITLE
Better info about automated user creation

### DIFF
--- a/content/docs/services/cloud-gov-service-account.md
+++ b/content/docs/services/cloud-gov-service-account.md
@@ -21,7 +21,7 @@ Plan Name | Description | Price
 
 ## How to create an instance
 
-After you create one of these service instances, you will see a new "user" in your org and space with a name made of 36 letters, numbers, and dashes as its unique identifier. 
+After you create one of these service instances, you will see a new "user" in your org and space with a name made of 36 letters, numbers, and dashes as its unique identifier, similar to `f6ab4cfb-6e6c-4b10-8585-3f39e740905c`.
 
 To create a service instance that can deploy applications, run the following command:
 

--- a/content/docs/services/cloud-gov-service-account.md
+++ b/content/docs/services/cloud-gov-service-account.md
@@ -21,6 +21,8 @@ Plan Name | Description | Price
 
 ## How to create an instance
 
+After you create one of these service instances, you will see a new "user" in your org and space with a name made of 36 letters and numbers as its unique identifier. It's good to know that this is normal.
+
 To create a service instance that can deploy applications, run the following command:
 
 ```bash
@@ -36,8 +38,6 @@ cf create-service cloud-gov-service-account space-auditor <SERVICE-INSTANCE-NAME
 ## More information
 
 To use this service, see [continuous deployment]({{< relref "docs/apps/continuous-deployment.md" >}}).
-
-After this process is completed, you will see the space deployer as a SpaceDeveloper with a guid as its name.
 
 ### The broker in GitHub
 

--- a/content/docs/services/cloud-gov-service-account.md
+++ b/content/docs/services/cloud-gov-service-account.md
@@ -21,7 +21,7 @@ Plan Name | Description | Price
 
 ## How to create an instance
 
-After you create one of these service instances, you will see a new "user" in your org and space with a name made of 36 letters and numbers as its unique identifier. It's good to know that this is normal.
+After you create one of these service instances, you will see a new "user" in your org and space with a name made of 36 letters, numbers, and dashes as its unique identifier. 
 
 To create a service instance that can deploy applications, run the following command:
 


### PR DESCRIPTION
Noting the automated user creation upfront and with more specific detail, so that people know what to expect. This also applies to both the Auditor and Developer services.