### PR TITLE
Add more info about using services properly

### DIFF
--- a/content/docs/apps/continuous-deployment.md
+++ b/content/docs/apps/continuous-deployment.md
@@ -46,7 +46,7 @@ You can provision a deployer account with permission to deploy to a single space
     Dashboard: https://fugacious.18f.gov/m/k3MtzJWVZaNlnjBYJ7FUdpW2ZkDvhmQz
     ```
 
-1. Retrieve your credentials from the dashboard link. Be sure to retrieve your credentials right away, since the link will only work for a brief length of time. Keep these credentials secure. If they're compromised, delete your deployer account and create another.
+1. Retrieve your credentials from the dashboard link. Be sure to retrieve your credentials right away, since the link will only work for a brief length of time. Keep these credentials secure. If they’re compromised, the way to invalidate the credentials is to delete the service instance (you can create another, and it will have a fresh set of credentials). <!-- this advice should match on /docs/apps/continuous-deployment/ + /docs/services/cloud-gov-service-account/ + /docs/services/cloud-gov-identity-provider/ -->
 
 To delete your deployer account, delete the service instance:
 

--- a/content/docs/apps/managed-services.md
+++ b/content/docs/apps/managed-services.md
@@ -31,7 +31,7 @@ Target the org and space which will hold the app to which the service instance w
 % cf target -o ORG -s SPACE
 ```
 
-Create a new service instance by specifying a service, plan, and a name of your choice for the service instance. Note that service instance names must be unique and can be renamed.
+Create a new service instance by specifying a service, plan, and a name of your choice for the service instance. Note that service instance names must be unique and can be renamed. For some services, you'll need to include additional parameters in your create-service command -- refer to [the services guide]({{< relref "docs/services/index.md" >}}) for details.
 
 ```
 % cf create-service SERVICE_NAME PLAN_NAME INSTANCE_NAME

--- a/content/docs/services/cloud-gov-identity-provider.md
+++ b/content/docs/services/cloud-gov-identity-provider.md
@@ -42,7 +42,7 @@ Once you've created the service instance, you'll want to obtain your client ID a
 cf service my-uaa-client
 ```
 
-This will display a link to a page on [Fugacious](https://fugacious.18f.gov/) which contains your credentials.
+This will display a link to a page on [Fugacious](https://fugacious.18f.gov/) which contains your credentials. Be sure to retrieve your credentials right away, since the link will only work for a brief length of time. Keep these credentials secure. If they’re compromised, the way to invalidate the credentials is to delete the service instance (you can create another, and it will have a fresh set of credentials). <!-- this advice should match on /docs/apps/continuous-deployment/ + /docs/services/cloud-gov-service-account/ + /docs/services/cloud-gov-identity-provider/ -->
 
 ## More information
 

--- a/content/docs/services/cloud-gov-service-account.md
+++ b/content/docs/services/cloud-gov-service-account.md
@@ -43,7 +43,9 @@ Once you've created the service instance, you'll want to obtain the username and
 cf service <SERVICE-INSTANCE-NAME>
 ```
 
-This will display a link to a page on [Fugacious](https://fugacious.18f.gov/) which contains your credentials. These can be used with the `cf login` command in automated deployment scripts.
+This will display a link to a page on [Fugacious](https://fugacious.18f.gov/) which contains your credentials. Be sure to retrieve your credentials right away, since the link will only work for a brief length of time. Keep these credentials secure. If they’re compromised, the way to invalidate the credentials is to delete the service instance (you can create another, and it will have a fresh set of credentials). <!-- this advice should match on /docs/apps/continuous-deployment/ + /docs/services/cloud-gov-service-account/ + /docs/services/cloud-gov-identity-provider/ -->
+
+These credentials can be used with the `cf login` command in automated deployment scripts.
 
 ## More information
 


### PR DESCRIPTION
Small improvements from trying to learn more about how services work:

* Be less prescriptive about the way to handle compromised credentials, since we don't know if deletion is the appropriate procedure for all customers (some customers may be required to contain/preserve rather than delete): "If they're compromised, delete your deployer account and create another." -> "If they’re compromised, the way to invalidate the credentials is to delete the service instance (you can create another, and it will have a fresh set of credentials)."
* Add note to managed services page to let readers know that some services require parameters for creation.
* Add matching notes to service-account service page and identity-provider service page about protecting credentials, and update continuous deployment page note about this to match them.

This needs technical review to make sure these recommendations make sense.