### PR TITLE
Move framework examples higher and mention popular CMSes

### DIFF
--- a/content/docs/apps/frameworks.md
+++ b/content/docs/apps/frameworks.md
@@ -17,6 +17,10 @@ cloud.gov uses [buildpacks]({{< relref "docs/getting-started/concepts.md#buildpa
 
 cloud.gov supports applications written in Go, Java, Node.js, .NET Core, PHP, Python, and Ruby. cloud.gov also supports applications that rely on a static binary that uses the 64-bit Linux kernel ABI, or that consist of static HTML, CSS, and Javascript assets. See the [Cloud Foundry system (supported) buildpacks list](http://docs.cloudfoundry.org/buildpacks/#system-buildpacks) for details.
 
+## Examples
+
+Check out [cloud.gov's collection of Hello World applications](https://github.com/18F/cf-hello-worlds) and [Cloud Foundry's sample applications](https://github.com/cloudfoundry-samples) for examples in many different languages and frameworks, including [Drupal](https://github.com/18F/cf-ex-drupal), [WordPress](https://github.com/18F/cf-ex-wordpress) and [SuiteCRM](https://github.com/18F/cf-example-suitecrm).
+
 ## Other languages
 
 You can use a custom buildpack to support other languages. See [custom buildpacks]({{< relref "docs/apps/experimental/custom-buildpacks.md" >}}) for more information about this experimental feature.
@@ -26,7 +30,3 @@ Cloud Foundry has a list of [community buildpacks](http://docs.cloudfoundry.org/
 ## Cannot run
 
 cloud.gov cannot run applications that use .NET Framework, or application binaries that require access to Microsoft Windows kernel or system APIs.
-
-## Examples
-
-Check out the [Cloud Foundry sample applications](https://github.com/cloudfoundry-samples) and [cloud.gov's collection of Hello World applications](https://github.com/18F/cf-hello-worlds) for examples of applications in many different languages.

--- a/content/docs/apps/frameworks.md
+++ b/content/docs/apps/frameworks.md
@@ -19,7 +19,7 @@ cloud.gov supports applications written in Go, Java, Node.js, .NET Core, PHP, Py
 
 ## Examples
 
-Check out [cloud.gov's collection of Hello World applications](https://github.com/18F/cf-hello-worlds) and [Cloud Foundry's sample applications](https://github.com/cloudfoundry-samples) for examples in many different languages and frameworks, including [Drupal](https://github.com/18F/cf-ex-drupal), [WordPress](https://github.com/18F/cf-ex-wordpress) and [SuiteCRM](https://github.com/18F/cf-example-suitecrm).
+You can explore examples of many languages and frameworks, including [Drupal](https://github.com/18F/cf-ex-drupal), [WordPress](https://github.com/18F/cf-ex-wordpress), [SuiteCRM](https://github.com/18F/cf-example-suitecrm) and [more](https://github.com/18F/cf-hello-worlds). If none of those suit your needs, Cloud Foundry has even more [sample applications](https://github.com/cloudfoundry-samples).
 
 ## Other languages
 


### PR DESCRIPTION
This PR adds links to our Drupal, WordPress and SuiteCRM examples so those terms will be indexed for site search and otherwise made easier to find on the [Languages and Frameworks](https://cloud.gov/docs/apps/frameworks/) page of the docs.

Context: potential customers have been asking whether they can run specific CMSes on cloud.gov. Though several are represented in our `cf-example-*` repos, they're currently discoverable only via the`cf-hello-worlds` repo's README.

Minimally closes https://favro.com/card/1e11108a2da81e3bd7153a7a/18F-6009.