### PR TITLE
Add transaction to totp reset example

### DIFF
--- a/content/docs/ops/managing-users.md
+++ b/content/docs/ops/managing-users.md
@@ -42,7 +42,9 @@ If the user requesting a reset has any apps, routes, or services in their sandbo
 
     ```bash
     $ psql postgres://{db_user}:{db_pass}@{db_address:port}/uaadb
+    => begin;
     => delete from totp_seed where username = "{email.address}";
+    => commit;
     ```
 
 4. Let the user know the reset process is complete, so they can set up a new authentication application and request access from Space Managers and Org Managers again.


### PR DESCRIPTION
Manual edits to a production database should always be done in a transaction in case something goes awry.