### PR TITLE
Improve transition instructions for old-style Fugacious service credentials

### DIFF
--- a/content/docs/services/cloud-gov-identity-provider.md
+++ b/content/docs/services/cloud-gov-identity-provider.md
@@ -16,8 +16,6 @@ Plan Name | Description | Price
 --------- | ----------- | -----
 `oauth-client` | OAuth2 client credentials for authenticating cloud.gov users in your app | Free
 
-Note: As of July 7, 2017, the instructions for obtaining credentials have changed. If you created an identity provider instance before this date, see [this post for changes]({{< relref "updates/2017-07-07-changes-to-credentials-broker.md" >}}).
-
 ## How to create an instance
 
 To create a service instance that can provision identity provider credentials, run the following command:
@@ -52,6 +50,12 @@ By default, identity provider service instances use the `openid` scope. You can 
 ```bash
 cf create-service-key my-uaa-client my-service-key -c '{"redirect_uri": ["https://my.app.cloud.gov"], "scopes": ["openid", "cloud_controller.read"]}'
 ```
+
+### If you can't find your service keys
+
+<!-- this description matches on cloud-gov-identity-provider.md and cloud-gov-service-account.md -->
+
+If you're trying to retrieve credentials for a service instance created before July 7, 2017, those old service instances had a different way of retrieving credentials. You can check this by running `cf services` to get your service instance name and then running `cf service service-instance-name` -- if the service information includes a link to `fugacious.18f.gov`, it's an old service instance. See [this post for changes]({{< relref "updates/2017-07-07-changes-to-credentials-broker.md" >}}) -- your best next step is to delete the old service instance and create a new one.
 
 ## More information
 

--- a/content/docs/services/cloud-gov-service-account.md
+++ b/content/docs/services/cloud-gov-service-account.md
@@ -19,8 +19,6 @@ Plan Name | Description | Price
 `space-deployer` | A service account for continuous deployment, limited to a single space | Free
 `space-auditor` | A service account for auditing configuration and monitoring events limited to a single space | Free
 
-Note: As of July 7, 2017, the instructions for obtaining credentials have changed. If you created a service account instance before this date, see [this post for changes]({{< relref "updates/2017-07-07-changes-to-credentials-broker.md" >}}).
-
 ## How to create an instance
 
 To create a service instance that can provision service accounts, run the following command:
@@ -49,6 +47,12 @@ This will create a cloud.gov service account and make the credentials available 
 After you create one of these service keys, you will see a new "user" in your org and space with a name made of 36 letters, numbers, and dashes as its unique identifier, similar to `f6ab4cfb-6e6c-4b10-8585-3f39e740905c`. In your event logs, its actions will display as actions by `service-account@cloud.gov`.
 
 These credentials can be used with the `cf login` command in automated deployment scripts.
+
+### If you can't find your service keys
+
+<!-- this description matches on cloud-gov-identity-provider.md and cloud-gov-service-account.md -->
+
+If you're trying to retrieve credentials for a service instance created before July 7, 2017, those old service instances had a different way of retrieving credentials. You can check this by running `cf services` to get your service instance name and then running `cf service service-instance-name` -- if the service information includes a link to `fugacious.18f.gov`, it's an old service instance. See [this post for changes]({{< relref "updates/2017-07-07-changes-to-credentials-broker.md" >}}) -- your best next step is to delete the old service instance and create a new one.
 
 ## More information
 


### PR DESCRIPTION
I observed an engineer at 18F who was baffled by the service account instructions because they were dealing with a legacy service account that had Fugacious credentials, and they missed the "note" at the top of the page . They didn't know when the service account was created (another engineer had created it).

I believe moving this top-of-page note down to an error-case note (and giving explicit transition instructions) will help other engineers who may run into this case.

Based on a quick glance at Admin UI, there are still several dozen service instances that use the old-style Fugacious credentials.