### PR TITLE
On leveraging auth page, fix info about state parameter

### DIFF
--- a/content/docs/apps/leveraging-authentication.md
+++ b/content/docs/apps/leveraging-authentication.md
@@ -36,14 +36,14 @@ query parameters:
 * `response_type=code`
 * (optional) `state=<ANYTHING>`
 
-You can optionally set a `state` parameter with any value you'd like.
-It will be returned to you in a later step. While optional, it's highly
-recommended that you use it for [security reasons](http://www.twobotechnologies.com/blog/2014/02/importance-of-state-in-oauth2.html).
+You can set a `state` parameter with any value you'd like.
+It will be returned to you in a later step. While optional, we *strongly*
+recommend that you use it with a high-quality random number or a hash generated with a secret key, because it [protects against cross-site request forgery attacks](https://tools.ietf.org/id/draft-bradley-oauth-jwt-encoded-state-07.html).
 
 Here is an example:
 
 ```html
-<a href="https://login.fr.cloud.gov/oauth/authorize?client_id=NAME&response_type=code">
+<a href="https://login.fr.cloud.gov/oauth/authorize?client_id=NAME&response_type=code&state=9ab894ad91d99eb9ee4b30ea7f02b9d8e43eb15db58ff93e4894f3b49817d7ab">
   Log in
 </a>
 ```


### PR DESCRIPTION
https://cloud.gov/docs/apps/leveraging-authentication/ has a [broken link](https://github.com/18F/cg-site/issues/253), so I tried to fix it:

* Replace broken link to security info with a link that might not be super helpful but emphasizes the importance of the parameter and probably won't break
* Add best practice to example
* Give a little more info about best practices ([borrowing from here](https://developers.google.com/identity/protocols/OpenIDConnect?hl=fr#createxsrftoken))

This definitely needs technical review.