### PR TITLE
Minor adjustments to compliance terms on homepage

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -42,9 +42,9 @@
       </p>
     </article>
     <article class="usa-width-one-third">
-      <h2>FISMA authorized</h2>
+      <h2>FedRAMP authorized</h2>
       <p>
-      cloud.gov is authorized by the FedRAMP Joint Authorization Board (JAB), which means it complies with federal security requirements. When you build a system on cloud.gov, you leverage this compliance and reduce the amount of work you need to do.
+      cloud.gov has a FedRAMP Joint Authorization Board (JAB) authorization, which means it complies with federal security requirements. When you build a system on cloud.gov, you leverage this compliance and reduce the amount of work you need to do.
       </p>
     </article>
     <article class="usa-width-one-third">
@@ -136,9 +136,9 @@
       </article>
 
       <article class="usa-width-one-third">
-        <h2 class="bar-top">FISMA packages</h2>
+        <h2 class="bar-top">Production packages</h2>
         <p>
-          FISMA production packages range from $20k to up to $90k per year for FISMA-moderate applications.
+          Production packages range from $20k per year for a FISMA Low system to $90k per year for a FISMA Moderate system.
         </p>
         <p>
           <a href="https://cloud.gov/overview/pricing/start-using-cloudgov/" class="button-link">Learn about purchasing</a>


### PR DESCRIPTION
Changes to reflect the phrasing that we typically use for compliance topics when talking to customers:

* FISMA authorized -> FedRAMP authorized, because FISMA is the law itself and FedRAMP gives the authorizations.
* FISMA packages -> Production packages, because we're always working within the context of FISMA, but the impact level (and associated pricing) is relevant for production systems that need ATOs.
* Specify 20k for Low because people are interested in that.
* applications -> systems, because a customer system may have several "applications" that work together to make up the system