### PR TITLE
Move Support For Customers To Top Of Page

### DIFF
--- a/content/docs/help.md
+++ b/content/docs/help.md
@@ -7,7 +7,7 @@ aliases:
 
 ### Support for people who use cloud.gov
 
-Email [**cloud-gov-support@gsa.gov**](mailto:cloud-gov-support@gsa.gov). We provide support for cloud.gov during typical business hours for U.S. East and West Coasts. We don't guarantee support for cloud.gov outside those hours, though we're always monitoring for signs of trouble that might affect customers.
+Email [**cloud-gov-support@gsa.gov**](mailto:cloud-gov-support@gsa.gov). If you need to report a security issue to us, the report must come from the System Owner. We provide support for cloud.gov during typical business hours for U.S. East and West Coasts. We don't guarantee support for cloud.gov outside those hours, though we're always monitoring for signs of trouble that might affect customers.  
 
 You shouldn't include any sensitive environment variables or passwords in your support emails; we don't need that information to help you, and we recommend you keep it limited to view by as few people as possible.
 

--- a/content/docs/help.md
+++ b/content/docs/help.md
@@ -5,14 +5,6 @@ aliases:
   - /contact
 ---
 
-### Want to use cloud.gov?
-
-If you're interested in using cloud.gov, email [**cloud-gov-inquiries@gsa.gov**](mailto:cloud-gov-inquiries@gsa.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20project%20or%20your%20questions%20about%20cloud.gov:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A) to tell us about your project and ask your questions. We’ll schedule a call where we can go over needs, options, and questions, then get the [federal Inter-Agency Agreement (IAA/MOU) process]({{< relref "overview/pricing/start-using-cloudgov.md" >}}) underway.
-
-If you have a U.S. federal government email address, you can [**get access to a free sandbox space**]({{< relref "overview/pricing/free-limited-sandbox.md" >}}) and try cloud.gov right away.
-
-To get news about cloud.gov, [**sign up for email updates**](/#updates).
-
 ### Support for people who use cloud.gov
 
 Email [**cloud-gov-support@gsa.gov**](mailto:cloud-gov-support@gsa.gov). We provide support for cloud.gov during typical business hours for U.S. East and West Coasts. We don't guarantee support for cloud.gov outside those hours, though we're always monitoring for signs of trouble that might affect customers.
@@ -20,6 +12,14 @@ Email [**cloud-gov-support@gsa.gov**](mailto:cloud-gov-support@gsa.gov). We prov
 You shouldn't include any sensitive environment variables or passwords in your support emails; we don't need that information to help you, and we recommend you keep it limited to view by as few people as possible.
 
 (If you're GSA TTS staff, you can also talk to us in [#cg-support](https://gsa-tts.slack.com/messages/cg-support).)
+
+### Want to use cloud.gov?
+
+If you're interested in using cloud.gov, email [**cloud-gov-inquiries@gsa.gov**](mailto:cloud-gov-inquiries@gsa.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20project%20or%20your%20questions%20about%20cloud.gov:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A) to tell us about your project and ask your questions. We’ll schedule a call where we can go over needs, options, and questions, then get the [federal Inter-Agency Agreement (IAA/MOU) process]({{< relref "overview/pricing/start-using-cloudgov.md" >}}) underway.
+
+If you have a U.S. federal government email address, you can [**get access to a free sandbox space**]({{< relref "overview/pricing/free-limited-sandbox.md" >}}) and try cloud.gov right away.
+
+To get news about cloud.gov, [**sign up for email updates**](/#updates).
 
 ### Questions from the public and industry
 


### PR DESCRIPTION
Folks who need support need it faster than folks who aren't using cloud.gov yet, so move content for them to the top of the page.