### PR TITLE
changed headline

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -35,7 +35,7 @@
   <a name="about"></a>
   <div class="usa-grid">
     <div class="section-content usa-content">
-      <h1 class="section-title">We understand what it takes to get from day one to delivery.</h1>
+      <h1 class="section-title">Get from day one to delivery.</h1>
 
       <p class="section-displaytext">cloud.gov offers a fast way for federal agencies to host and update websites (and other web applications, such as APIs), so employees and contractors can skip managing server infrastructure and instead focus on developing services that support agency missions.</p>
 


### PR DESCRIPTION
Changed "We understand what it takes to get from day one to delivery." to "Get from day one to delivery." This content is about our users and their need, not us/the platform.