### PR TITLE
Fix broken link on homepage

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,7 +18,7 @@
       <p class="subhead-rule">A cloud application platform for government teams</p>
       <h1 class="billboard-second_text">
         Focus on the services you need to build — cloud.gov makes it faster, simpler, and more secure. <br /><br/>
-        Read more about the <a href="/overview/overview/what-is-cloudgov/">product</a>, <a href="/overview/pricing/rates/">packages and rates</a>, and <a ref="/overview/technology/responsibilities/">security and compliance</a>.
+        Read more about the <a href="/overview/overview/what-is-cloudgov/">product</a>, <a href="/overview/pricing/rates/">packages and rates</a>, and <a href="/overview/technology/responsibilities/">security and compliance</a>.
       </h1>
     </div>
     <div class="usa-width-one-third section-sidebar">


### PR DESCRIPTION
This is a followup to https://github.com/18F/cg-site/pull/1045 - cc @femmebot and @jcscottiii. The "security and compliance" link isn't working on the current live homepage since it it's a `ref` instead of a `href`.