### PR TITLE
Fix rendering of placeholder names on S3 page

### DIFF
--- a/content/docs/services/s3.md
+++ b/content/docs/services/s3.md
@@ -60,7 +60,7 @@ If you need to access multiple S3 buckets using the same access credentials--for
 cf bind-service <APP_NAME> <SERVICE_INSTANCE_NAME>-s3 -c '{"additional_instances": ["<ADDITIONAL_INSTANCE_NAME>"]}'
 ```
 
-The credentials created for this binding will have access to both the bucket managed by <SERVICE_INSTANCE_NAME> and <ADDITIONAL_INSTANCE_NAME>, and the bucket managed by <ADDITIONAL_INSTANCE_NAME> will be listed in the `additional_buckets` field of the credentials.
+The credentials created for this binding will have access to both the bucket managed by `<SERVICE_INSTANCE_NAME>` and `<ADDITIONAL_INSTANCE_NAME>`, and the bucket managed by `<ADDITIONAL_INSTANCE_NAME>` will be listed in the `additional_buckets` field of the credentials.
 
 ### Interacting with your S3 bucket from outside cloud.gov
 


### PR DESCRIPTION
<img width="599" alt="screen shot 2017-07-18 at 5 39 46 pm" src="https://user-images.githubusercontent.com/391313/28341088-26670614-6be0-11e7-8856-bca1dbd5ed13.png">

->

<img width="652" alt="screen shot 2017-07-18 at 5 41 45 pm" src="https://user-images.githubusercontent.com/391313/28341155-65d7ec3c-6be0-11e7-861c-98bc1cb25676.png">


cc @jmcarp 