### PR TITLE
Use cf-service-connect plugin instead of random cli binaries.

### DIFF
--- a/content/docs/services/relational-database.md
+++ b/content/docs/services/relational-database.md
@@ -81,41 +81,28 @@ The instructions below are for PostgreSQL, but should be similar for MySQL or ot
 
 #### Using cf ssh
 
-To access a service database, use the [cf ssh]({{< relref "docs/getting-started/one-off-tasks.md#cf-ssh" >}}) CLI command to login to an instance that is bound to the service and download the `psql` binary to that instance:
-
-```sh
-cf ssh APP_NAME
-curl https://s3.amazonaws.com/18f-cf-cli/psql-9.4.4-ubuntu-14.04.tar.gz | tar xvz
-./psql/bin/psql $DATABASE_URL
-```
-
-You should now have an open `psql` terminal connected to the service database.
-
-You can also use the [cf-service-connect plugin](https://github.com/18F/cf-service-connect#readme) for a shortcut way to do this.
+To access a service database, use the [cf-service-connect plugin](https://github.com/18F/cf-service-connect#readme).
 
 ### Export
 
 #### Create backup
 
-#### Using cf ssh
-
-First, connect to an instance:
+First, connect to an instance using the [cf-service-connect plugin](https://github.com/18F/cf-service-connect#readme):
 
 ```sh
-$ cf ssh {app name}
+$ cf connect-to-service --no-client ${APP_NAME} ${SERVICE_NAME}
+...
+Host: localhost
+Port: ...
+Username: ...
+Password: ...
+Name: ...
 ```
 
-Next, install the Postgresql tools:
+Without closing the SSH session managed by the cf-service-connect plugin, create the backup file using the parameters provided by the plugin:
 
 ```sh
-$ curl https://s3.amazonaws.com/18f-cf-cli/psql-9.4.4-ubuntu-14.04.tar.gz > psql.tgz
-$ tar xzvf psql.tgz
-```
-
-Now you can create the export file:
-
-```sh
-$ psql/bin/pg_dump --format=custom $DATABASE_URL > backup.pg
+$ pg_dump postgresql://${USERNAME}:${PASSWORD}@${HOST}/${PORT}/${NAME} -f backup.pg
 ```
 
 ### Download


### PR DESCRIPTION
Because we don't want to encourage users to use unmaintained cli binaries from a random s3 bucket, and we also don't want to maintain those binaries.