### PR TITLE
Link to live service-level stats

### DIFF
--- a/content/overview/pricing/pricing-terminology.md
+++ b/content/overview/pricing/pricing-terminology.md
@@ -23,7 +23,7 @@ A system maps to an [“org” in cloud.gov and Cloud Foundry](http://docs.cloud
 
 ### Support {#support}
 
-“Support” is support to use the platform as intended, on a best-effort basis. We have no existing service-level agreement (SLA). We plan to always publish metrics that give agencies the ability to make an informed choice about whether to use cloud.gov or an alternative PaaS solution based on our actual track record.
+“Support” is support to use the platform as intended, on a best-effort basis. We have no existing service-level agreement (SLA). We [publish metrics](https://cloudgov.statuspage.io/) that give agencies the ability to make an informed choice about whether to use cloud.gov or an alternative PaaS solution based on our actual track record.
 
 ### Consulting
 


### PR DESCRIPTION
There are probably other places where we can or should surface this link, but at least this closely associates the one search hit for `SLA` with a link to view our uptime stats!