### PR TITLE
Explain org and space limits as well as app limits

### DIFF
--- a/content/docs/apps/deployment.md
+++ b/content/docs/apps/deployment.md
@@ -31,7 +31,7 @@ Don't depend on local file system storage. When your application restarts (for e
 
 ### The platform will restart your application
 
-cloud.gov will automatically restart your application instances occasionally. For example, application instances will be restarted if they exceed [memory limits]({{< relref "docs/apps/limits.md" >}}).
+cloud.gov will automatically restart your application instances occasionally. For example, application instances will be restarted if they exceed [memory limits]({{< relref "docs/apps/limits.md#app" >}}).
 
 Application instances will also be restarted when the cloud.gov platform is updated, which can be several times a week. This shouldn't disrupt your running application if you [set up multiple application instances]({{< relref "docs/apps/multiple-instances.md" >}}) and avoid writing to the local file system.
 

--- a/content/docs/apps/limits.md
+++ b/content/docs/apps/limits.md
@@ -15,7 +15,7 @@ To view your [org quota]({{< relref "overview/pricing/quotas.md" >}}):
 2. Find your quota name from the `quota:` property.
 3. View your quota: `cf quota <quota>`
 
-To change your org quota, [ask support](/help/). You can request an increase in number of routes or service instances with no cost impact. Increasing or decreasing org memory quota changes your usage costs.
+To change your org quota, [ask support](/help/). You can request an increase in number of [application routes]({{< relref "docs/apps/custom-domains.md" >}}) or [service instances]({{< relref "docs/apps/managed-services.md" >}}) with no cost impact. Increasing or decreasing org memory quota changes your usage costs.
 
 ### Tracking quota usage
 

--- a/content/docs/apps/limits.md
+++ b/content/docs/apps/limits.md
@@ -2,12 +2,34 @@
 menu:
   docs:
     parent: advanced
-title: Application limits
+title: Set org, space, and app limits
 ---
 
-cloud.gov Org Managers are free to divide your [organization's quota]({{< relref "overview/pricing/quotas.md" >}}) capacity among your applications as you see fit by way of application limits. Application limits are specified in your [application manifest](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) or as `cf push` command line options.
+Org Managers are free to configure your org's [quota]({{< relref "overview/pricing/quotas.md" >}}) capacity among your spaces and applications as you see fit. This enables Org Managers to limit usage and corresponding costs.
 
-## Application limit options
+## Org
+
+To change your [org quota]({{< relref "overview/pricing/quotas.md" >}}), [ask support](/help/). You can request an increase in number of routes or service instances with no cost impact. Increasing or decreasing org memory quota changes your usage costs.
+
+### Tracking quota usage
+
+You can use the following `cf` CLI plugins to help identify the right quota to set for your org. They are available from the _CF-Community_ plugin site: `cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org/`
+
+- The [Usage Report plugin](https://github.com/krujos/usagereport-plugin) gives you a report of how your quota is used across visible organizations and spaces. To install: `cf install-plugin 'Usage Report' -r CF-Community`
+
+- The [Statistics plugin](https://github.com/swisscom/cf-statistics-plugin) gives you real-time visibility of the actual memory usage for each application instance compared to the memory limit. To install: `cf install-plugin Statistics -r CF-Community`
+
+You can use these two in combination to get a good sense of where you can lower instance memory limits to make room for more instances elsewhere in your org or just reduce your quota to reduce costs. 
+
+## Space
+
+Org Managers can [create and modify space quota plans](https://docs.cloudfoundry.org/adminguide/quota-plans.html#space) to limit the resources used by spaces. See the CF CLI documentation for [`create-space-quota`](http://cli.cloudfoundry.org/en-US/cf/create-space-quota.html) to create the quota plan, and create a space with that quota plan using [`create-space`](http://cli.cloudfoundry.org/en-US/cf/create-space.html) (which has the option `[-q SPACE_QUOTA]`).
+
+## App
+
+Space Developers can specify application limits in your [application manifest](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) or as `cf push` command line options.
+
+### Application limit options
 
 `memory: / -m`
 
@@ -21,7 +43,7 @@ The maximum amount of disk space available to your app.
 
 Sets the number of application instances to launch. Each additional instance receives the same memory and disk reservation. An application with a manifest specifying `memory: 256M` and `instances: 4` would reserve 1GB (256M x 4) total.
 
-## Application limit options: memory share equals compute share
+### Application limit options: memory share equals compute share
 
 As noted above, your application's compute limit is derived from its memory limit. Each application receives a compute share equal to its relative share of memory.
 
@@ -49,7 +71,7 @@ Your application can use all available CPU time. If there are other applications
 The application cannot access more than the specified amount of memory.
 
 
-## Application limit options: sizing
+### Application limit options: sizing
 
 - The environment default of 512MB `memory:` is sufficient for most applications. Static sites and utility applications such as schedulers or loaders may require less. Use `cf app APPNAME` to check your application's current memory and compute utilization.
 

--- a/content/docs/apps/limits.md
+++ b/content/docs/apps/limits.md
@@ -9,7 +9,13 @@ Org Managers are free to configure your org's [quota]({{< relref "overview/prici
 
 ## Org
 
-To change your [org quota]({{< relref "overview/pricing/quotas.md" >}}), [ask support](/help/). You can request an increase in number of routes or service instances with no cost impact. Increasing or decreasing org memory quota changes your usage costs.
+To view your [org quota]({{< relref "overview/pricing/quotas.md" >}}):
+
+1. List the details about your org: `cf org <org>`
+2. Find your quota name from the `quota:` property.
+3. View your quota: `cf quota <quota>`
+
+To change your org quota, [ask support](/help/). You can request an increase in number of routes or service instances with no cost impact. Increasing or decreasing org memory quota changes your usage costs.
 
 ### Tracking quota usage
 

--- a/content/overview/pricing/quotas.md
+++ b/content/overview/pricing/quotas.md
@@ -46,5 +46,5 @@ If a new application `push` would exceed your organization's quota, the request 
 In this situation you have three options:
 
 1. Delete existing resources with `cf delete`, `delete-service`, `delete-route` or similar.
-2. Reconfigure individual existing [Application Quotas]({{< relref "docs/apps/limits.md" >}}) and redeploy.
+2. Reconfigure individual existing [application quotas]({{< relref "docs/apps/limits.md#app" >}}) and redeploy.
 3. Request a quota change by [asking support](/help/). You can request an increase in number of routes or service instances with no cost impact. Increasing memory quota changes your costs (as described above).


### PR DESCRIPTION
This takes the good ideas from both @fureigh at https://github.com/18F/cg-site/pull/926 and @pburkholder at https://github.com/18F/cg-site/pull/910 and puts them together into expanding https://cloud.gov/docs/apps/limits/ to cover org, space, and app limits/quotas. This should make that page more helpful to org managers.

Review welcome by all! @LindsayYoung - might be interesting to you as well.