### PR TITLE
changing name from Fugacious to Toaster

### DIFF
--- a/content/docs/services/cloud-gov-identity-provider.md
+++ b/content/docs/services/cloud-gov-identity-provider.md
@@ -42,7 +42,7 @@ Once you've created the service instance, you'll want to obtain your client ID a
 cf service my-uaa-client
 ```
 
-This will display a link to a page on [Fugacious](https://fugacious.18f.gov/) which contains your credentials. Be sure to retrieve your credentials right away, since the link will only work for a brief length of time. Keep these credentials secure. If they’re compromised, the way to invalidate the credentials is to delete the service instance (you can create another, and it will have a fresh set of credentials). <!-- this advice should match on /docs/apps/continuous-deployment/ + /docs/services/cloud-gov-service-account/ + /docs/services/cloud-gov-identity-provider/ -->
+This will display a link to a page on [Toaster](https://fugacious.18f.gov/) (Fugacious) which contains your credentials. Be sure to retrieve your credentials right away, since the link will only work for a brief length of time. Keep these credentials secure. If they’re compromised, the way to invalidate the credentials is to delete the service instance (you can create another, and it will have a fresh set of credentials). <!-- this advice should match on /docs/apps/continuous-deployment/ + /docs/services/cloud-gov-service-account/ + /docs/services/cloud-gov-identity-provider/ -->
 
 ## More information
 


### PR DESCRIPTION
FYI, the service is still located at fugacious.18f.gov, so we may need to change this in the future. 