### PR TITLE
Add login info to first deploy page

### DIFF
--- a/content/docs/getting-started/setup.md
+++ b/content/docs/getting-started/setup.md
@@ -18,8 +18,12 @@ The dashboard gives you web-based access to common tasks: [**https://dashboard.f
 cloud.gov is based on the Cloud Foundry open source project, so cloud.gov uses the Cloud Foundry command line interface (CLI) to give you full access.
 
 1. Install the Cloud Foundry CLI: [Windows](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#windows), [Mac OS X](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#mac), or [Linux](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#linux). If you can't use the installer, you can [download the CLI binary and install it manually](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#bin).
-1. Log in: **`cf login -a api.fr.cloud.gov --sso`**
-  - It'll say `One Time Code ( Get one at `[`https://login.fr.cloud.gov/passcode`](https://login.fr.cloud.gov/passcode)` )` -- visit that link in your browser to log in and get your 10-character code. Copy and paste the code into the command line (no typing indicators will show), and enter it.
+1. Log in:
+  1. Enter **`cf login -a api.fr.cloud.gov --sso`**
+  1. It'll say `One Time Code ( Get one at `[`https://login.fr.cloud.gov/passcode`](https://login.fr.cloud.gov/passcode)` )` -- visit this login link in your browser.
+  1. If you use a cloud.gov account, you may need to log in using your email address, password, and multi-factor authentication token. (EPA, FDIC, and GSA: use your agency SSO button.)
+  1. After you log in, the page will display your 10-character Temporary Authentication Code.
+  1. Copy and paste that 10-character code into the command line (no typing indicators will show), and enter it.
 
 <!--**Tip:** The `fr.` in this URL (and other cloud.gov URLs) is short for FedRAMP.-->
 

--- a/content/docs/getting-started/setup.md
+++ b/content/docs/getting-started/setup.md
@@ -21,7 +21,7 @@ cloud.gov is based on the Cloud Foundry open source project, so cloud.gov uses t
 1. Log in:
   1. Enter **`cf login -a api.fr.cloud.gov --sso`**
   1. It'll say `One Time Code ( Get one at `[`https://login.fr.cloud.gov/passcode`](https://login.fr.cloud.gov/passcode)` )` -- visit this login link in your browser.
-  1. If you use a cloud.gov account, you may need to log in using your email address, password, and multi-factor authentication token. (EPA, FDIC, and GSA: use your agency SSO button.)
+  1. If you use a cloud.gov account, you may need to log in using your email address, password, and multi-factor authentication token. (EPA, FDIC, and GSA: use your agency button.)
   1. After you log in, the page will display your 10-character Temporary Authentication Code.
   1. Copy and paste that 10-character code into the command line (no typing indicators will show), and enter it.
 

--- a/content/docs/getting-started/your-first-deploy.md
+++ b/content/docs/getting-started/your-first-deploy.md
@@ -16,7 +16,7 @@ Log in:
 
   1. Enter **`cf login -a api.fr.cloud.gov --sso`**
   1. It'll say `One Time Code ( Get one at `[`https://login.fr.cloud.gov/passcode`](https://login.fr.cloud.gov/passcode)` )` -- visit this login link in your browser.
-  1. If you use a cloud.gov account, you may need to log in using your email address, password, and multi-factor authentication token. (EPA, FDIC, and GSA: use your agency SSO button.)
+  1. If you use a cloud.gov account, you may need to log in using your email address, password, and multi-factor authentication token. (EPA, FDIC, and GSA: use your agency button.)
   1. After you log in, the page will display your 10-character Temporary Authentication Code.
   1. Copy and paste that 10-character code into the command line (no typing indicators will show), and enter it.
 

--- a/content/docs/getting-started/your-first-deploy.md
+++ b/content/docs/getting-started/your-first-deploy.md
@@ -14,10 +14,11 @@ First, [set up your command line interface (CLI)]({{< relref "setup.md" >}}) (if
 
 Log in:
 
-```
-cf login -a api.fr.cloud.gov --sso
-```
-  - It'll say `One Time Code ( Get one at `[`https://login.fr.cloud.gov/passcode`](https://login.fr.cloud.gov/passcode)` )` -- visit that link in your browser to log in and get your 10-character code. Copy and paste the code into the command line (no typing indicators will show), and enter it.
+  1. Enter **`cf login -a api.fr.cloud.gov --sso`**
+  1. It'll say `One Time Code ( Get one at `[`https://login.fr.cloud.gov/passcode`](https://login.fr.cloud.gov/passcode)` )` -- visit this login link in your browser.
+  1. If you use a cloud.gov account, you may need to log in using your email address, password, and multi-factor authentication token. (EPA, FDIC, and GSA: use your agency SSO button.)
+  1. After you log in, the page will display your 10-character Temporary Authentication Code.
+  1. Copy and paste that 10-character code into the command line (no typing indicators will show), and enter it.
 
 ## Target your "sandbox"
 

--- a/content/docs/getting-started/your-first-deploy.md
+++ b/content/docs/getting-started/your-first-deploy.md
@@ -12,18 +12,18 @@ Practice deploying a simple "hello world" application using the cloud.gov comman
 
 First, [set up your command line interface (CLI)]({{< relref "setup.md" >}}) (if you haven't already).
 
-## Target your "sandbox"
-
-If you have a federal email address, when you log in for the first time, cloud.gov will start automatically creating a [sandbox space]({{< relref "overview/pricing/free-limited-sandbox.md" >}}) for you. You might need to wait up to 5 minutes before it becomes available.
-
-Here's how to deploy a test app in your sandbox using the CLI.
-
 Log in:
 
 ```
 cf login -a api.fr.cloud.gov --sso
 ```
   - It'll say `One Time Code ( Get one at `[`https://login.fr.cloud.gov/passcode`](https://login.fr.cloud.gov/passcode)` )` -- visit that link in your browser to log in and get your 10-character code. Copy and paste the code into the command line (no typing indicators will show), and enter it.
+
+## Target your "sandbox"
+
+If you have a federal email address, when you log in for the first time, cloud.gov will start automatically creating a [sandbox space]({{< relref "overview/pricing/free-limited-sandbox.md" >}}) for you. You might need to wait up to 5 minutes before it becomes available.
+
+Here's how to deploy a test app in your sandbox using the CLI.
 
 Enter the following `cf target` command:
 

--- a/content/docs/getting-started/your-first-deploy.md
+++ b/content/docs/getting-started/your-first-deploy.md
@@ -18,7 +18,14 @@ If you have a federal email address, when you log in for the first time, cloud.g
 
 Here's how to deploy a test app in your sandbox using the CLI.
 
-Start with the following `cf target` command:
+Log in:
+
+```
+cf login -a api.fr.cloud.gov --sso
+```
+  - It'll say `One Time Code ( Get one at `[`https://login.fr.cloud.gov/passcode`](https://login.fr.cloud.gov/passcode)` )` -- visit that link in your browser to log in and get your 10-character code. Copy and paste the code into the command line (no typing indicators will show), and enter it.
+
+Enter the following `cf target` command:
 
 ```sh
 cf target -o <ORG> -s <SPACE>


### PR DESCRIPTION
This duplicates the info at https://cloud.gov/docs/getting-started/setup/ so that the first deploy page is more self-contained.