### PR TITLE
Make overview styling match docs styling, to fix USA banner

### DIFF
--- a/layouts/partials/overview-header.html
+++ b/layouts/partials/overview-header.html
@@ -10,9 +10,13 @@
 
     <link href="/assets/font-awesome/css/font-awesome.min.css" rel="stylesheet" />
     <link href="/assets/css/cloudgov-style.css" rel="stylesheet">
+    <link href="/assets/css/main.css" rel="stylesheet">
+    <link href="/assets/css/highlight-tomorrow.min.css" rel="stylesheet">
+    <link href="/assets/css/jquery-ui.min.css" rel="stylesheet">
     <link rel="shortcut icon" type="image/x-icon" href="/assets/img/favicon.ico" />
 
   </head>
+
   <body>
     {{ partial "header.html" . }}
     <div class="title_bar">


### PR DESCRIPTION
Followup to https://github.com/18F/cg-site/pull/1068 to make the banner work in the overview section (fixing my own bug report from [this card](https://favro.com/card/1e11108a2da81e3bd7153a7a/18F-8083)).

Before:

<img width="1061" alt="screen shot 2017-09-19 at 5 14 04 pm" src="https://user-images.githubusercontent.com/391313/30621095-ffba7b7c-9d5d-11e7-8782-e2ac88a0065f.png">

After:

<img width="1074" alt="screen shot 2017-09-19 at 5 14 52 pm" src="https://user-images.githubusercontent.com/391313/30621121-1446e530-9d5e-11e7-8a97-a1920000d9bd.png">
