### PR TITLE
Add info to SSH page about disabling SSH

### DIFF
--- a/content/docs/apps/using-ssh.md
+++ b/content/docs/apps/using-ssh.md
@@ -21,7 +21,7 @@ You can interact directly with the services bound to your application via [port-
 
 ### Error messages
 
-* `cf ssh` uses port 2222, 22, or 443. If your network blocks all of these ports, you may receive an error message such as `Error opening SSH connection`.
+* `cf ssh` uses port 2222. If your network blocks port 2222, you may receive an error message such as `Error opening SSH connection`.
 * Running `python` within an SSH session results in `ImportError: No module named site`.  
   * To resolve this, configure your SSH session environment with these commands:
     ```

--- a/content/docs/apps/using-ssh.md
+++ b/content/docs/apps/using-ssh.md
@@ -32,6 +32,10 @@ You can interact directly with the services bound to your application via [port-
     export PYTHONHOME=/home/vcap/deps/0/python
     ```
 
+### How to disable SSH access
+
+SSH access is enabled by default. Space Developers can disable SSH access to individual applications, and Space Managers can disable SSH access to all apps running within a space. See [Enabling and Disabling SSH Access](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#enable-disable-ssh) for the commands.
+
 ### SSH version information 
 
 The cloud.gov application containers use the SSH-2.0 protocol. The SSH service uses the [CloudFoundry SSH implementation](https://github.com/cloudfoundry/diego-ssh). For more on how Cloud Foundry implements SSH, refer to Cloud Foundry's documentation on [Understanding Application SSH](https://docs.cloudfoundry.org/concepts/diego/ssh-conceptual.html).

--- a/content/docs/apps/using-ssh.md
+++ b/content/docs/apps/using-ssh.md
@@ -21,7 +21,7 @@ You can interact directly with the services bound to your application via [port-
 
 ### Error messages
 
-* `cf ssh` uses port 2222. If your network blocks port 2222, you may receive an error message such as `Error opening SSH connection`.
+* `cf ssh` uses port 2222, 22, or 443. If your network blocks all of these ports, you may receive an error message such as `Error opening SSH connection`.
 * Running `python` within an SSH session results in `ImportError: No module named site`.  
   * To resolve this, configure your SSH session environment with these commands:
     ```


### PR DESCRIPTION
Changes:
* Note that SSH is enabled by default and how to disable it.
* ~Mention the alternate SSH ports available ([cloud.gov team: as documented here](https://docs.google.com/document/d/1-yWK83jESYB-hUQVe_J65jR65UOy0MImDh5GkX3uHlk/edit)). I don't know if this description accurately represents the user experience - does it automatically work like this, or does the user need to do something special to use the alternate ports?~

This needs technical review.