### PR TITLE
Enable correct redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ Hugo uses Markdown to build the pages. Add your page to the section you want ins
 1. Run `npm start` and browse to [http://localhost:1313](http://localhost:1313).
 
 
-### Running the site on cloud.gov
+### Testing the site on cloud.gov within a personal space
 
 1. Run: `npm install && npm run build && hugo`
-1. Login: `cf login --sso`
-1. Push: `cf push -n landing-unique`
+1. Push: `cf push -n landing-unique` (where 'unique' is your own unique name)
 1. Browse to your unique https://landing-unique.app.cloud.gov
 1. Make updates with `npm run build && hugo && cf push -n landing-unique`
+
+This test site will redirect 301s to cloud.gov unless you comment out `CG_REDIR_HOST` in `manifest.yml`, or run: `cf unset-env CG_REDIR_HOST; cf restage`
 
 ### Process tips for cloud.gov team members
 

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,4 @@
 baseurl = "https://cloud.gov"
-canonifyurls = "true"
-relativeurls = "true"
 languageCode = "en-us"
 title = "cloud.gov"
 pluralizelisttitles = "false"

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,12 @@
+# A custom start command needed until #103 is fixed in Staticfile buildpack
+# https://github.com/cloudfoundry/staticfile-buildpack/issues/103
 ---
 applications:
 - name: landing
   host: landing
   command: erb < $HOME/nginx/conf/includes/cg_redir.conf.erb > $HOME/nginx/conf/includes/cg_redir.conf && $HOME/boot.sh
+  env:
+    CG_REDIR_HOST: cloud.gov
 memory: 64M
 instances: 2
 buildpack: staticfile_buildpack

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,7 @@
 applications:
 - name: landing
   host: landing
+  command: erb < $HOME/nginx/conf/includes/cg_redir.conf.erb > $HOME/nginx/conf/includes/cg_redir.conf && $HOME/boot.sh
 memory: 64M
 instances: 2
 buildpack: staticfile_buildpack

--- a/nginx/conf/includes/cg_redir.conf.erb
+++ b/nginx/conf/includes/cg_redir.conf.erb
@@ -1,0 +1,8 @@
+
+<% if ENV["CG_REDIR_HOST"] -%>
+location / {
+	if (-d $request_filename) {
+			rewrite [^/]$ $scheme://<%= ENV["CG_REDIR_HOST"] %>$uri/ permanent;
+	}
+}
+<% end -%>

--- a/nginx/conf/includes/cg_redir.conf.erb
+++ b/nginx/conf/includes/cg_redir.conf.erb
@@ -1,8 +1,7 @@
-
-<% if ENV["CG_REDIR_HOST"] -%>
+<% if ENV["CG_REDIR_HOST"] %>
 location / {
 	if (-d $request_filename) {
 			rewrite [^/]$ $scheme://<%= ENV["CG_REDIR_HOST"] %>$uri/ permanent;
 	}
 }
-<% end -%>
+<% end %>

--- a/nginx/conf/includes/location.conf
+++ b/nginx/conf/includes/location.conf
@@ -5,4 +5,3 @@ add_header Cache-Control max-age=300;
 add_header X-Content-Type-Options nosniff;
 
 add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
-

--- a/nginx/conf/includes/location.conf
+++ b/nginx/conf/includes/location.conf
@@ -5,3 +5,9 @@ add_header Cache-Control max-age=300;
 add_header X-Content-Type-Options nosniff;
 
 add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
+
+location / {
+	if (-d $request_filename) {
+			rewrite [^/]$ $scheme://$http_host$uri/ permanent;
+	}
+}

--- a/nginx/conf/includes/location.conf
+++ b/nginx/conf/includes/location.conf
@@ -6,8 +6,3 @@ add_header X-Content-Type-Options nosniff;
 
 add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
 
-location / {
-	if (-d $request_filename) {
-			rewrite [^/]$ $scheme://$http_host$uri/ permanent;
-	}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -417,7 +417,7 @@
     },
     "base64-js": {
       "version": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha1-qRlH2h9KUW6jjltOwOw3c2deCIY="
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
     },
     "bcrypt-pbkdf": {
       "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -4710,7 +4710,7 @@
     },
     "readable-stream": {
       "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
         "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -5025,7 +5025,7 @@
     },
     "stream-http": {
       "version": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-      "integrity": "sha1-QKBQ7I3DtTsz2ZCUFcAsC/Gr+60=",
+      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "requires": {
         "builtin-status-codes": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",


### PR DESCRIPTION
Clients that request, say, `https://cloud.gov/quickstart` hit an AWS cloudfront endpoint that proxies the request to the origin, `https://landing.app.cloud.gov/quickstart`, and that request does not include an `X-Forwarded-Host` or other header to inform the application what the canonical hostname is for redirects (at least I've not been able to discern any from Googling or logs or the gorouter githup repo).

This PR sets a default env var to enable correct redirects. 

