### PR TITLE
Minor process updates to service disruption guide

### DIFF
--- a/content/docs/ops/service-disruption-guide.md
+++ b/content/docs/ops/service-disruption-guide.md
@@ -23,6 +23,7 @@ Examples:
 * A platform-owned component such as the dashboard or brokers is giving errors.
 * Two or more teams using cloud.gov have reported the same non-trivial problem, which indicates it isn't just a problem with a customer application.
 * AWS or another service we depend on is causing problems for our users.
+* Something unexpected went wrong during scheduled maintenance, and it impacts users.
 
 ## How soon to post to Status Page
 
@@ -41,6 +42,10 @@ As soon as possible. Goal: at most 15 minutes after the first cloud.gov team mem
 
 [We have some templates and drafting space in this doc.](https://docs.google.com/document/d/1paDOxlB7GFItrEJ9pqPExApiAd4GeB_SpGR6Ronf4Lw/edit)
 
+### Updates
+
+* If you're writing an update to a post about a new related problem, also update the post summary (the subject line) to make it summarize the whole event.
+
 ## When to close
 
 We close the event when **we believe the disruption is no longer affecting customers**.
@@ -54,3 +59,5 @@ A postmortem is not necessary to close, and it does not have to happen immediate
 ## Ensure a postmortem happens
 
 The person who closes the event should then put a card on the component-owning squad’s board in the urgent lane about writing and posting a postmortem.
+
+For non-security-sensitive work, work to resolve root causes does not have to be completely done before we post the postmortem.


### PR DESCRIPTION
Additions:

* Another example of when to use this guide: "Something unexpected went wrong during scheduled maintenance, and it impacts users."
* Advice on writing updates: "If you're writing an update to a post about a new related problem, also update the post summary (the subject line) to make it summarize the whole event."
* Postmortem guidance: "For non-security-sensitive work, work to resolve root causes does not have to be completely done before we post the postmortem."