### PR TITLE
Clarify instructions for using services

### DIFF
--- a/content/docs/apps/managed-services.md
+++ b/content/docs/apps/managed-services.md
@@ -37,9 +37,9 @@ The note `* These service plans have an associated cost` indicates paid services
 
 ### Bind the service instance
 
-A service instance must be bound to the application which will access it. This can be done in a single step by adding a binding to the application's `manifest.yml`.
+For services that apply to an application ([Elasticsearch]({{< relref "docs/services/elasticsearch24.md" >}}), [Redis]({{< relref "docs/services/redis.md" >}}), [relational databases (RDS)]({{< relref "docs/services/relational-database.md" >}}), and [S3]({{< relref "docs/services/s3.md" >}})), the service instance must be bound to the application which will access it. (The [CDN service]({{< relref "docs/services/cdn-route.md" >}}), [identity provider]({{< relref "docs/services/cloud-gov-identity-provider.md" >}}), and [service account]({{< relref "docs/services/cloud-gov-service-account.md" >}}) have different instructions, available in their service documentation.) 
 
-**manifest.yml**
+Binding to an application can be done in a single step by adding a binding to the application's `manifest.yml`, for example:
 
 ```yaml
 ---
@@ -52,15 +52,13 @@ applications:
 
 A service binding will be created with the next `cf push`.
 
-Alternatively, a service instance can also bound to an existing application via the `cf` cli.
+Alternatively, a service instance can also bound to an existing application via the `cf` CLI:
 
 ```
 % cf bind-service APPLICATION INSTANCE_NAME
 ```
 
-Use `cf env APPLICATION` to display the application environment variables, including `VCAP_SERVICES` which holds information for each bound service.
-
-**Output:**
+Use `cf env APPLICATION` to display the application environment variables, including `VCAP_SERVICES` which holds information for each bound service. Output:
 
 ```javascript
 // ...

--- a/content/docs/services/cdn-route.md
+++ b/content/docs/services/cdn-route.md
@@ -10,8 +10,8 @@ status: "Production Ready"
 
 This service provides three key elements to support production applications:
 
-1. Custom domain support, so that your application can have your domain instead of the default `*.app.cloud.gov` domain.
-2. Content Distribution Network (CDN) caching (using [AWS CloudFront](https://aws.amazon.com/cloudfront/)), for fast delivery of content to your users.
+1. [Custom domain]({{< relref "docs/apps/custom-domains.md" >}}) support, so that your application can have your domain instead of the default `*.app.cloud.gov` domain.
+2. Content Distribution Network (CDN) caching (using [AWS CloudFront](https://aws.amazon.com/cloudfront/)), for fast delivery of content to your users. Before setting up this service, review [how the CDN works](#more-about-how-the-cdn-works).
 3. HTTPS support via free TLS certificates with auto-renewal (using [Let's Encrypt](https://letsencrypt.org/)), so that user traffic is encrypted.
 
 ## Plans
@@ -179,15 +179,6 @@ Then [set up DNS](#how-to-set-up-dns).
 
 ## More about how the CDN works
 
-### CDN configuration options
-
-If you don't want to [forward cookies to your origin](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html), you can disable this by setting the `cookies` parameter to `false`:
-
-```sh
-cf create-service cdn-route cdn-route my-cdn-route \
-    -c '{"domain": "my.example.gov", "cookies": false}'
-```
-
 ### Caching
 
 CloudFront [uses](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html)
@@ -198,17 +189,25 @@ particularly confusing as different requests might be routed to different
 CloudFront Edge endpoints.
 
 While there is no mechanism for cloud.gov users to trigger a cache clear, 
-[cloud.gov support](/help/) can. Note however, that cache invalidation is not
+[cloud.gov support](/help/) can. Cache invalidation is not
 instantaneous; Amazon recommends expecting a lag time of 10-15 minutes (more if there are
 many distinct endpoints).
 
 ### Authentication
 
-As noted above, cookies are passed through the CDN by default, meaning that
-cookie-based authentication will work as expected. Other headers, such as HTTP
-auth, are stripped by default. If you need a different configuration, contact [cloud.gov support](/help/).
+Cookies are passed through the CDN by default, meaning that
+cookie-based authentication will work as expected. If you don't want to [forward cookies to your origin](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html), you can disable this by setting the `cookies` parameter to `false`:
 
-### Certificate validity and renewal
+```sh
+cf create-service cdn-route cdn-route my-cdn-route \
+    -c '{"domain": "my.example.gov", "cookies": false}'
+```
+
+Other headers, such as HTTP auth, are stripped by default.
+
+If you need a different configuration, contact [cloud.gov support](/help/).
+
+## Certificate validity and renewal
 
 Let's Encrypt TLS certificates are valid for 90 days.  The broker will automatically renew your certificate every 60 days.  This process is usually immedate but can take several days to complete.  If your certificate is expiring within the next 21 days and has not been renewed automatically, contact [cloud.gov support](/help/).
 

--- a/content/docs/services/elasticsearch24.md
+++ b/content/docs/services/elasticsearch24.md
@@ -2,7 +2,7 @@
 menu:
   docs:
     parent: services
-title: Elasticsearch 2.4
+title: Elasticsearch
 name: "elasticsearch24"
 description: "Elasticsearch version 2.4: a distributed, RESTful search and analytics engine"
 status: "Beta"

--- a/content/docs/services/relational-database.md
+++ b/content/docs/services/relational-database.md
@@ -2,7 +2,7 @@
 menu:
   docs:
     parent: services
-title: Relational databases (aws-rds)
+title: Relational databases (RDS)
 description: "Persistent, relational databases using Amazon RDS"
 aliases:
   - /docs/apps/databases
@@ -14,7 +14,7 @@ If your application uses relational databases for storage, you can use the AWS R
 
 Plan Name | Description | Price
 --------- | ----------- | -----
-`shared-psql`            | Shared PostgresSQL database for prototyping (no sensitive or production data) | Free
+`shared-psql`            | Shared PostgreSQL database for prototyping (no sensitive or production data) | Free
 `medium-psql`            | Dedicated medium RDS PostgreSQL DB instance                                   | Will be paid per hour + storage
 `medium-psql-redundant`  | Dedicated redundant medium RDS PostgreSQL DB instance                         | Will be paid per hour + storage
 `large-psql`             | Dedicated large RDS PostgreSQL DB instance                                    | Will be paid per hour + storage


### PR DESCRIPTION
Changes:
* Explain on the [Managed Services page](https://cloud.gov/docs/apps/managed-services/) that some services have different instructions, so that people don't get confused about how to bind a CDN service. (I got confused by this.)
* On the CDN service page, link to the custom domain page.
* On the CDN service page, advise upfront to review our CloudFront config info before setting up the CDN service, to prevent surprises.
* On the CDN service page, consolidate info about cookie forwarding.
* Elasticsearch page doesn't need its version number in its title.
* RDS page had a typo and doesn't need a brand name in its title.