### PR TITLE
Explain more about setting up CircleCI and other CD services

### DIFF
--- a/content/docs/apps/continuous-deployment.md
+++ b/content/docs/apps/continuous-deployment.md
@@ -24,7 +24,11 @@ To provision a deployer account with permission to deploy to a single space, [se
 
 ## Configure your service
 
-cloud.gov does not yet provide a CI/CD (continuous integration/continuous deployment) service, but you can use any CI/CD service of your choice. Here are examples of how to set up two common cloud-based services that have free tiers for open source projects, [Travis](https://travis-ci.org/) and [CircleCI](https://circleci.com/). (You can also find and adapt instructions for using other CI/CD services with other Cloud Foundry deployments, such as [this explanation of how to use Jenkins](https://docs.cloud.service.gov.uk/#setting-up-the-cloud-foundry-jenkins-plugin).)
+cloud.gov does not yet provide a CI/CD (continuous integration/continuous deployment) service, but you can use any CI/CD service of your choice.
+
+You can configure your code repositories, [spaces]({{< relref "docs/getting-started/concepts.md#spaces" >}}), and CI/CD service together to enable automated or semi-automated deployments to your environments (such as development, staging, and production environments). For deployments in each environment, you can configure access control and testing requirements according to your project's needs.
+
+Here are examples of how to set up two cloud-based services that have free tiers for open source projects, [Travis](https://docs.travis-ci.com/) and [CircleCI](https://circleci.com/docs/1.0/). (You can also find and adapt instructions for using other CI/CD services with other Cloud Foundry deployments, such as [this explanation of how to use Jenkins](https://docs.cloud.service.gov.uk/#setting-up-the-cloud-foundry-jenkins-plugin).)
 
 ### Travis
 

--- a/content/docs/apps/continuous-deployment.md
+++ b/content/docs/apps/continuous-deployment.md
@@ -13,7 +13,8 @@ changes to your desired environment.
 Before setting up continuous deployment:
 
 1. Go through the [production-ready guide]({{< relref "production-ready.md" >}}) to ensure your application uses the [core best practices]({{< relref "production-ready.md#core-best-practices" >}}) and [zero-downtime deployment]({{< relref "production-ready.md#zero-downtime-deploy" >}}). This will help you use continuous deployment with reduced risk of errors and outages.
-1. Set up continuous integration. This will protect you from deploying a broken application. You can use the same service for continuous integration and continuous deployment — see [the list of continuous integration services below]({{< relref "#continuous-integration-services" >}}) for suggestions.
+ * The essential requirements: your code needs to be in version control, and it needs to include [a `manifest.yml` file](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) that captures the intended deployment configuration for your application.
+1. Set up continuous integration. This will protect you from deploying a broken application. You can use the same service for continuous integration and continuous deployment — see [the list of continuous integration services below]({{< relref "#configure-your-service" >}}) for suggestions.
 
 ## Provision deployment credentials
 
@@ -21,9 +22,9 @@ Continuous deployment systems require credentials for use in pushing new version
 
 To provision a deployer account with permission to deploy to a single space, [set up an instance of a cloud.gov service account]({{< relref "docs/services/cloud-gov-service-account.md" >}}).
 
-## Continuous integration services
+## Configure your service
 
-To set up any of these services, you will need to provide [a `manifest.yml` file](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) that captures the intended deployment configuration for your application.
+cloud.gov does not yet provide a CI/CD (continuous integration/continuous deployment) service, but you can use any CI/CD service of your choice. Here are examples of how to set up two common cloud-based services that have free tiers for open source projects, [Travis](https://travis-ci.org/) and [CircleCI](https://circleci.com/). (You can also find and adapt instructions for using other CI/CD services with other Cloud Foundry deployments, such as [this explanation of how to use Jenkins](https://docs.cloud.service.gov.uk/#setting-up-the-cloud-foundry-jenkins-plugin).)
 
 ### Travis
 
@@ -72,7 +73,9 @@ For details, see [Jekyll's Continuous Integration guide](http://jekyllrb.com/doc
 
 ### CircleCI
 
-Add these items to your `circle.yml` file:
+See [Getting Started with CircleCI](https://circleci.com/docs/1.0/getting-started/) -- you'll need to set up a CircleCI account and give it access to your code repository.
+
+In your code repository, use the following template to set up your `circle.yml` file. This uses CircleCI 1.0 syntax.
 
 ```yaml
 dependencies:
@@ -83,7 +86,7 @@ dependencies:
 
 test:
   post:
-    - cf login -a https://api.fr.cloud.gov -u DEPLOYER_USER -p $CF_PASS -o ORG -s SPACE
+    - cf login -a https://api.fr.cloud.gov -u DEPLOYER_SERVICE_ACCOUNT_USERNAME -p $CF_PASS -o ORG -s SPACE
 
 deployment:
   production:
@@ -92,6 +95,8 @@ deployment:
       - cf push
 ```
 
-Replace `DEPLOYER_USER`, `ORG`, and `SPACE` accordingly, and export the `CF_PASS` environment variable in the Circle interface to add the deployer's password.
+Replace `DEPLOYER_SERVICE_ACCOUNT_USERNAME`, `ORG`, and `SPACE` with your information. **Do not replace** `$CF_PASS` with your deployer service account password -- instead, export the `CF_PASS` environment variable [in the CircleCI interface](https://circleci.com/docs/1.0/environment-variables/#setting-environment-variables-for-all-commands-without-adding-them-to-git) and put the deployer password there.
+
+You can also review their [sample circle.yml file](https://circleci.com/docs/1.0/config-sample/) for more configuration options.
 
 **Note**: If your `manifest.yml` describes more than one app, you might want to specify which app to push in the `cf push` line.


### PR DESCRIPTION
I recently set up CD for the first time for a cloud.gov app, and these instructions would have helped me a little bit. These changes are also informed by [the questions this prospective customer asked](https://docs.google.com/document/d/1S_TZGkRRuF_x-qCqQbaBpGgK_wx7JYatLfZ84-c22OY/edit?pli=1#heading=h.9oozu1baya5v) when I demoed that basic CD setup, as well as the questions [that this prospective customer asked](https://docs.google.com/document/d/1aZPGLlmrTpnIhfR-m3ZHIQJt4aKNMesl211bCBlfAE8/edit#).

Changes:
* Move requirement for `manifest.yml` up into the requirements section.
* Explicitly explain that your code needs to be in version control.
* Explain that the Travis and CircleCI examples are just examples, and that you can use any CI/CD service.
* Link to [this UK explanation of how to use Jenkins](https://docs.cloud.service.gov.uk/#setting-up-the-cloud-foundry-jenkins-plugin) - not sure how much of it applies, but I figure it may be a helpful starting point for a person familiar with Jenkins.
* Explain initial CircleCI setup, and make the environment variable instructions more specific and direct.

Limitations: this does not explain how to set up conditional deployments with CircleCI, since I don't know how to do that. [This circle.yml file looks helpful](https://github.com/AusDTO/dto-digitalmarketplace-frontend/blob/master/circle.yml) (thanks @sharms) but I don't understand it well enough yet to explain it.

This needs technical review.