### PR TITLE
Add checklist for new repositories to configuration management plan

### DIFF
--- a/content/docs/ops/configuration-management.md
+++ b/content/docs/ops/configuration-management.md
@@ -48,12 +48,14 @@ is encouraged and qualifies as a review. Review should include assessment of arc
 
 ## Checklist for new repositories
 
-* Give it a name starting with `cg-` or `cf-`.
-* [Add `LICENSE`, `CONTRIBUTING`, and `README` files](https://github.com/18F/open-source-policy/blob/master/practice.md#how-to-license-18f-repos).
+Before we put a new repository into production:
+
+* Give it a name starting with `cg-` or `cf-` (to help us identify our work, unless we have a good reason to name it something else).
+* [Add `LICENSE`, `CONTRIBUTING`, and `README` files](https://github.com/18F/open-source-policy/blob/master/practice.md#how-to-license-18f-repos) (to support open source reuse of our work).
 * Set up [Code Climate](https://docs.codeclimate.com/docs/github#pull-requests) (SI-3).
 * Configure a [protected master branch](https://help.github.com/articles/about-protected-branches/) with required reviews (CM-9).
-* Configure permissions:
-  * If it's a platform configuration repo, restrict permissions to Cloud Ops (CM-3), as follows:
+* Configure permissions (CM-3):
+  * If it's a platform configuration repo, restrict permissions to Cloud Ops, as follows:
      * `Read` for [18F](https://github.com/orgs/18F/teams/18f/members).
      * `Read` for [cloud-gov](https://github.com/orgs/18F/teams/cloud-gov/members).
      * `Admin` for [cloud-gov-ops](https://github.com/orgs/18F/teams/cloud-gov-ops/members).
@@ -61,8 +63,8 @@ is encouraged and qualifies as a review. Review should include assessment of arc
      * `Read` for [18F](https://github.com/orgs/18F/teams/18f/members).
      * `Admin` for [cloud-gov](https://github.com/orgs/18F/teams/cloud-gov/members).
      * `Admin` for [cloud-gov-ops](https://github.com/orgs/18F/teams/cloud-gov-ops/members).
-* Set up CI/CD for changes.
-* Open a PR to add it to the [repos list]({{< relref "docs/ops/repos.md#repositories" >}}).
+* Set up CI/CD for changes (CM-3).
+* Open a PR to add it to the [repos list]({{< relref "docs/ops/repos.md#repositories" >}}) (to help us keep track of our repos and support open source reuse of our work).
 
 ## What if a configuration changed and it is not in Configuration Management?
 If possible, Configuration Management tools need to be set up to always roll back to a known state. Other than that, these tools need to be able to "recreate" all settings from the known configurations.

--- a/content/docs/ops/configuration-management.md
+++ b/content/docs/ops/configuration-management.md
@@ -46,9 +46,23 @@ is encouraged and qualifies as a review. Review should include assessment of arc
 
 1. The CI/CD tool uses GitHub repositories and S3-stored sensitive content as the canonical source of truth for what the platform should look like. If there are manual changes, it will reset the state of all systems to match.
 
-![Pipeline Example](/img/pipeline-example.png)
+## Checklist for new repositories
 
-A more detailed example of this process can be seen in [Updating Cloud Foundry]({{< relref "updating-cf.md" >}}).
+* Give it a name starting with `cg-` or `cf-`.
+* [Add `LICENSE`, `CONTRIBUTING`, and `README` files](https://github.com/18F/open-source-policy/blob/master/practice.md#how-to-license-18f-repos).
+* Set up [Code Climate](https://docs.codeclimate.com/docs/github#pull-requests) (SI-3).
+* Configure a [protected master branch](https://help.github.com/articles/about-protected-branches/) with required reviews (CM-9).
+* Configure permissions:
+  * If it's a platform configuration repo, restrict permissions to Cloud Ops (CM-3), as follows:
+     * `Read` for [18F](https://github.com/orgs/18F/teams/18f/members).
+     * `Read` for [cloud-gov](https://github.com/orgs/18F/teams/cloud-gov/members).
+     * `Admin` for [cloud-gov-ops](https://github.com/orgs/18F/teams/cloud-gov-ops/members).
+  * If it's not a platform configuration repo, configure as follows:
+     * `Read` for [18F](https://github.com/orgs/18F/teams/18f/members).
+     * `Admin` for [cloud-gov](https://github.com/orgs/18F/teams/cloud-gov/members).
+     * `Admin` for [cloud-gov-ops](https://github.com/orgs/18F/teams/cloud-gov-ops/members).
+* Set up CI/CD for changes.
+* Open a PR to add it to the [repos list]({{< relref "docs/ops/repos.md#repositories" >}}).
 
 ## What if a configuration changed and it is not in Configuration Management?
 If possible, Configuration Management tools need to be set up to always roll back to a known state. Other than that, these tools need to be able to "recreate" all settings from the known configurations.

--- a/content/docs/ops/configuration-management.md
+++ b/content/docs/ops/configuration-management.md
@@ -50,7 +50,7 @@ is encouraged and qualifies as a review. Review should include assessment of arc
 
 Before we put a new repository into production:
 
-* Give it a name starting with `cg-` or `cf-` (to help us identify our work, unless we have a good reason to name it something else).
+* Give it a name starting with `cg-` or `cf-` (to make clear that it's part of our work, unless we have a good reason to name it something else).
 * [Add `LICENSE`, `CONTRIBUTING`, and `README` files](https://github.com/18F/open-source-policy/blob/master/practice.md#how-to-license-18f-repos) (to support open source reuse of our work).
 * Set up [Code Climate](https://docs.codeclimate.com/docs/github#pull-requests) (SI-3).
 * Configure a [protected master branch](https://help.github.com/articles/about-protected-branches/) with required reviews (CM-9).


### PR DESCRIPTION
This follows up on the idea at https://github.com/18F/cg-site/issues/592 by adding a small, slightly aspirational checklist for new cloud.gov repositories. Needs review to make sure this says reasonable things, including the right set of repo permissions.

This change also removes the pipeline screenshot and the link to an example, since those parts seemed unnecessary.