### PR TITLE
Add info about cron jobs and give context for the additional option for one-off tasks

### DIFF
--- a/content/docs/apps/experimental/docker.md
+++ b/content/docs/apps/experimental/docker.md
@@ -35,4 +35,4 @@ Here are some considerations to keep in mind when deciding to use Docker images 
 
 #### Docker as tasks
 
-There is [an experimental Cloud Foundry API for tasks creation](http://v3-apidocs.cloudfoundry.org/version/3.0.0-alpha.1/index.html#tasks). This will allow single, one-off tasks to be triggered through the API.
+There is [a Cloud Foundry API for tasks creation](http://v3-apidocs.cloudfoundry.org/version/3.31.0/index.html#tasks). This allows single, one-off tasks to be triggered through the API.

--- a/content/docs/apps/using-ssh.md
+++ b/content/docs/apps/using-ssh.md
@@ -12,7 +12,7 @@ ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-comma
 command, which lets you securely log in to an application instance where you can
 perform debugging, environment inspection, and other tasks.
 
-Your application environment is not completely setup when you log in. You'll probably need
+Your application environment is not completely set up when you log in. You'll probably need
 to [configure your session to match your application's
 environment](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-env)
 in order to debug your application.
@@ -38,6 +38,6 @@ SSH access is enabled by default. Space Developers can disable SSH access to ind
 
 ### SSH version information 
 
-The cloud.gov application containers use the SSH-2.0 protocol. The SSH service uses the [CloudFoundry SSH implementation](https://github.com/cloudfoundry/diego-ssh). For more on how Cloud Foundry implements SSH, refer to Cloud Foundry's documentation on [Understanding Application SSH](https://docs.cloudfoundry.org/concepts/diego/ssh-conceptual.html).
+Application containers use the SSH-2.0 protocol. The SSH service uses the [Cloud Foundry SSH implementation](https://github.com/cloudfoundry/diego-ssh). For more on how Cloud Foundry implements SSH, refer to Cloud Foundry's documentation on [Understanding Application SSH](https://docs.cloudfoundry.org/concepts/diego/ssh-conceptual.html).
 
 

--- a/content/docs/getting-started/one-off-tasks.md
+++ b/content/docs/getting-started/one-off-tasks.md
@@ -12,8 +12,13 @@ What are you trying to do? | Documentation
 Inspect an app instance to figure out what's wrong | [`cf ssh`]({{< relref "docs/apps/using-ssh.md" >}})
 Work with one of your service instances | [`cf ssh` with port forwarding]({{< relref "docs/apps/using-ssh.md" >}})
 Run a non-interactive process that does a task (such as generating a report, cleaning up garbage, mailing people, processing some data, etc.) | [Cloud Foundry Tasks](https://docs.cloudfoundry.org/devguide/using-tasks.html)
+Alternative way to run a non-interactive process that does a task (may be suitable if you want full control over the task app lifecycle) | [Deploy an app that performs a task](#deploy-an-app-that-performs-a-task)
 
-## Deploy a short-lived app
+## Run periodic scheduled tasks
+
+If you'd like to run a periodic scheduled task (similar to a cron job), you should find a cron-like library in the programming language that you're working with, and implement the task using that library. You can run this as part of an existing application or as a separate application.
+
+## Deploy an app that performs a task
 
 ### Know before you deploy
 
@@ -39,7 +44,7 @@ Note that this will not work for any command that is interactive.
     cp manifest.yml task_manifest.yml
     ```
 
-1. Modify the `task_manifest.yml`:
+2. Modify the `task_manifest.yml`:
     * Change the `name` value to be `task-runner` (or something descriptive).
     * Remove the following attributes, if present:
         * `domain`
@@ -54,22 +59,19 @@ Note that this will not work for any command that is interactive.
         command: (<your command> && echo SUCCESS || echo FAIL) && sleep infinity
         ```
 
-1. Deploy the one-off app, and view the output:
-
-   When deploying the one-off tasks, it's important to disable health-checks and
+3. Deploy the one-off app, and view the output. When deploying the one-off tasks, it's important to disable health-checks and
    routes in order to prevent deployment issues during the buildpack phase and
    having multiple applications with the same mapped route respectively. For
    more information on these options, see the [`--no-route`][cf-no-route] and
    [`--health-check-type`][cf-health-check] documentation. In order to keep
    changes to your copied manifest at a minimum, you can provide these
-   configuration options directly on the command-line.
-
-    ```sh
-    cf push -f task_manifest.yml --health-check-type none --no-route
-    cf logs --recent task-runner
-    ```
-1. If needed, use [`cf files`][] to collect any artifacts.
-1. Run `cf delete task-runner` to clean it up. **If you don't do this, your short-lived app may automatically run itself again in the future.** cloud.gov sometimes automatically restarts apps as part of routine operations (such as platform updates), which can include restarting this kind of app if it hasn't been deleted.
+   configuration options directly on the command-line:
+```sh
+cf push -f task_manifest.yml --health-check-type none --no-route
+cf logs --recent task-runner
+```
+4. If needed, use [`cf files`][] to collect any artifacts.
+5. Run `cf delete task-runner` to clean it up. **If you don't do this, your app may automatically run itself again in the future.** cloud.gov sometimes automatically restarts apps as part of routine operations (such as platform updates), which can include restarting this kind of app if it hasn't been deleted.
 
 [`cf files`]: http://cli.cloudfoundry.org/en-US/cf/files.html
 

--- a/content/docs/getting-started/one-off-tasks.md
+++ b/content/docs/getting-started/one-off-tasks.md
@@ -18,6 +18,8 @@ Alternative way to run a non-interactive process that does a task (may be suitab
 
 If you'd like to run a periodic scheduled task (similar to a cron job), you should find a cron-like library in the programming language that you're working with, and implement the task using that library. You can run this as part of an existing application or as a separate application.
 
+If you use [continuous deployment]({{< relref "docs/apps/continuous-deployment.md" >}}), you can use a timer as an input to a task or pipeline that runs a [Cloud Foundry Task](https://docs.cloudfoundry.org/devguide/using-tasks.html).
+
 ## Deploy an app that performs a task
 
 ### Know before you deploy

--- a/content/docs/getting-started/one-off-tasks.md
+++ b/content/docs/getting-started/one-off-tasks.md
@@ -70,10 +70,8 @@ Note that this will not work for any command that is interactive.
 cf push -f task_manifest.yml --health-check-type none --no-route
 cf logs --recent task-runner
 ```
-4. If needed, use [`cf files`][] to collect any artifacts.
+4. If needed, use [`cf ssh`]({{< relref "docs/apps/using-ssh.md" >}}) to collect any artifacts.
 5. Run `cf delete task-runner` to clean it up. **If you don't do this, your app may automatically run itself again in the future.** cloud.gov sometimes automatically restarts apps as part of routine operations (such as platform updates), which can include restarting this kind of app if it hasn't been deleted.
-
-[`cf files`]: https://cli.cloudfoundry.org/en-US/cf/files.html
 
 [cf-no-route]: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#no-route "CloudFoundry Documentation about --no-route"
 [cf-health-check]: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#health-check-type "CloudFoundry Documentation about --health-check-type"

--- a/content/docs/getting-started/one-off-tasks.md
+++ b/content/docs/getting-started/one-off-tasks.md
@@ -46,7 +46,7 @@ Note that this will not work for any command that is interactive.
     cp manifest.yml task_manifest.yml
     ```
 
-2. Modify the `task_manifest.yml`:
+1. Modify the `task_manifest.yml`:
     * Change the `name` value to be `task-runner` (or something descriptive).
     * Remove the following attributes, if present:
         * `domain`
@@ -61,7 +61,7 @@ Note that this will not work for any command that is interactive.
         command: (<your command> && echo SUCCESS || echo FAIL) && sleep infinity
         ```
 
-3. Deploy the one-off app, and view the output. When deploying the one-off tasks, it's important to disable health-checks and
+1. Deploy the one-off app, and view the output. When deploying the one-off tasks, it's important to disable health-checks and
    routes in order to prevent deployment issues during the buildpack phase and
    having multiple applications with the same mapped route respectively. For
    more information on these options, see the [`--no-route`][cf-no-route] and
@@ -72,8 +72,8 @@ Note that this will not work for any command that is interactive.
 cf push -f task_manifest.yml --health-check-type none --no-route
 cf logs --recent task-runner
 ```
-4. If needed, use [`cf ssh`]({{< relref "docs/apps/using-ssh.md" >}}) to collect any artifacts.
-5. Run `cf delete task-runner` to clean it up. **If you don't do this, your app may automatically run itself again in the future.** cloud.gov sometimes automatically restarts apps as part of routine operations (such as platform updates), which can include restarting this kind of app if it hasn't been deleted.
+1. If needed, use [`cf ssh`]({{< relref "docs/apps/using-ssh.md" >}}) to collect any artifacts.
+1. Run `cf delete task-runner` to clean it up. **If you don't do this, your app may automatically run itself again in the future.** cloud.gov sometimes automatically restarts apps as part of routine operations (such as platform updates), which can include restarting this kind of app if it hasn't been deleted.
 
 [cf-no-route]: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#no-route "CloudFoundry Documentation about --no-route"
 [cf-health-check]: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#health-check-type "CloudFoundry Documentation about --health-check-type"

--- a/content/docs/getting-started/one-off-tasks.md
+++ b/content/docs/getting-started/one-off-tasks.md
@@ -73,7 +73,7 @@ cf logs --recent task-runner
 4. If needed, use [`cf files`][] to collect any artifacts.
 5. Run `cf delete task-runner` to clean it up. **If you don't do this, your app may automatically run itself again in the future.** cloud.gov sometimes automatically restarts apps as part of routine operations (such as platform updates), which can include restarting this kind of app if it hasn't been deleted.
 
-[`cf files`]: http://cli.cloudfoundry.org/en-US/cf/files.html
+[`cf files`]: https://cli.cloudfoundry.org/en-US/cf/files.html
 
 [cf-no-route]: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#no-route "CloudFoundry Documentation about --no-route"
 [cf-health-check]: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#health-check-type "CloudFoundry Documentation about --health-check-type"


### PR DESCRIPTION
Changes on the [one-off tasks page](https://cloud.gov/docs/getting-started/one-off-tasks/):

* The extra option documented on that page was not in the table at the top of the page, so I added it to the table as an option.
* I added a recommendation for how to implement cron jobs.
* I corrected the formatting and updated the instructions for the extra option documented on the page.

I also put in a couple of copyedits for the SSH page, and I updated a note on the Docker page.

Thanks to @jmcarp, @rogeruiz, and @mogul for giving suggestions I used to write this PR! This PR needs technical review before merge.