### PR TITLE
Update sql query for dropping user from TOTP Seed

### DIFF
--- a/content/docs/ops/managing-users.md
+++ b/content/docs/ops/managing-users.md
@@ -43,7 +43,7 @@ If the user requesting a reset has any apps, routes, or services in their sandbo
     ```bash
     $ psql postgres://{db_user}:{db_pass}@{db_address:port}/uaadb
     => begin;
-    => delete from totp_seed where username = "{email.address}";
+    => delete from totp_seed where "username" = '{email.address}';
     => commit;
     ```
 


### PR DESCRIPTION
After trying these instructions, I received an error.

Upon running:
`DELETE FROM totp_seed WHERE username = "email@address.com";`
I received this error:
`ERROR:  column "email@address.com" does not exist`

Changed the query to what worked for me.