### PR TITLE
Add another CI/CD diagram and more explanation

### DIFF
--- a/content/docs/apps/continuous-deployment.md
+++ b/content/docs/apps/continuous-deployment.md
@@ -20,13 +20,15 @@ Before setting up continuous deployment:
 
 Continuous deployment systems require credentials for use in pushing new versions of your application code to cloud.gov. You should use a restricted set of credentials that can only access a particular target space, rather than credentials tied to a user who has more access, or who may lose access when leaving your team or project. This "least privilege" approach minimizes the harm that is possible if the credentials are compromised in any way.
 
-To provision a deployer account with permission to deploy to a single space, [set up an instance of a cloud.gov service account]({{< relref "docs/services/cloud-gov-service-account.md" >}}).
+To create deployer account credentials with permission to deploy to a single space, [set up a service account]({{< relref "docs/services/cloud-gov-service-account.md" >}}).
 
 ## Configure your service
 
-cloud.gov does not yet provide a CI/CD (continuous integration/continuous deployment) service, but you can use any CI/CD service of your choice.
+cloud.gov does not provide a CI/CD (continuous integration/continuous deployment) service, but you can use any CI/CD service of your choice.
 
 You can configure your code repositories, [spaces]({{< relref "docs/getting-started/concepts.md#spaces" >}}), and CI/CD service together to enable automated or semi-automated deployments to your environments (such as development, staging, and production environments). For deployments in each environment, you can configure access control and testing requirements according to your project's needs.
+
+The core concept is to set up a script that triggers when you update the material that you want to test and deploy (typically your code in your version control system). The script runs your commands, including your deploy command, using your service account credentials.
 
 To illustrate how a CI/CD workflow could be incorporated with cloud.gov:
 
@@ -52,6 +54,20 @@ Repo -->|Automatically notify that a commit happened|CD(Continuous Deployment se
 CD -->|If dev branch, deploy| Dev
 CD -->|If staging branch, deploy| Staging
 CD -->|If prod branch, deploy| Prod
+{{< /diagrams >}}
+
+Another example of a CI/CD workflow (this illustration omits the org/space boundaries):
+
+{{< diagrams id-prefix="Figure-2.-Alternate-continuous-deployment-workflow" >}}
+graph TD
+
+Developer((Developer)) -->|Commit code| Repo(Code repository)
+Repo -->|Automatically notify that a commit happened|CD(Continuous Deployment service)
+CD -->|If dev branch, deploy| Dev(Dev app on cloud.gov)
+CD -->|If prod branch, deploy, run tests | Preprod(Preprod app on cloud.gov)
+Preprod --> | Test results | CD
+CD -->|If preprod tests OK, deploy prod branch| Prod(Prod app on cloud.gov)
+
 {{< /diagrams >}}
 
 ## Service examples


### PR DESCRIPTION
This is a followup to https://github.com/18F/cg-site/pull/1101 with the following changes:

* Simplify a couple of sentences.
* Add a basic explanation of the overall concept here (informed by [this explanation of user experience](https://cloud-gov.zendesk.com/agent/tickets/782)).
* Add another example of a CI/CD setup, simplified from the diagram @pburkholder made at https://github.com/18F/cg-site/pull/1101#issuecomment-341128527 - I took out a few parts, and it displays a little wide but okay. I think this diagram is helpful for showing that customers can configure CI/CD according to their own needs.

![screen shot 2017-11-07 at 8 08 21 pm](https://user-images.githubusercontent.com/391313/32531313-e9b36454-c3f7-11e7-93c9-ecb9a1d52b9a.png)
