### PR TITLE
Eliminate redirects to landing.app.cloud.gov when there's no trailing slash

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,6 @@
 baseurl = "https://cloud.gov"
+canonifyurls = "true"
+relativeurls = "true"
 languageCode = "en-us"
 title = "cloud.gov"
 pluralizelisttitles = "false"

--- a/content/docs/services/redis.md
+++ b/content/docs/services/redis.md
@@ -5,7 +5,7 @@ menu:
 title: Redis
 description: "Redis: an in-memory data structure store"
 aliases:
-- docs/services/redis28/
+- docs/services/redis28
 ---
 
 cloud.gov offers [Redis](http://www.redis.io/) 2.8 and 3.2 as a service.

--- a/content/docs/services/redis.md
+++ b/content/docs/services/redis.md
@@ -5,7 +5,7 @@ menu:
 title: Redis
 description: "Redis: an in-memory data structure store"
 aliases:
-- docs/services/redis28
+- /docs/services/redis28
 ---
 
 cloud.gov offers [Redis](http://www.redis.io/) 2.8 and 3.2 as a service.


### PR DESCRIPTION
Trying to increase deployment independence and avoid landing on unexpected URLs depending on the presence of a trailing slash.

I _think_this means that URLs not reached through the baseurl will redirect to the baseurl, and any generated URLs will be relative. independence.
https://discourse.gohugo.io/t/canonifyurls-relativeurls-interaction/5448