### PR TITLE
Add header to ops docs.

### DIFF
--- a/content/docs/ops/aws-onboarding.md
+++ b/content/docs/ops/aws-onboarding.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: operations
+layout: ops
 title: AWS onboarding
 aliases:
   - /docs/ops/aws-accounts/

--- a/content/docs/ops/configuration-management.md
+++ b/content/docs/ops/configuration-management.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: policies
+layout: ops
 title: Configuration management
 ---
 

--- a/content/docs/ops/contingency-plan.md
+++ b/content/docs/ops/contingency-plan.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: policies
+layout: ops
 title: Contingency plan
 ---
 

--- a/content/docs/ops/continuous-monitoring.md
+++ b/content/docs/ops/continuous-monitoring.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: policies
+layout: ops
 title: Continuous monitoring strategy
 ---
 

--- a/content/docs/ops/create-org.md
+++ b/content/docs/ops/create-org.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: tenants
+layout: ops
 title: Creating organizations
 ---
 

--- a/content/docs/ops/creating-a-development-environment-with-bosh-lite.md
+++ b/content/docs/ops/creating-a-development-environment-with-bosh-lite.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: deployment
+layout: ops
 title: Creating a Dev Environment on AWS
 linktitle: AWS
 ---

--- a/content/docs/ops/creating-a-local-dev-environment-in-Virtual-Box.md
+++ b/content/docs/ops/creating-a-local-dev-environment-in-Virtual-Box.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: deployment
+layout: ops
 title: Creating a Local Dev Environment With VirtualBox
 linktitle: Local
 ---

--- a/content/docs/ops/dns.md
+++ b/content/docs/ops/dns.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: operations
+layout: ops
 title: DNS settings for cloud.gov
 ---
 

--- a/content/docs/ops/federated-identity.md
+++ b/content/docs/ops/federated-identity.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: tenants
+layout: ops
 title: Federated identity
 weight: 10
 ---

--- a/content/docs/ops/maintenance-list.md
+++ b/content/docs/ops/maintenance-list.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: operations
+layout: ops
 title: Ongoing platform maintenance
 ---
 

--- a/content/docs/ops/making-announcements.md
+++ b/content/docs/ops/making-announcements.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: operations
+layout: ops
 title: Making announcements
 ---
 

--- a/content/docs/ops/managing-users.md
+++ b/content/docs/ops/managing-users.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: tenants
+layout: ops
 title: Managing users
 ---
 

--- a/content/docs/ops/quotas.md
+++ b/content/docs/ops/quotas.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: tenants
+layout: ops
 title: Managing quotas
 ---
 

--- a/content/docs/ops/repos.md
+++ b/content/docs/ops/repos.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: ops
+layout: ops
 title: Code repositories
 weight: -100
 aliases:

--- a/content/docs/ops/runbook/rotating-bosh.md
+++ b/content/docs/ops/runbook/rotating-bosh.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: runbook
+layout: ops
 
 title: Rotating Secrets III - BOSH
 ---

--- a/content/docs/ops/runbook/rotating-cloudfoundry-diego.md
+++ b/content/docs/ops/runbook/rotating-cloudfoundry-diego.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: runbook
+layout: ops
 
 title: Rotating Secrets V - Cloud Foundry and Diego
 ---

--- a/content/docs/ops/runbook/rotating-concourse.md
+++ b/content/docs/ops/runbook/rotating-concourse.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: runbook
+layout: ops
 
 title: Rotating Secrets IV - Concourse
 ---

--- a/content/docs/ops/runbook/rotating-iam-users.md
+++ b/content/docs/ops/runbook/rotating-iam-users.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: runbook
+layout: ops
 
 title: Rotating Secrets II - IAM users via Terraform
 ---

--- a/content/docs/ops/runbook/rotating-kubernetes.md
+++ b/content/docs/ops/runbook/rotating-kubernetes.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: runbook
+layout: ops
 
 title: Rotating Secrets VI - Kubernetes
 ---

--- a/content/docs/ops/runbook/rotating-secrets.md
+++ b/content/docs/ops/runbook/rotating-secrets.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: runbook
+layout: ops
 
 title: Rotating Secrets I
 ---

--- a/content/docs/ops/runbook/troubleshooting-bosh.md
+++ b/content/docs/ops/runbook/troubleshooting-bosh.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: runbook
+layout: ops
 
 title: Troubleshooting Bosh
 ---

--- a/content/docs/ops/runbook/troubleshooting-kubernetes.md
+++ b/content/docs/ops/runbook/troubleshooting-kubernetes.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: runbook
+layout: ops
 
 title: Troubleshooting Kubernetes
 ---

--- a/content/docs/ops/runbook/troubleshooting-logsearch.md
+++ b/content/docs/ops/runbook/troubleshooting-logsearch.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: runbook
+layout: ops
 
 title: Troubleshooting Logsearch
 ---

--- a/content/docs/ops/runbook/troubleshooting-nessus.md
+++ b/content/docs/ops/runbook/troubleshooting-nessus.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: runbook
+layout: ops
 
 title: Troubleshooting Nessus Manager
 ---

--- a/content/docs/ops/runbook/troubleshooting-smtp.md
+++ b/content/docs/ops/runbook/troubleshooting-smtp.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: runbook
+layout: ops
 
 title: Troubleshooting SMTP
 ---

--- a/content/docs/ops/runbook/troubleshooting-snort.md
+++ b/content/docs/ops/runbook/troubleshooting-snort.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: runbook
+layout: ops
 
 title: Troubleshooting Snort
 ---

--- a/content/docs/ops/secrets.md
+++ b/content/docs/ops/secrets.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: operations
+layout: ops
 title: Secret key management
 ---
 

--- a/content/docs/ops/security-ir-checklist.md
+++ b/content/docs/ops/security-ir-checklist.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: policies
+layout: ops
 title: Security Incident Response checklist
 linktitle: Security IR checklist
 ---

--- a/content/docs/ops/security-ir.md
+++ b/content/docs/ops/security-ir.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: policies
+layout: ops
 title: Security Incident Response Guide
 linktitle: Security IR Guide
 ---

--- a/content/docs/ops/service-credential-rotation.md
+++ b/content/docs/ops/service-credential-rotation.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: tenants
+layout: ops
 title: Rotating service credentials
 ---
 

--- a/content/docs/ops/service-disruption-guide.md
+++ b/content/docs/ops/service-disruption-guide.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: policies
+layout: ops
 title: Service disruption guide
 ---
 

--- a/content/docs/ops/system-tooling-overview.md
+++ b/content/docs/ops/system-tooling-overview.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: operations
+layout: ops
 title: System tooling overview
 ---
 

--- a/content/docs/ops/updating-cf.md
+++ b/content/docs/ops/updating-cf.md
@@ -2,6 +2,7 @@
 menu:
   docs:
     parent: deployment
+layout: ops
 title: Updating Cloud Foundry
 ---
 

--- a/layouts/docs/ops.html
+++ b/layouts/docs/ops.html
@@ -1,9 +1,11 @@
 {{ partial "docs-header.html" . }}
 
-<h3>
-  Note: these docs are primarily intended for cloud.gov operators; check out
-  our <a href="/docs">user documentation</a> for help with using the platform.
-</h3>
+<p>
+<em>
+  This page is primarily for the cloud.gov team, and it's public so that you can learn 
+  from it. For help with using cloud.gov, see the <a href="/docs/">user docs</a>.
+</em>
+</p>
 
 {{ .Content }}
 

--- a/layouts/docs/ops.html
+++ b/layouts/docs/ops.html
@@ -2,8 +2,8 @@
 
 <p>
 <em>
-  This page is primarily for the cloud.gov team, and it's public so that you can learn 
-  from it. For help with using cloud.gov, see the <a href="/docs/">user docs</a>.
+  This page is primarily for the cloud.gov team. It's public so that you can learn 
+  from it. For help using cloud.gov, see the <a href="/docs/">user docs</a>.
 </em>
 </p>
 

--- a/layouts/docs/ops.html
+++ b/layouts/docs/ops.html
@@ -1,0 +1,12 @@
+{{ partial "docs-header.html" . }}
+
+<h3>
+  Note: these docs are primarily intended for cloud.gov operators; check out
+  our <a href="/docs">user documentation</a> for help with using the platform.
+</h3>
+
+{{ .Content }}
+
+{{ partial "docs-footer.html" . }}
+{{ partial "footer.html" . }}
+{{ partial "javascript.html" . }}


### PR DESCRIPTION
Note: Hugo doesn't support layouts for nested sections yet, but once it
does, we can drop the `layout` stanza for each `ops` page:
https://discourse.gohugo.io/t/layout-for-nested-section/7292.

[Resolves #893]