### PR TITLE
Remove homemade static site instructions

### DIFF
--- a/content/docs/apps/static.md
+++ b/content/docs/apps/static.md
@@ -5,54 +5,13 @@ menu:
 title: Deploying static sites
 ---
 
-To push static content to the web, use the Staticfile buildpack. Examples of static content are front-end JavaScript apps and static HTML content. 
+To push static content to the web, use the Staticfile buildpack. Examples of static content are front-end JavaScript apps and static HTML content.
 
-To get a full list of configuration options, including how to configure nginx, see the [Cloud Foundry Staticfile buildpack documentation](https://docs.cloudfoundry.org/buildpacks/staticfile/index.html).
-
-### Basics
-
-Create `index.html`:
-
-```
-$ touch index.html
-```
-
-Add some markup:
-
-```html
-<html>
-  <head>
-    <title>Static Site</title>
-  </head>
-  <body>
-    <p>Welcome to the static site!</p>
-  </body>
-</html>
-```
-
-Create a `manifest.yml` that uses the [`staticfile-buildpack`](https://github.com/cloudfoundry/staticfile-buildpack):
-
-```yml
----
-applications:
-- name: my-static-site
-  memory: 64M
-  buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
-  env:
-    FORCE_HTTPS: true
-```
-
-If the static content is included in a different folder, you can add a `path` declaration. E.g., `path: dist` or `path: assets`.
-
-Deploy:
-
-```
-$ cf push
-```
+To set up a "hello world" demo or a more complex static site, see the [Cloud Foundry Staticfile buildpack documentation](https://docs.cloudfoundry.org/buildpacks/staticfile/index.html). It includes ["hello world" instructions](https://docs.cloudfoundry.org/buildpacks/staticfile/index.html#sample) and a full list of configuration options, including how to set up basic authentication and configure nginx (the underlying web server).
 
 ### Builds
 
-If you are using a static site generator (e.g. [Jekyll]({{< relref "#jekyll" >}}) or [Hugo](http://gohugo.io/)) and/or it requires dependencies to be installed at deploy-time, it's _especially_ recommended that you set up [continuous deployment]({{< relref "continuous-deployment.md" >}}). This way, the build happens in your Continuous Integration (CI) system rather than during the deploy itself within Cloud Foundry. This helps to make your deployments more reliable, have a smaller footprint, and reduce downtime.
+If you are using a static site generator (e.g. [Jekyll]({{< relref "#jekyll" >}}) or [Hugo](http://gohugo.io/)) and/or it requires dependencies to be installed at deploy-time, you should set up [continuous deployment]({{< relref "continuous-deployment.md" >}}). This way, the build happens in your Continuous Integration (CI) system rather than during the deploy itself within Cloud Foundry. This helps to make your deployments more reliable, have a smaller footprint, and reduce downtime.
 
 ### Jekyll
 
@@ -65,16 +24,10 @@ Deploying a [Jekyll](http://jekyllrb.com/) site requires a few things:
     gem 'jekyll'
     ```
 
-* Add a `Staticfile` pointing to the root of the built site as specified above. The [static buildpack](https://github.com/cloudfoundry/staticfile-buildpack) will interpret with file.
+* Add a `Staticfile` pointing to the root of the built site, as specified in the [Cloud Foundry Staticfile buildpack documentation](https://docs.cloudfoundry.org/buildpacks/staticfile/index.html#config-process).
 
     ```yaml
     root: _site
-    ```
-
-* Update `manifest.yml` to use the [static buildpack](https://github.com/cloudfoundry/staticfile-buildpack).
-
-    ```yaml
-    buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
     ```
 
 See [18F/notalone](https://github.com/18F/notalone) for an example.


### PR DESCRIPTION
The [Cloud Foundry Staticfile buildpack documentation](https://docs.cloudfoundry.org/buildpacks/staticfile/index.html) has better instructions that are updated more often than ours. Our instructions were outdated, including how to set up a `path` declaration.