### PR TITLE
Add basic info on RDS page about getting database version info

### DIFF
--- a/content/docs/services/relational-database.md
+++ b/content/docs/services/relational-database.md
@@ -12,19 +12,19 @@ If your application uses relational databases for storage, you can use the AWS R
 
 ## Plans
 
-Plan Name | Description | Price
---------- | ----------- | -----
-`shared-psql`            | Shared PostgreSQL database for prototyping (no sensitive or production data) | Free
-`medium-psql`            | Dedicated medium RDS PostgreSQL DB instance                                   | Will be paid per hour + storage
-`medium-psql-redundant`  | Dedicated redundant medium RDS PostgreSQL DB instance                         | Will be paid per hour + storage
-`large-psql`             | Dedicated large RDS PostgreSQL DB instance                                    | Will be paid per hour + storage
-`large-psql-redundant`   | Dedicated redundant large RDS PostgreSQL DB instance                          | Will be paid per hour + storage
-`shared-mysql`           | Shared MySQL database for prototyping (no sensitive or production data)       | Free
-`medium-mysql`           | Dedicated medium RDS MySQL DB instance                                        | Will be paid per hour + storage
-`medium-mysql-redundant` | Dedicated redundant medium RDS MySQL DB instance                              | Will be paid per hour + storage
-`large-mysql`            | Dedicated large RDS MySQL DB instance                                         | Will be paid per hour + storage
-`large-mysql-redundant`  | Dedicated redundant large RDS MySQL DB instance                               | Will be paid per hour + storage
-`medium-oracle-se2`      | Dedicated medium RDS Oracle SE2 DB | Will be paid per hour + storage
+Plan Name | Description | Version | Price
+--------- | ----------- | ------- | -----
+`shared-psql`            | Shared PostgreSQL database for prototyping (no sensitive or production data) | 9.4.7 | Free
+`medium-psql`            | Dedicated medium RDS PostgreSQL DB instance                                  | 9.6.2 |  Will be paid per hour + storage
+`medium-psql-redundant`  | Dedicated redundant medium RDS PostgreSQL DB instance                        | 9.6.2 | Will be paid per hour + storage
+`large-psql`             | Dedicated large RDS PostgreSQL DB instance                                   | 9.6.2 | Will be paid per hour + storage
+`large-psql-redundant`   | Dedicated redundant large RDS PostgreSQL DB instance                         | 9.6.2 | Will be paid per hour + storage
+`shared-mysql`           | Shared MySQL database for prototyping (no sensitive or production data)      | 5.6.27 | Free
+`medium-mysql`           | Dedicated medium RDS MySQL DB instance                                       | 5.6.35 | Will be paid per hour + storage
+`medium-mysql-redundant` | Dedicated redundant medium RDS MySQL DB instance                             | 5.6.35 | Will be paid per hour + storage
+`large-mysql`            | Dedicated large RDS MySQL DB instance                                        | 5.6.35 | Will be paid per hour + storage
+`large-mysql-redundant`  | Dedicated redundant large RDS MySQL DB instance                              | 5.6.35 | Will be paid per hour + storage
+`medium-oracle-se2`      | Dedicated medium RDS Oracle SE2 DB | 12.0.1.2.v8 | Will be paid per hour + storage
 
 ### Pricing
 Shared instances are free. Simple and redundant instances will have pricing per hour and per GB per month. [Learn more about managed service pricing.]({{< relref "overview/pricing/managed-services-cost.md" >}})
@@ -158,12 +158,11 @@ You can rotate credentials by creating a new instance and deleting the existing 
 
 ## Version information
 
+Dedicated RDS plans use the latest database version available from AWS at the time. Shared plans may use older database versions.
+
+All RDS plans are configured to automatically upgrade to the most recent compatible [minor version](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Upgrading.html) available via AWS.
+
 In general, you can view version information about database instances bound to applications using [`cf ssh`]({{< relref "docs/apps/using-ssh.md" >}}) and the standard database-specific commands for viewing version information.
-
-**PostgreSQL**: 
-
-* New dedicated PostgreSQL service instances (`medium-psql`, `medium-psql-redundant`, `large-psql`, `large-psql-redundant`) are on PostgreSQL 9.6.2. We periodically update this to the latest stable release available in AWS RDS GovCloud US.
-* Shared PostgreSQL service instances (`shared-psql`) are on an older version.
 
 ## The broker in GitHub
 

--- a/content/docs/services/relational-database.md
+++ b/content/docs/services/relational-database.md
@@ -12,7 +12,7 @@ If your application uses relational databases for storage, you can use the AWS R
 
 ## Plans
 
-Plan Name | Description | Version | Price
+Plan Name | Description | Software Version | Price
 --------- | ----------- | ------- | -----
 `shared-psql`            | Shared PostgreSQL database for prototyping (no sensitive or production data) | 9.4.7 | Free
 `medium-psql`            | Dedicated medium RDS PostgreSQL DB instance                                  | 9.6.2 |  Will be paid per hour + storage
@@ -150,7 +150,7 @@ For shared plans (`shared-psql` and `shared-mysql`), RDS does not back up your d
 
 ## Encryption
 
-Every RDS instance configured through cloud.gov is [encrypted at rest](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html). We use the industry standard AES-256 encryption algorithm to encrypt your data on the server that hosts your RDS instance. The RDS then handles authenticating access and decrypting your data, with minimal performance impact and without requiring you to modify your applications.
+Every RDS instance configured through cloud.gov is [encrypted at rest](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html). We use the industry standard AES-256 encryption algorithm to encrypt your data on the server that hosts your RDS instance. The RDS then handles authenticating access and decrypting your data, with minimal performance impact and without requiring you to modify your applications.
 
 ## Rotating credentials
 
@@ -158,9 +158,9 @@ You can rotate credentials by creating a new instance and deleting the existing 
 
 ## Version information
 
-Dedicated RDS plans use the latest database version available from AWS at the time. Shared plans may use older database versions.
+Dedicated RDS plans use the latest database version available from AWS RDS GovCloud (US) at the time. Shared plans may use older database versions.
 
-All RDS plans are configured to automatically upgrade to the most recent compatible [minor version](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Upgrading.html) available via AWS.
+All RDS plans are configured to automatically upgrade to the most recent compatible [minor version](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Upgrading.html) available via AWS RDS GovCloud (US).
 
 In general, you can view version information about database instances bound to applications using [`cf ssh`]({{< relref "docs/apps/using-ssh.md" >}}) and the standard database-specific commands for viewing version information.
 

--- a/content/docs/services/relational-database.md
+++ b/content/docs/services/relational-database.md
@@ -125,7 +125,7 @@ Run `sftp` or `scp` to transfer files to/from an application instance.  You must
 
 For example, to connect to instance 0 of the application with GUID 0745e60b-c7f3-49a7-a6c2-878516a34796:
 
-```
+```sh
 $ sftp -P 2222 cf:0745e60b-c7f3-49a7-a6c2-878516a34796/0@ssh.fr.cloud.gov
 cf:0745e60b-c7f3-49a7-a6c2-878516a34796/0@ssh.fr.cloud.gov's password: ******
 Connected to ssh.fr.cloud.gov.
@@ -155,6 +155,15 @@ Every RDS instance configured through cloud.gov is [encrypted at rest](http://do
 ## Rotating credentials
 
 You can rotate credentials by creating a new instance and deleting the existing instance. If this is not an option, email [cloud.gov support](mailto:cloud-gov-support@gsa.gov) to request rotating the credentials manually.
+
+## Version information
+
+In general, you can view version information about database instances bound to applications using [`cf ssh`]({{< relref "docs/apps/using-ssh.md" >}}) and the standard database-specific commands for viewing version information.
+
+**PostgreSQL**: 
+
+* New dedicated PostgreSQL service instances (`medium-psql`, `medium-psql-redundant`, `large-psql`, `large-psql-redundant`) are on PostgreSQL 9.6.2. We periodically update this to the latest stable release available in AWS RDS GovCloud US.
+* Shared PostgreSQL service instances (`shared-psql`) are on an older version.
 
 ## The broker in GitHub
 

--- a/content/docs/services/relational-database.md
+++ b/content/docs/services/relational-database.md
@@ -162,8 +162,6 @@ Dedicated RDS plans use the latest database version available from AWS RDS GovCl
 
 All RDS plans are configured to automatically upgrade to the most recent compatible [minor version](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Upgrading.html) available via AWS RDS GovCloud (US).
 
-In general, you can view version information about database instances bound to applications using [`cf ssh`]({{< relref "docs/apps/using-ssh.md" >}}) and the standard database-specific commands for viewing version information.
-
 ## The broker in GitHub
 
 You can find the broker here: [https://github.com/18F/aws-broker](https://github.com/18F/aws-broker).


### PR DESCRIPTION
Prompted by [user question here](https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1506111900000018). This PR should probably be fleshed out with MySQL and Oracle info too - I'll leave that to somebody else (since I'm not sure how to get it).

Also stuck in `sh` to make some syntax highlighting a little less weird.