### PR TITLE
Add rationale and detail to sandbox announcement

### DIFF
--- a/content/updates/2017-12-08-starting-now-sandboxes-expire-after-90-days.md
+++ b/content/updates/2017-12-08-starting-now-sandboxes-expire-after-90-days.md
@@ -3,13 +3,15 @@ date = "2017-12-08"
 title = "Starting now, sandboxes expire after 90 days"
 +++
 
-In our [monthly update from November]({{< relref "updates/2017-11-20-release-notes-buildpacks-volume-services-other-new-features.md" >}}), we mentioned we would start expiring [sandbox spaces]({{< relref "overview/pricing/free-limited-sandbox.md" >}}) after 90 days. Today, we're starting that clock. Here's what to expect.
+Starting today, [sandbox spaces]({{< relref "overview/pricing/free-limited-sandbox.md" >}}) will expire automatically every 90 days, as planned in our [monthly update from November]({{< relref "updates/2017-11-20-release-notes-buildpacks-volume-services-other-new-features.md" >}}).
+
+Here's what to expect:
  
-* Any sandbox applications you have right now will be deleted 90 days from today, along with service instances, routes, etc., in the sandbox.
+* Any sandbox applications you have right now will be deleted 90 days from today, along with service instances (such as databases), routes, etc., in the sandbox.
 * You will not lose your cloud.gov account.
 * You can start a new 90-day evaluation period just by creating a new app or service.
 * Starting five days before we delete your sandbox, we'll send you an email reminder every day unless you delete your applications yourself.
 
-We hope you find the sandbox helpful.
+We're putting in place this clean-up process to ensure that any unmaintained test applications won't become increasingly vulnerable to new security exploits. This process also ensures that any forgotten test applications won't indefinitely consume resources.
 
-If you'd like to keep your sandbox applications online for longer than 90 days, you should consider purchasing a paid cloud.gov plan. [Any prototyping or production package]({{< relref "overview/pricing/rates.md" >}} will allow you to host apps for any amount of time. [Contact us to learn how to get started with a paid plan](mailto:cloud-gov-inquiries@gsa.gov).
+For long-term prototyping, consider purchasing a paid cloud.gov plan. [Any prototyping or production package]({{< relref "overview/pricing/rates.md" >}}) will allow you to host apps without time limitations. Contact us at [cloud-gov-inquiries@gsa.gov](mailto:cloud-gov-inquiries@gsa.gov) with any questions or to start purchasing a paid plan.


### PR DESCRIPTION
Followup on https://github.com/18F/cg-site/pull/1145 with input from @khandelwal! This has the following changes:

* Start with clear statement of what's happening, then followup with reference to previous post (gets to the point faster, and some readers may not have read or remember the past post).
* Add example of databases to make clear that data will be deleted.
* Remove "We hope you find the sandbox helpful." since it could be interpreted as cold.
* Explain why we're putting in place the clearing process.
* Clarify call to action.
* Fix link.