### PR TITLE
Make the s3 service key example work.

### DIFF
--- a/content/docs/services/s3.md
+++ b/content/docs/services/s3.md
@@ -78,11 +78,11 @@ For automated or CLI processes, you may want to use the [jq](https://stedolan.gi
 For example, you might want to use the [AWS Command Line Interface](https://aws.amazon.com/cli/) to add, modify, and download files in a bucket. The AWS CLI requires the values above as environment variables. This script will set them:
 
 ```bash
-export INSTANCE_NAME=your-s3-service-instance-name-here
-export KEY_NAME=your-service-key-name-here
+INSTANCE_NAME=your-s3-service-instance-name-here
+KEY_NAME=your-service-key-name-here
 
 cf create-service-key "${INSTANCE_NAME}" "${KEY_NAME}"
-export S3_CREDENTIALS=`cf service-key "${KEY_NAME}" | tail -n +2`
+S3_CREDENTIALS=`cf service-key "${INSTANCE_NAME}" "${KEY_NAME}" | tail -n +2`
 
 export AWS_ACCESS_KEY_ID=`echo "${S3_CREDENTIALS}" | jq -r .access_key_id`
 export AWS_SECRET_ACCESS_KEY=`echo "${S3_CREDENTIALS}" | jq -r .secret_access_key`


### PR DESCRIPTION
* Fix broken `cf service-key` usage
* Don't export json; breaks in zsh