### PR TITLE
Add a "not for human consumption" note to service account page

### DIFF
--- a/content/docs/services/cloud-gov-service-account.md
+++ b/content/docs/services/cloud-gov-service-account.md
@@ -64,6 +64,10 @@ To use this service, see [continuous deployment]({{< relref "docs/apps/continuou
 
 The service account service creates unique cloud.gov credentials for each service key. To rotate credentials associated with a service key, [delete](https://docs.cloudfoundry.org/devguide/services/service-keys.html#delete) and recreate the service key.
 
+### Not for human consumption
+
+Don't use service account credentials to manually log into cloud.gov as a human. cloud.gov has no technical mechanism to prevent you from doing this, because there's no way to distinguish a human from an automated script at login. Typically, your agency and system security compliance requirements require people to only log in using their own accounts (agency single sign-on accounts or cloud.gov accounts with multi-factor authentication).
+
 ### The broker in GitHub
 
 You can find the broker here: [https://github.com/cloudfoundry-community/uaa-credentials-broker](https://github.com/cloudfoundry-community/uaa-credentials-broker).


### PR DESCRIPTION
Just good for people to know this, to help them understand risks and how to mitigate them. This needs technical review to make sure I phrased it accurately.