### PR TITLE
Clarify future pricing in the service docs

### DIFF
--- a/content/docs/apps/managed-services.md
+++ b/content/docs/apps/managed-services.md
@@ -45,7 +45,7 @@ For example, to create an instance of the elasticsearch service using the free p
 
 ##### Paid services
 
-The note `* These service plans have an associated cost` indicates paid services. [Learn about managed service pricing.]({{< relref "overview/pricing/rates.md#managed-services" >}})
+The note `* These service plans have an associated cost` indicates paid services. [Learn about managed service pricing.]({{< relref "overview/pricing/managed-services-cost.md" >}})
 
 #### Bind the service instance
 

--- a/content/docs/services/relational-database.md
+++ b/content/docs/services/relational-database.md
@@ -15,21 +15,18 @@ If your application uses relational databases for storage, you can use the AWS R
 Plan Name | Description | Price
 --------- | ----------- | -----
 `shared-psql`            | Shared PostgresSQL database for prototyping (no sensitive or production data) | Free
-`medium-psql`            | Dedicated medium RDS PostgreSQL DB instance                                   | $0.115 / hr + storage
-`medium-psql-redundant`  | Dedicated redundant medium RDS PostgreSQL DB instance                         | $0.230 / hr + storage
-`large-psql`             | Dedicated large RDS PostgreSQL DB instance                                    | $0.230 / hr + storage
-`large-psql-redundant`   | Dedicated redundant large RDS PostgreSQL DB instance                          | $0.470 / hr + storage
+`medium-psql`            | Dedicated medium RDS PostgreSQL DB instance                                   | Will be paid per hour + storage
+`medium-psql-redundant`  | Dedicated redundant medium RDS PostgreSQL DB instance                         | Will be paid per hour + storage
+`large-psql`             | Dedicated large RDS PostgreSQL DB instance                                    | Will be paid per hour + storage
+`large-psql-redundant`   | Dedicated redundant large RDS PostgreSQL DB instance                          | Will be paid per hour + storage
 `shared-mysql`           | Shared MySQL database for prototyping (no sensitive or production data)       | Free
-`medium-mysql`           | Dedicated medium RDS MySQL DB instance                                        | $0.110 / hr + storage
-`medium-mysql-redundant` | Dedicated redundant medium RDS MySQL DB instance                              | $0.220 / hr + storage
-`large-mysql`            | Dedicated large RDS MySQL DB instance                                         | $0.220 / hr + storage
-`large-mysql-redundant`  | Dedicated redundant large RDS MySQL DB instance                               | $0.440 / hr + storage
+`medium-mysql`           | Dedicated medium RDS MySQL DB instance                                        | Will be paid per hour + storage
+`medium-mysql-redundant` | Dedicated redundant medium RDS MySQL DB instance                              | Will be paid per hour + storage
+`large-mysql`            | Dedicated large RDS MySQL DB instance                                         | Will be paid per hour + storage
+`large-mysql-redundant`  | Dedicated redundant large RDS MySQL DB instance                               | Will be paid per hour + storage
 
-### Storage pricing:
-
-- Shared instance: Free
-- Simple instance: $0.138 per GB per month
-- Redundant instance: $0.276 per GB per month
+### Pricing
+Shared instances are free. Simple and redundant instances will have pricing per hour and per GB per month. [Learn more about managed service pricing.]({{< relref "overview/pricing/managed-services-cost.md" >}})
 
 ## Options
 

--- a/content/docs/services/s3.md
+++ b/content/docs/services/s3.md
@@ -16,8 +16,12 @@ You can store application content in S3 using a [managed service]({{< relref "do
 
 Plan Name | Description | Price
 --------- | ----------- | -----
-`basic`   | A single private bucket with unlimited storage | $0.03 / GB / month
-`basic-public` | A single public bucket with unlimited storage, where the files are **all public** to read | $0.03 / GB / month
+`basic`   | A single private bucket with unlimited storage | Will be paid per GB per month
+`basic-public` | A single public bucket with unlimited storage, where the files are **all public** to read | Will be paid per GB per month
+
+### Pricing
+
+Instances will have pricing per GB per month. [Learn about managed service pricing.]({{< relref "overview/pricing/managed-services-cost.md" >}})
 
 ## How to create an instance
 


### PR DESCRIPTION
Remove the listed prices for the S3 and RDS services since we aren't charging for them yet, to reduce confusion.