### PR TITLE
Add Links For Security Issues

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -23,6 +23,9 @@
         <li>
           <a href="https://18f.gsa.gov/vulnerability-disclosure-policy/">Vulnerability disclosure policy</a>
         </li>
+        <li>
+          <a href="/docs/help">Security Issues</a>
+        <li>
       </ul>
     </section>
 </footer>


### PR DESCRIPTION
Folks who are looking to contact about a security issue are going to search for "security" on the page before they settle for "contact".