### PR TITLE
Removing multi-buildpack reference

### DIFF
--- a/content/docs/apps/experimental/custom-buildpacks.md
+++ b/content/docs/apps/experimental/custom-buildpacks.md
@@ -24,12 +24,6 @@ Once you push your code using a custom buildpack, cloud.gov cannot update it for
 
 ## Example custom buildpacks
 
-### buildpack-multi
-
-If you may need multiple buildpacks for a project, we recommend [splitting your project into multiple applications]({{< relref "docs/getting-started/concepts.md">}}#buildpacks) and using one buildpack for each application, or [building assets on CI]({{< relref "assets.md#build-assets-on-ci" >}}).
-
-If you can't do that, Cloud Foundry is capable of deploying multi-language projects with a custom buildpack, [`cf-buildpack-multi`](https://bitbucket.org/cf-utilities/cf-buildpack-multi). This buildpack applies any buildpacks listed in the `.buildpacks` file. Multi-buildpack deploys can be difficult to debug because `cf-buildpack-multi` hides the error logs.
-
 ### apt-buildpack
 
 cloud.gov does not allow the use of `sudo` inside of buildpacks. If your app depends on a library that is `apt-get` installable, you can use the CF flavor of [`apt-buildpack`](https://github.com/pivotal-cf-experimental/apt-buildpack), which is a custom buildpack. This can work with `cf-buildpack-multi`.

--- a/content/docs/apps/experimental/custom-buildpacks.md
+++ b/content/docs/apps/experimental/custom-buildpacks.md
@@ -26,6 +26,6 @@ Once you push your code using a custom buildpack, cloud.gov cannot update it for
 
 ### apt-buildpack
 
-cloud.gov does not allow the use of `sudo` inside of buildpacks. If your app depends on a library that is `apt-get` installable, you can use the CF flavor of [`apt-buildpack`](https://github.com/pivotal-cf-experimental/apt-buildpack), which is a custom buildpack. This can work with `cf-buildpack-multi`.
+cloud.gov does not allow the use of `sudo` inside of buildpacks. If your app depends on a library that is `apt-get` installable, you can use the CF flavor of [`apt-buildpack`](https://github.com/pivotal-cf-experimental/apt-buildpack), which is a custom buildpack.
 
 You can see this in the wild in 18F's [`iaa-pdf-api`](https://github.com/18f/iaa-pdf-api) repo, which depends on the [`pdftk`](https://www.pdflabs.com/tools/pdftk-server/) library.


### PR DESCRIPTION
Now multi-buildpacks are officially supported, and we'll have them as of the deployment of [the new release](https://github.com/cloudfoundry/capi-release/releases/tag/1.36.0) (any day now)! So we may as well stop recommending this path to people to avoid them having to migrate later.