### PR TITLE
Update S3 CORS language to be more precise and less scary

### DIFF
--- a/content/docs/services/s3.md
+++ b/content/docs/services/s3.md
@@ -127,7 +127,8 @@ Note that "website mode" URLs don't support HTTPS, and they aren't appropriate f
 Either way, if the bucket is private, attempting to access resources will result in `AccessDenied` errors unless your application generates [pre-signed URLs](http://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html) for objects that need to be shared.
 
 ### Allowing web access from external applications
-If users wish to access their S3 buckets from outside of their cloud.gov application then set a CORS policy, which loosens security restrictions.  This is *NOT* recommended, however with a sufficiently restricted list of sites and methods can be safe:
+
+If users wish to access their S3 buckets from outside of their cloud.gov application then set a CORS policy, which allows the bucket to be read by other third-party applications and web services. Allowing blanket access to entire buckets is generally *not* recommended, but you can restrict access to a specific list of sites and methods:
 
 ```sh
 # Adjust CORS AllowedOrigins to known locations such as a IP address
@@ -135,7 +136,7 @@ cat << EOF > cors.json
 {
   "CORSRules": [
     {
-      "AllowedOrigins": ["YOUR.OTHER.APP.IP"],
+      "AllowedOrigins": ["otherapp.hostname.gov", "anotherapp.hostname.com"],
       "AllowedHeaders": ["*"],
       "AllowedMethods": ["HEAD", "GET"],
       "ExposeHeaders": ["ETag"]

--- a/content/docs/services/s3.md
+++ b/content/docs/services/s3.md
@@ -126,9 +126,13 @@ Note that "website mode" URLs don't support HTTPS, and they aren't appropriate f
 
 Either way, if the bucket is private, attempting to access resources will result in `AccessDenied` errors unless your application generates [pre-signed URLs](http://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html) for objects that need to be shared.
 
-### Allowing web access from external applications
+### Allowing client-side web access from external applications
 
-If users wish to access their S3 buckets from outside of their cloud.gov application then set a [CORS policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS), which allows the bucket to be accessed by requests made by JavaScript code run in the context of other third-party web services. You can set a CORS policy allowing arbitrary origins to read bucket data, or you can restrict access to a specific list of sites and methods:
+By default, browsers only allow JavaScript to make HTTP requests to the same domain as the page serving the JavaScript, as part of the web's [Same Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy). This means that by default, S3 buckets can only be accessed by JavaScript when that JavaScript is served directly from the same origin as the S3 bucket.
+
+If an application wishes to allow client-side JavaScript in other applications to access its S3 buckets, this can be done by setting a [CORS policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS). CORS allows an origin to "opt in" to allowing its contents to be accessed by JavaScript in specified origins (or any origin) to access the bucket.
+
+You can set a CORS policy restricting access to a specific list of sites and methods (such as the example below), or allow arbitrary origins (using `*`) to read bucket data:
 
 ```sh
 # Adjust CORS AllowedOrigins to known locations such as a IP address

--- a/content/docs/services/s3.md
+++ b/content/docs/services/s3.md
@@ -128,7 +128,7 @@ Either way, if the bucket is private, attempting to access resources will result
 
 ### Allowing web access from external applications
 
-If users wish to access their S3 buckets from outside of their cloud.gov application then set a CORS policy, which allows the bucket to be read by other third-party applications and web services. Allowing blanket access to entire buckets is generally *not* recommended, but you can restrict access to a specific list of sites and methods:
+If users wish to access their S3 buckets from outside of their cloud.gov application then set a CORS policy, which allows the bucket to be accessed by requests made by JavaScript code run in the context of other third-party web services. You can set a CORS policy allowing arbitrary origins to read bucket data, or you can restrict access to a specific list of sites and methods:
 
 ```sh
 # Adjust CORS AllowedOrigins to known locations such as a IP address

--- a/content/docs/services/s3.md
+++ b/content/docs/services/s3.md
@@ -128,7 +128,7 @@ Either way, if the bucket is private, attempting to access resources will result
 
 ### Allowing web access from external applications
 
-If users wish to access their S3 buckets from outside of their cloud.gov application then set a CORS policy, which allows the bucket to be accessed by requests made by JavaScript code run in the context of other third-party web services. You can set a CORS policy allowing arbitrary origins to read bucket data, or you can restrict access to a specific list of sites and methods:
+If users wish to access their S3 buckets from outside of their cloud.gov application then set a [CORS policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS), which allows the bucket to be accessed by requests made by JavaScript code run in the context of other third-party web services. You can set a CORS policy allowing arbitrary origins to read bucket data, or you can restrict access to a specific list of sites and methods:
 
 ```sh
 # Adjust CORS AllowedOrigins to known locations such as a IP address


### PR DESCRIPTION
The S3/CORS section has some inaccurate information and is overly discouraging.

Adding a CORS policy to S3 buckets isn't a bad thing. Even a blanket policy of `*` for origins isn't a bad thing, if the data is non-sensitive.

The description implies that CORS "loosens security restrictions" in a general way, and CORS is a security-relevant protocol, but for an S3 bucket containing static data, CORS configuration is unlikely to be a very security-relevant decision.

The example CORS policy uses mock data that suggests that the CORS policy should have IP addresses, but that's not how CORS works -- you specify origins, which the browser can then use to determine whether a given origin has permission to make an HTTP request to that resource.

It's especially important to understand that **CORS cannot protect data from being read**, and it **has no impact on bucket permissions**. CORS exists only to allow browsers to decide whether JS running in a given environment is authorized to make requests and read responses to/from other origins. It doesn't actually control whether the data is readable to the public or to any particular application.