### PR TITLE
Remove redundant info on account info page

### DIFF
--- a/content/docs/getting-started/accounts.md
+++ b/content/docs/getting-started/accounts.md
@@ -45,12 +45,6 @@ If you lose access to your authentication application (such as if you lose your 
 4. Reset your account's authentication application.
 5. Let you know this is complete, so that you can set up a new authentication application and request access from your Space Managers and Org Managers again. It is their responsibility to verify that this is a legitimate request from you.
 
-In order to perform multi-factor authentication, you need an authentication application that generates time-based one-time passcodes, such as [Google Authenticator](https://support.google.com/accounts/answer/1066447?hl=en) or [Authy](https://www.authy.com/app/mobile). Download the app on your mobile device. When you log into cloud.gov for the first time, follow the instructions to store the `cloud.gov` key in your application.
-
-### Deployer accounts
-
-If you're using the [deployer account broker]({{< relref "docs/apps/continuous-deployment.md" >}}), you can delete and recreate that account to reset the credentials.
-
 ## Use your account responsibly
 
 Acceptable uses of cloud.gov include:


### PR DESCRIPTION
Changes:

* Remove repeated paragraph about setting up auth apps.
* Remove outdated info about resetting deployer account credentials - people are not likely to look for that on this page anymore. It made sense here back when we were transitioning from manual deployer accounts to automated ones, but now they're [all automated](https://cloud.gov/docs/services/cloud-gov-service-account/).

Up for review by anyone.