### PR TITLE
Improve explanation of quotas for sandboxes

### DIFF
--- a/content/docs/apps/custom-domains.md
+++ b/content/docs/apps/custom-domains.md
@@ -5,16 +5,17 @@ menu:
 title: Custom domains
 ---
 
-To put your app on your project's custom domain name, use the [CDN service]({{< relref "docs/services/cdn-route.md" >}}).
+### How to set up a custom domain
+By default, your application receives a `*.app.cloud.gov` route. To put your app on your project's custom domain name, use the [CDN service]({{< relref "docs/services/cdn-route.md" >}}).
 
-This supports IPv6.
+This supports IPv6. For all custom domains, we recommend incorporating [HTTPS-Only Standard guidance](https://https.cio.gov/), including [HSTS](https://https.cio.gov/hsts/) and [preloading](https://https.cio.gov/guide/#options-for-hsts-compliance). If your application requires DNSSEC, you are responsible for ensuring your custom domain is DNSSEC-enabled before following these instructions.
 
-For all custom domains, we recommend incorporating [HTTPS-Only Standard guidance](https://https.cio.gov/), including [HSTS](https://https.cio.gov/hsts/) and [preloading](https://https.cio.gov/guide/#options-for-hsts-compliance).
+### Background knowledge
 
-If your application requires DNSSEC, you are responsible for ensuring your custom domain is DNSSEC-enabled before following these instructions.
+[Cloud Foundry's Routes and Domains documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html) explains the overall model and terminology that cloud.gov uses.
 
-For context, [Cloud Foundry's Routes and Domains documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html) explains the overall model and terminology that cloud.gov uses.
+In short, a "route" is a path that can be mapped to an application, such as:
 
-### GSA TTS
-
-If you need to set up an app on a domain managed by GSA TTS, you may also be interested in [18F/dns](https://github.com/18F/dns).
+* `myapp.app.cloud.gov`
+* `myapp.app.cloud.gov/test`
+* `example.gov`

--- a/content/docs/apps/managed-services.md
+++ b/content/docs/apps/managed-services.md
@@ -7,15 +7,9 @@ title: Managed services
 
 Managed services provide applications with on-demand access to services outside of the stateless application environment. Typical managed services include databases, queues, and key-value stores.
 
-### Prerequisites
-
-Verify your [setup is complete]({{< relref "docs/getting-started/setup.md" >}}).
-
-### Procedure
+### List services
 
 To create a service instance and binding for use with an application, you first need to identify the available services and their respective plans.
-
-#### List services
 
 ```
 % cf marketplace
@@ -23,7 +17,7 @@ To create a service instance and binding for use with an application, you first 
 
 See [the services guide]({{< relref "docs/services/index.md" >}}) as well.
 
-#### Create a service instance
+### Create a service instance
 
 Target the org and space which will hold the app to which the service instance will be bound.
 
@@ -37,17 +31,11 @@ Create a new service instance by specifying a service, plan, and a name of your 
 % cf create-service SERVICE_NAME PLAN_NAME INSTANCE_NAME
 ```
 
-For example, to create an instance of the elasticsearch service using the free plan with name `myapp-elasticsearch`:
-
-```
-% cf create-service elasticsearch-swarm-1.7.1 1x myapp-elasticsearch
-```
-
-##### Paid services
+#### Paid services
 
 The note `* These service plans have an associated cost` indicates paid services. [Learn about managed service pricing.]({{< relref "overview/pricing/managed-services-cost.md" >}})
 
-#### Bind the service instance
+### Bind the service instance
 
 A service instance must be bound to the application which will access it. This can be done in a single step by adding a binding to the application's `manifest.yml`.
 
@@ -105,7 +93,7 @@ In this case, `url` alone could be sufficient for establishing a connection from
 
 The contents of the `VCAP_SERVICES` environment variable contain the credentials to access your service. Treat the contents of this and all other environment variables as sensitive.
 
-#### Access the service configuration
+### Access the service configuration
 
 Configuration and credentials for the bound service can be accessed in several ways:
 
@@ -113,7 +101,7 @@ Configuration and credentials for the bound service can be accessed in several w
 * Through a language-specific module such as [cfenv](https://www.npmjs.org/package/cfenv) for node.js.
 * Through buildpack-populated environment variables as in the [Ruby buildpack](http://docs.cloudfoundry.org/buildpacks/ruby/ruby-service-bindings.html#vcap-services-defines-database-url).
 
-##### Node.js example
+#### Node.js example
 
 To access the elasticsearch service described above with a node app:
 
@@ -144,7 +132,7 @@ var client = new elasticsearch.Client({
 // ...
 ```
 
-##### Ruby on Rails example
+#### Ruby on Rails example
 
 **config/initializers/elasticsearch.rb**
 

--- a/content/overview/pricing/free-limited-sandbox.md
+++ b/content/overview/pricing/free-limited-sandbox.md
@@ -43,6 +43,7 @@ Sandboxes are for testing; they’re suitable for information and applications t
 Limitations include:
 
 * Resource usage is capped at 1 GB of memory total, for all the applications in your space combined.
+* You're [capped at using a maximum]({{< relref "overview/pricing/quotas.md#what-quotas-limit" >}}) of 10 [service instances]({{< relref "docs/apps/managed-services.md" >}}), 10 [service keys](https://docs.cloudfoundry.org/devguide/services/service-keys.html), and 10 [application routes]({{< relref "docs/apps/custom-domains.md" >}}), for all the applications in your space combined.
 * Currently sandbox applications may run indefinitely, but **soon we will delete sandbox content once a month**. We will send notice emails to all sandbox users before we implement this change in policy. Once this new policy is in place, we’ll also send a note to sandbox users a few days before deletions so people can preserve information they need.
 * Sandboxes do not have an “org manager” role available. (You can control access and permissions for your own sandbox space.) If you want to manage an org of prototyping spaces for people at your agency, consider purchasing a [prototyping package]({{< relref "overview/pricing/prototyping.md" >}}).
 

--- a/content/overview/pricing/quotas.md
+++ b/content/overview/pricing/quotas.md
@@ -30,10 +30,10 @@ Quotas are associated with and billed to a project IAA number or equivalent bill
 
 Quotas limit the following resources:  
 
-- Application routes.  
-- Application memory.  
-- Service instances.  
-- Access to paid service plans.  
+- Number of [application routes]({{< relref "docs/apps/custom-domains.md" >}})
+- Amount of application memory
+- Number of [service instances]({{< relref "docs/apps/managed-services.md" >}})
+- Access to paid service plans
 
 If a new application `push` would exceed your organization's quota, the request will fail with status code `400` and a message that describes the limit that would be exceeded.
 


### PR DESCRIPTION
On the [sandbox info page](https://cloud.gov/overview/pricing/free-limited-sandbox/), I put in an explanation for the quota on service instances, service keys, and routes. This meant I needed to also improve the following pages to support that explanation:

* On [quotas page](https://cloud.gov/overview/pricing/quotas/), add details and links.
* On [custom domains page](https://cloud.gov/docs/apps/custom-domains/), consolidate guidance, remove GSA TTS info, and add more info about what a "route" means (which wasn't explained anywhere before in our docs but is helpful to understand in general).
* Simplify [managed services page](https://cloud.gov/docs/apps/managed-services/) so that a person interested in learning what a service instance is can figure that out faster. Remove outdated Elasticsearch example.