### PR TITLE
Add diagrams for domains and continuous deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ To link to another page within cg-site, use `relref` to create [relative links](
 To add a diagram to a documentation page, use the `{{< diagrams
 id-prefix="title-for-diagram" >}}` shortcode to create them inline for the
 documentation pages. Use the [Mermaid language syntax](https://github.com/knsv/mermaid)
-to create diagrams in the same way diagrams are made for [cg-diagrams](https://github.com/18F/cg-diagrams).
+to create diagrams in the same way diagrams are made for [cg-diagrams](https://github.com/18F/cg-diagrams). 
+Try the [Mermaid live editor](https://mermaidjs.github.io/mermaid-live-editor/)!
 
 > If you find you have a need to create these diagrams on pages outside of the
 > documentation pages, please open a PR to discuss what other pages it should

--- a/content/docs/apps/continuous-deployment.md
+++ b/content/docs/apps/continuous-deployment.md
@@ -28,6 +28,34 @@ cloud.gov does not yet provide a CI/CD (continuous integration/continuous deploy
 
 You can configure your code repositories, [spaces]({{< relref "docs/getting-started/concepts.md#spaces" >}}), and CI/CD service together to enable automated or semi-automated deployments to your environments (such as development, staging, and production environments). For deployments in each environment, you can configure access control and testing requirements according to your project's needs.
 
+An overview of a common workflow for CI/CD with cloud.gov:
+
+{{< diagrams id-prefix="Figure-1.-Continuous-deployment-workflow" >}}
+graph TD
+
+subgraph cloud.gov
+  subgraph Org
+  subgraph Dev space
+      Dev[App]
+    end
+    subgraph Staging space
+      Staging[App]
+    end
+    subgraph Production space
+      Prod[App]
+    end
+  end
+end
+
+Developer((Developer)) -->|Commit code| Repo(Code repository)
+Repo -->|Automatically notify that a commit happened|CD(Continuous Deployment service)
+CD -->|If dev branch, deploy| Dev
+CD -->|If staging branch, deploy| Staging
+CD -->|If prod branch, deploy| Prod
+{{< /diagrams >}}
+
+## Service examples
+
 Here are examples of how to set up two cloud-based services that have free tiers for open source projects, [Travis](https://docs.travis-ci.com/) and [CircleCI](https://circleci.com/docs/1.0/). (You can also find and adapt instructions for using other CI/CD services with other Cloud Foundry deployments, such as [this explanation of how to use Jenkins](https://docs.cloud.service.gov.uk/#setting-up-the-cloud-foundry-jenkins-plugin).)
 
 ### Travis

--- a/content/docs/apps/continuous-deployment.md
+++ b/content/docs/apps/continuous-deployment.md
@@ -28,7 +28,7 @@ cloud.gov does not yet provide a CI/CD (continuous integration/continuous deploy
 
 You can configure your code repositories, [spaces]({{< relref "docs/getting-started/concepts.md#spaces" >}}), and CI/CD service together to enable automated or semi-automated deployments to your environments (such as development, staging, and production environments). For deployments in each environment, you can configure access control and testing requirements according to your project's needs.
 
-An overview of a common workflow for CI/CD with cloud.gov:
+To illustrate how a CI/CD workflow could be incorporated with cloud.gov:
 
 {{< diagrams id-prefix="Figure-1.-Continuous-deployment-workflow" >}}
 graph TD

--- a/content/docs/apps/custom-domains.md
+++ b/content/docs/apps/custom-domains.md
@@ -30,10 +30,10 @@ subgraph Amazon Web Services
     CG-DNS
     Router[App router]
     subgraph Org: agency-org
-    subgraph App A prod space
+    subgraph App A space
         AppA[App A]
       end
-      subgraph App B prod space
+      subgraph App B space
         AppB[App B]
       end
     end     

--- a/content/docs/apps/custom-domains.md
+++ b/content/docs/apps/custom-domains.md
@@ -19,7 +19,7 @@ To make your app accessible via your custom domain name, use the [CDN service]({
 
 ### Comparison of default domains and custom domains
 
-Here's an example of the difference between a default *.app.cloud.gov domain and a custom agency domain. In this example, a staging application is using a default domain, and the production version of the same application is using a custom domain.
+Here's an example of the difference between a default *.app.cloud.gov domain and a custom domain. In this example, a staging application is using a default domain, and the production version of the application is using a custom domain.
 
 {{< diagrams id-prefix="Figure-1.-Domain-comparison" >}}
 graph TD
@@ -28,6 +28,7 @@ subgraph Amazon Web Services
   subgraph cloud.gov
     CDN
     CG-DNS
+    Router[App router]
     subgraph Org
     subgraph Staging space
         Staging[App]
@@ -39,11 +40,13 @@ subgraph Amazon Web Services
   end
 end
 
-Public((Public)) -->|HTTPS| A-DNS(Agency DNS: example.gov)
-Public((Public)) -->|HTTPS| CG-DNS(DNS: example.app.cloud.gov)
+Public((Public user)) -->|HTTPS| A-DNS(Agency DNS: example.gov)
+Public((Public user)) -->|HTTPS| CG-DNS(DNS: example.app.cloud.gov)
 A-DNS -->|HTTPS| CDN(CDN)
-CG-DNS -->|HTTPS|Staging
-CDN -->|HTTPS|Production
+CG-DNS -->Router
+CDN -->Router
+Router-->Staging
+Router-->Production
 {{< /diagrams >}}
 
 ## How domains and routes work in cloud.gov

--- a/content/docs/apps/custom-domains.md
+++ b/content/docs/apps/custom-domains.md
@@ -17,6 +17,35 @@ To make your app accessible via your custom domain name, use the [CDN service]({
 
 *Additional details are available in the [cloud.gov FedRAMP P-ATO documentation package]({{< relref "overview/security/fedramp-tracker.md#how-you-can-use-this-p-ato" >}}), including in System Security Plan controls SC-20, SC-21, SC-22, and SC-23.*
 
+### Comparison of default domains and custom domains
+
+Here's an example of the difference between a default *.app.cloud.gov domain and a custom agency domain. In this example, a staging application is using a default domain, and the production version of the same application is using a custom domain.
+
+{{< diagrams id-prefix="Figure-1.-Domain-comparison" >}}
+graph TD
+
+subgraph Amazon Web Services
+  subgraph cloud.gov
+    CDN
+    CG-DNS
+    subgraph Org
+    subgraph Staging space
+        Staging[App]
+      end
+      subgraph Production space
+        Production[App]
+      end
+    end     
+  end
+end
+
+Public((Public)) -->|HTTPS| A-DNS(Agency DNS: example.gov)
+Public((Public)) -->|HTTPS| CG-DNS(DNS: example.app.cloud.gov)
+A-DNS -->|HTTPS| CDN(CDN)
+CG-DNS -->|HTTPS|Staging
+CDN -->|HTTPS|Production
+{{< /diagrams >}}
+
 ## How domains and routes work in cloud.gov
 
 A "route" is a domain with an optional subdomain and path that maps client requests to a particular application, such as:

--- a/content/docs/apps/custom-domains.md
+++ b/content/docs/apps/custom-domains.md
@@ -29,24 +29,24 @@ subgraph Amazon Web Services
     CDN
     CG-DNS
     Router[App router]
-    subgraph Org
-    subgraph Staging space
-        Staging[App]
+    subgraph Org: agency-org
+    subgraph App A prod space
+        AppA[App A]
       end
-      subgraph Production space
-        Production[App]
+      subgraph App B prod space
+        AppB[App B]
       end
     end     
   end
 end
 
-Public((Public user)) -->|HTTPS| A-DNS(Agency DNS: example.gov)
-Public((Public user)) -->|HTTPS| CG-DNS(DNS: example.app.cloud.gov)
+Public((Public user)) -->|HTTPS| A-DNS(Agency DNS: appB.agency.gov)
+Public((Public user)) -->|HTTPS| CG-DNS(DNS: appA_agency.app.cloud.gov)
 A-DNS -->|HTTPS| CDN(CDN)
 CG-DNS -->Router
 CDN -->Router
-Router-->Staging
-Router-->Production
+Router -->AppA
+Router -->AppB
 {{< /diagrams >}}
 
 ## How domains and routes work in cloud.gov

--- a/content/docs/apps/custom-domains.md
+++ b/content/docs/apps/custom-domains.md
@@ -19,7 +19,7 @@ To make your app accessible via your custom domain name, use the [CDN service]({
 
 ### Comparison of default domains and custom domains
 
-Here's an example of the difference between a default *.app.cloud.gov domain and a custom domain. In this example, a staging application is using a default domain, and the production version of the application is using a custom domain.
+Here's an example of the difference between a default *.app.cloud.gov domain and a custom domain. In this example, an agency's application `App A` is using a default domain, and their application `App B` is using a custom domain.
 
 {{< diagrams id-prefix="Figure-1.-Domain-comparison" >}}
 graph TD

--- a/content/docs/compliance/diagrams.md
+++ b/content/docs/compliance/diagrams.md
@@ -1,0 +1,24 @@
+---
+menu:
+  docs:
+    parent: compliance
+title: Data flow diagrams
+---
+
+These diagrams can help you build a System Security Plan for an application, or assess the security and compliance of an application.
+
+## Customer systems
+
+* [Data flow from the public to a public application]({{< relref "docs/apps/custom-domains.md#comparison-of-default-domains-and-custom-domains" >}})
+* [Continuous deployment]({{< relref "docs/apps/continuous-deployment.md#configure-your-service" >}})
+* [Administrative access to customer systems]({{< relref "docs/compliance/meeting-tic-requirements.md#use-cases-for-accessing-cloud-gov" >}})
+
+## Platform
+
+Platform architecture diagrams from the [cloud.gov P-ATO documentation package]({{< relref "overview/security/fedramp-tracker.md#how-you-can-use-this-p-ato" >}}):
+
+* [Network](https://diagrams.fr.cloud.gov/10-1-network.html)
+* [Customer data flow](https://diagrams.fr.cloud.gov/10-4.1-customer-data-flow.html)
+* [Jumpbox data flow](https://diagrams.fr.cloud.gov/10-4.2-jumpbox.html)
+* [Monitoring and alerting data flow](https://diagrams.fr.cloud.gov/10-4.3-monitoring.html)
+* [Software deployment data flow](https://diagrams.fr.cloud.gov/10-4.4-software-deployment.html)


### PR DESCRIPTION
I had too much fun with the [Mermaid live editor](https://mermaidjs.github.io/mermaid-live-editor/) while thinking about how to [answer this question](https://gsa-tts.slack.com/archives/C0DF6LAMQ/p1508551252000078), so here are a couple new diagrams for review, along with a page that serves as a directory of diagrams.

I think [leveraging authentication](https://cloud.gov/docs/apps/leveraging-authentication/) could be illustrated next, giving an abstracted version of [this diagram](https://docs.google.com/drawings/d/1k1wykk5PbLKSNJj8FyZbIlpX0D8r1q3-w-uRK_WWt9g/edit). We could also provide an abstracted version of [this other diagram](https://docs.google.com/drawings/d/1nwclBJQfbuzsnGOqe88VukQl3uiH1Jfa4c0FT1Cq43I/edit).

For CI/CD page:
<img width="632" alt="screen shot 2017-10-20 at 10 56 26 pm" src="https://user-images.githubusercontent.com/391313/31848558-22f85c9a-b5ea-11e7-9b26-789010663614.png">

For custom domains page:
<img width="527" alt="screen shot 2017-10-20 at 10 56 47 pm" src="https://user-images.githubusercontent.com/391313/31848561-2a02e730-b5ea-11e7-8475-e5d72ab2d3db.png">

Under compliance section:
<img width="653" alt="screen shot 2017-10-20 at 10 57 47 pm" src="https://user-images.githubusercontent.com/391313/31848565-2d75a204-b5ea-11e7-850d-4521fcbbd859.png">
