### PR TITLE
Link to GSA/cloud.gov google drive for notes when contingency plan activated

### DIFF
--- a/content/docs/ops/contingency-plan.md
+++ b/content/docs/ops/contingency-plan.md
@@ -48,7 +48,7 @@ The IC notifies and coordinates with the following people as well:
 * Designated FedRAMP personnel (when applicable)
 * cloud.gov users ([through StatusPage]({{< relref "making-announcements.md" >}}), when applicable)
 
-The IC keeps a log of the situation in a GSA Google Drive document; if this is also a security incident, the IC also follows the [security incident communications process]({{< relref "security-ir.md#initiate" >}}) (which includes updating a GitHub issue, updating the 18F #incident-response channel, and sending sitreps by email to GSA Information Security). The IC should delegate assistant ICs for aspects of the situation as necessary.
+The IC keeps a log of the situation in a [GSA Google Drive document](https://drive.google.com/drive/folders/0B58iDAWKmw_BSEtqcUFFQ041MHc); if this is also a security incident, the IC also follows the [security incident communications process]({{< relref "security-ir.md#initiate" >}}) (which includes updating a GitHub issue, updating the 18F #incident-response channel, and sending sitreps by email to GSA Information Security). The IC should delegate assistant ICs for aspects of the situation as necessary.
 
 ### Recovery
 


### PR DESCRIPTION
Add link to cloud.gov drive for storing notes in case of contingency plan activation