### PR TITLE
Provide more direct guidance to the service usage docs

### DIFF
--- a/content/docs/services/relational-database.md
+++ b/content/docs/services/relational-database.md
@@ -53,13 +53,15 @@ cf create-service aws-rds medium-psql my-db-service -c '{"storage": 50}'
 
 ### Bind to an application
 
-`cf bind-service` will provide a `DATABASE_URL` environment variable for your app, which is then picked up by the `restage`. Note that for a Rails app, `bind-service` will [overwrite your `database.yml`](http://docs.cloudfoundry.org/buildpacks/ruby/ruby-service-bindings.html#rails-applications-have-autoconfigured-database-yml). The full documentation for managing service instances is [here](https://docs.cloudfoundry.org/devguide/services/managing-services.html).
+To use the service instance from your application, "bind" the service instance to the application. For an overview of this process and how to retrieve the credentials for the service instance from environment variables, see [Bind a Service Instance](https://docs.cloudfoundry.org/devguide/services/managing-services.html#bind) and the linked details at [Delivering Service Credentials to an Application](https://docs.cloudfoundry.org/devguide/services/application-binding.html).
+
+In short, `cf bind-service` will provide a `DATABASE_URL` environment variable for your app, which is then picked up by the `restage`. Note that for a Rails app, `bind-service` will [overwrite your `database.yml`](http://docs.cloudfoundry.org/buildpacks/ruby/ruby-service-bindings.html#rails-applications-have-autoconfigured-database-yml).
 
 The contents of the `DATABASE_URL` environment variable contain the credentials to access your database. Treat the contents of this and all other environment variables as sensitive.
 
 ## Access the data in the database
 
-There are currently two ways to access the database.
+There are currently two ways to access the database directly.
 
 1. [The `cg-migrate-db` plugin](#cg-migrate-db-plugin). It is a self contained
 executable which will interactively assist with accessing the data in the

--- a/content/docs/services/relational-database.md
+++ b/content/docs/services/relational-database.md
@@ -53,7 +53,7 @@ cf create-service aws-rds medium-psql my-db-service -c '{"storage": 50}'
 
 ### Bind to an application
 
-To use the service instance from your application, "bind" the service instance to the application. For an overview of this process and how to retrieve the credentials for the service instance from environment variables, see [Bind a Service Instance](https://docs.cloudfoundry.org/devguide/services/managing-services.html#bind) and the linked details at [Delivering Service Credentials to an Application](https://docs.cloudfoundry.org/devguide/services/application-binding.html).
+To use the service instance from your application, bind the service instance to the application. For an overview of this process and how to retrieve the credentials for the service instance from environment variables, see [Bind a Service Instance](https://docs.cloudfoundry.org/devguide/services/managing-services.html#bind) and the linked details at [Delivering Service Credentials to an Application](https://docs.cloudfoundry.org/devguide/services/application-binding.html).
 
 In short, `cf bind-service` will provide a `DATABASE_URL` environment variable for your app, which is then picked up by the `restage`. Note that for a Rails app, `bind-service` will [overwrite your `database.yml`](http://docs.cloudfoundry.org/buildpacks/ruby/ruby-service-bindings.html#rails-applications-have-autoconfigured-database-yml).
 


### PR DESCRIPTION
We've received several support requests about how to use the aws-rds service (links for cloud.gov teammates: [example 1](https://cloud-gov.zendesk.com/agent/tickets/425), [example 2](https://cloud-gov.zendesk.com/agent/tickets/426)), so here's an effort at providing more direct guidance to the instructions for binding a service instance.

This needs technical review.