### PR TITLE
Restage frequency should be determined by customer

### DIFF
--- a/content/docs/getting-started/app-maintenance.md
+++ b/content/docs/getting-started/app-maintenance.md
@@ -11,7 +11,7 @@ One of the benefits of hosting your application or website on cloud.gov is that 
 
 Restaging is [a process that recreates your app](https://docs.cloudfoundry.org/devguide/deploy-apps/start-restart-restage.html#restage) on cloud.gov using the most recent environment. When the platform updates the filesystem (rootfs) and buildpacks, your apps need to be restaged in order to use them. cloud.gov doesn’t restage your apps for you because doing so may have unintended consequences for your app. Make restaging a part of your development process. You may choose to restage your development and staging environment apps before restaging your production apps.
 
-Run `cf restage <app-name>` every two weeks to get any updates we may have pushed that affect your app, especially if you don’t update your own code very often. Changes like these are announced in the platform release notes so you can know when we’ve mitigated a critical security issue or fixed a bug that affects your app’s stability. Without a restage, your app will miss out on these updates.
+Run `cf restage <app-name>` periodically (for example, every two weeks) to get any updates we may have pushed that affect your app, especially if you don’t update your own code very often. Changes like these are announced in the platform release notes so you can know when we’ve mitigated a critical security issue or fixed a bug that affects your app’s stability. Without a restage, your app will miss out on these updates.
 
 ## Keeping your app up to date
 


### PR DESCRIPTION
Some customers need to restage more or less frequently than two weeks depending on their security requirements, impact level, etc.