### PR TITLE
Add http_strict_transport_security

### DIFF
--- a/Staticfile
+++ b/Staticfile
@@ -1,3 +1,2 @@
 root: public
 location_include: includes/*.conf
-http_strict_transport_security: true

--- a/Staticfile
+++ b/Staticfile
@@ -1,2 +1,3 @@
 root: public
 location_include: includes/*.conf
+http_strict_transport_security: true

--- a/nginx/conf/includes/location.conf
+++ b/nginx/conf/includes/location.conf
@@ -3,3 +3,5 @@ error_page 404 /404.html;
 
 add_header Cache-Control max-age=300;
 add_header X-Content-Type-Options nosniff;
+
+add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';


### PR DESCRIPTION
Looks like @dlapiduz had us using a [custom buildpack from a while back to enable HSTS support](https://github.com/18F/cg-site/commit/9963fa939750bef0678888421996a47d57f582c8) and back when the landing site was part of cg-landing we had a [complete custom nginx.conf](https://github.com/18F/cg-landing/blob/master/nginx.conf#L37). According to [the staticfile_buildpack release notes, we can leverage setting the above property to true in our Staticfile](https://github.com/cloudfoundry/staticfile-buildpack/releases/tag/v1.3.13) from all the way back in Nov 2016 which we did, but it doesn't include `includeSubDomains` and `preload` options. I submitted something upstream to fix it there too.