### PR TITLE
Add useful CF docs to troubleshooting page

### DIFF
--- a/content/docs/apps/troubleshooting.md
+++ b/content/docs/apps/troubleshooting.md
@@ -42,9 +42,9 @@ Cloud Foundry will attempt to detect the buildpack to use with your app by exami
 
 If you're seeing errors installing any Python dependencies, check whether you have a `vendor/` directory in your app's root. The Python buildpack won't use PyPI if you have a `vendor/` directory, so you'll need to rename that directory to something else.
 
-## Potential causes of issues during Droplet Execution Phase [DEA]
+## Potential causes of issues during app starting/stopping [CELL]
 
-If you see problems in your logs in lines that include the label `[DEA]`, these explanations may help you resolve them.
+If you see problems in your logs in lines that include the label `[CELL]`, these explanations may help you resolve them.
 
 ### App manifest contents
 

--- a/content/docs/apps/troubleshooting.md
+++ b/content/docs/apps/troubleshooting.md
@@ -7,7 +7,7 @@ linktitle: Troubleshooting
 weight: 100
 ---
 
-Here are some common problems and recommended practices for solving them. Make sure to [look at the logs]({{< relref "logs.md" >}}) to help troubleshoot.
+Seeing problems with your applications? Take a look at [your app logs]({{< relref "logs.md" >}}) and [review these common issues and solutions](https://docs.cloudfoundry.org/devguide/deploy-apps/troubleshoot-app-health.html).
 
 ## Application restarts and crash messages
 
@@ -17,9 +17,9 @@ If you see recent messages such as `The app crashed because of an unknown reason
 
 If your application only has one instance, you may see brief interruptions in service during restarts due to routine platform updates. You can fix this by setting up [multiple application instances]({{< relref "docs/apps/multiple-instances.md" >}}).
 
-## [STG] Staging Phase
+## Potential causes of issues during staging phase ([STG])
 
-If you see problems in your logs in lines that include the label `[STG]`, these recommendations may help you resolve them.
+If you see problems in your logs in lines that include the label `[STG]`, these explanations may help you resolve them.
 
 ### App dependency specification
 
@@ -42,9 +42,9 @@ Cloud Foundry will attempt to detect the buildpack to use with your app by exami
 
 If you're seeing errors installing any Python dependencies, check whether you have a `vendor/` directory in your app's root. The Python buildpack won't use PyPI if you have a `vendor/` directory, so you'll need to rename that directory to something else.
 
-## [DEA] Droplet Execution Phase
+## Potential causes of issues during Droplet Execution Phase [DEA]
 
-If you see problems in your logs in lines that include the label `[DEA]`, these recommendations may help you resolve them.
+If you see problems in your logs in lines that include the label `[DEA]`, these explanations may help you resolve them.
 
 ### App manifest contents
 


### PR DESCRIPTION
The page at https://docs.cloudfoundry.org/devguide/deploy-apps/troubleshoot-app-health.html has some good user-centered advice - each section start with a description of the problem and then provides ways to solve it. I added a link to it!

Our STG / DEA tips are organized by stage of deployment - I'm not sure this really works well for user needs, but we can work on that another time. I tried at least revising the titles a little bit.