### PR TITLE
Fix broken links in services table and update service info

### DIFF
--- a/content/docs/services/index.md
+++ b/content/docs/services/index.md
@@ -7,8 +7,8 @@ layout: services
 weight: -1
 ---
 
-cloud.gov offers multiple services to allow your application to expand its functionality.
+cloud.gov offers multiple [managed services]({{< relref "docs/apps/managed-services.md" >}}) to allow your application to expand its functionality. You can also create [user-provided services]({{< relref "docs/apps/production-ready.md#protect-access-to-sensitive-credentials" >}}).
 
-To list all the services and plans available to your organization, you can run `cf marketplace` from your command line.
+To list all the managed services and plans available to your organization, you can run `cf marketplace` from your command line.
 
-Here is a list of the services that are generally available:
+Here is a list of the managed services that are generally available:

--- a/data/services/cloud-gov-service-account.toml
+++ b/data/services/cloud-gov-service-account.toml
@@ -2,4 +2,4 @@
 # https://github.com/cloudfoundry-community/uaa-credentials-broker/blob/ee4743a/broker.go#L38
 name = "cloud-gov-service-account"
 description = "cloud.gov service accounts for automated access by programs"
-status = "Beta"
+status = "Production Ready"

--- a/data/services/redis.toml
+++ b/data/services/redis.toml
@@ -1,0 +1,6 @@
+# Service metadata lives
+# https://github.com/18F/kubernetes-broker/blob/master/catalogData/redis28/service.json#L4
+# https://github.com/18F/kubernetes-broker/blob/master/catalogData/redis32/service.json#L4
+name = "redis"
+description = "[Redis](https://redis.io/): an open source in-memory database."
+status = "Beta"

--- a/data/services/redis28.toml
+++ b/data/services/redis28.toml
@@ -1,5 +1,0 @@
-# Service metadata lives
-# https://github.com/18F/kubernetes-broker/blob/master/catalogData/redis28/service.json#L4
-name = "redis28"
-description = "[Redis](https://redis.io/) version 2.8: An open source in-memory database."
-status = "Beta"

--- a/data/services/redis32.toml
+++ b/data/services/redis32.toml
@@ -1,6 +1,0 @@
-
-# Service metadata lives
-# https://github.com/18F/kubernetes-broker/blob/master/catalogData/redis32/service.json#L4
-name = "redis32"
-description = "[Redis](https://redis.io/) version 3.2: An open source in-memory database."
-status = "Beta"

--- a/layouts/docs/services.html
+++ b/layouts/docs/services.html
@@ -13,7 +13,7 @@
   <tbody>
   {{ range $.Site.Data.services }}
     <tr>
-      <td><a href="{{ "/docs/services/" }}{{ .page_name | default .name | urlize }}">{{ .name }}</a></td>
+      <td><a href="{{ "/docs/services/" }}{{ .page_name | default .name | urlize }}/">{{ .name }}</a></td>
       <td>{{ .description | markdownify }}</td>
       <td>{{ .status }}</td>
     </tr>


### PR DESCRIPTION
Changes:
* Add trailing slash to links so that they work as expected (this is a band-aid for a regression - see https://github.com/18F/cg-site/pull/1009 for more info)
* Remove `redis28.toml` and `redis32.toml` files and replace with a combined `redis.toml`, since right now we get a broken link to `https://cloud.gov/docs/services/redis32`
* Promote the service account service to production ready, since it's fine for production use
* Add note about user-provided services