### PR TITLE
Link to alerts READMEs in source control

### DIFF
--- a/content/docs/ops/maintenance-list.md
+++ b/content/docs/ops/maintenance-list.md
@@ -66,15 +66,15 @@ Verify the monitoring system is functioning correctly and confirm that alerts
 are reaching their expected destinations.
 
 ### Investigate open alerts
-- Use our [guide for reviewing cloud.gov alerts](https://docs.google.com/document/d/1Nk5Cv9FjnqBywK8LPyw_jtmP4WNJBnqdbC-7nIcjMVI/edit#) for alert descriptions, links to the relevant rules, and starting points for reviewing each type of alert.
-- Was the alert caused by known maintenance or testing in dev environments? Check with other members of the cloud.gov team if you can't determine the source. 
+- Use our guides for reviewing cloud.gov alerts ([prometheus](https://github.com/18F/cg-deploy-prometheus/tree/master/bosh/alerts), [elastalert](https://github.com/18F/cg-deploy-logsearch/tree/master/elastalert)) for alert descriptions, links to the relevant rules, and starting points for reviewing each type of alert.
+- Was the alert caused by known maintenance or testing in dev environments? Check with other members of the cloud.gov team if you can't determine the source.
 - Is this a recurring alert? Search alert history to determine how frequently it is occuring and what event may have started its firing.
 - Should the underlying condition have caused an alert? Alerts should only be raised when they're something we need to remediate.
 
 #### Is the alert a real issue?
-If the alert may indicate a security issue follow the 
+If the alert may indicate a security issue follow the
 [Security Incident Response Guide]({{< relref "docs/ops/security-ir.md" >}})
-, otherwise work to remediate its cause. 
+, otherwise work to remediate its cause.
 
 #### Is the alert a false-positive?
 If the alert can be tuned to reduce the number of false-positives with less than


### PR DESCRIPTION
Link to public alerts READMEs in our prometheus and elastalert repos

Depends on
- https://github.com/18F/cg-deploy-logsearch/pull/114
- https://github.com/18F/cg-deploy-prometheus/pull/43 