### PR TITLE
Fix for services URLs not ending in slash

### DIFF
--- a/layouts/docs/services.html
+++ b/layouts/docs/services.html
@@ -13,7 +13,7 @@
   <tbody>
   {{ range $.Site.Data.services }}
     <tr>
-      <td><a href="{{ "/docs/services/" }}{{ .page_name | default .name | urlize }}">{{ .name }}</a></td>
+      <td><a href="{{ "/docs/services/" }}{{ .page_name | default .name | urlize }}/">{{ .name }}</a></td>
       <td>{{ .description | markdownify }}</td>
       <td>{{ .status }}</td>
     </tr>


### PR DESCRIPTION
Currently on [the services overview page](https://cloud.gov/docs/services/), the links look like this: `https://cloud.gov/docs/services/cloud-gov-identity-provider`

But when we have links without a trailing slash, those links redirect to URLs like this: `https://landing.app.cloud.gov/docs/services/cloud-gov-identity-provider/`

So this is an attempt at fixing the symptom by adding a trailing slash in the template that generates those URLs.

I don't know if this is the best way to fix this, but it seems to work locally, so maybe this helps.

Update: Based on https://gsa-tts.slack.com/archives/C1RHZMF88/p1477409699002145 it looks like that symptom was supposed to be fixed by https://github.com/18F/cg-site/pull/482 - so this needs a bit of review. Probably should be fixed instead by fixing that thing again.