### PR TITLE
Update python hints post libbuildpack

### DIFF
--- a/content/docs/apps/using-ssh.md
+++ b/content/docs/apps/using-ssh.md
@@ -26,11 +26,10 @@ You can interact directly with the services bound to your application via [port 
   * To resolve this, configure your SSH session environment with these commands:
 
 ```bash
+export DEPS_DIR=/home/vcap/deps
 for f in /home/vcap/app/.profile.d/*.sh;
   do source "$f";
 done
-export LD_LIBRARY_PATH=/home/vcap/deps/0/python/lib/
-export PYTHONHOME=/home/vcap/deps/0/python
 ```
 
 ## How to disable SSH access


### PR DESCRIPTION
The profile.d stuff has changed since

https://github.com/cloudfoundry/python-buildpack/commit/e2baf3066b4ef9651e9f226267ed5ce2e5525a81

so this works now.

to test:

```
cf ssh cms
export DEPS_DIR=/home/vcap/deps
for f in /home/vcap/app/.profile.d/*.sh;
  do source "$f";
done

app/fec/manage.py
```