### PR TITLE
Update custom buildpack links

### DIFF
--- a/content/docs/apps/experimental/custom-buildpacks.md
+++ b/content/docs/apps/experimental/custom-buildpacks.md
@@ -16,9 +16,9 @@ Cloud Foundry (the underlying open source project behind cloud.gov) uses [buildp
 
 cloud.gov [officially supports]({{< relref "overview/pricing/rates.md">}}#what-s-included) a set of buildpacks, and it also allows you to provide your own.
 
-For example, if you want to use the ["R" buildpack](https://github.com/alexkago/cf-buildpack-r), you can push your code by typing:
+For example, if you want to use [this "R" buildpack](https://github.com/virtualstaticvoid/heroku-buildpack-r/tree/heroku-16), you can push your code by typing:
 
-`cf push myapp -b https://github.com/alexkago/cf-buildpack-r`
+`cf push myapp -b http://github.com/virtualstaticvoid/heroku-buildpack-r.git#heroku-16`
 
 Once you push your code using a custom buildpack, cloud.gov cannot update it for you. You are responsible for keeping it up to date. Please see [this description of responsibilities]({{< relref "overview/technology/responsibilities.md">}}).
 
@@ -26,6 +26,4 @@ Once you push your code using a custom buildpack, cloud.gov cannot update it for
 
 ### apt-buildpack
 
-cloud.gov does not allow the use of `sudo` inside of buildpacks. If your app depends on a library that is `apt-get` installable, you can use the CF flavor of [`apt-buildpack`](https://github.com/pivotal-cf-experimental/apt-buildpack), which is a custom buildpack.
-
-You can see this in the wild in 18F's [`iaa-pdf-api`](https://github.com/18f/iaa-pdf-api) repo, which depends on the [`pdftk`](https://www.pdflabs.com/tools/pdftk-server/) library.
+cloud.gov does not allow the use of `sudo` inside of buildpacks. If your app depends on a library that is `apt-get` installable, you can use the CF flavor of [`apt-buildpack`](https://github.com/cloudfoundry/apt-buildpack), which is a custom buildpack.


### PR DESCRIPTION
Changes:

* Update the apt buildpack link ([see this support thread](https://cloud-gov.zendesk.com/agent/tickets/854)).
* Link to a maintained R buildpack ([see this other recent support thread](https://cloud-gov.zendesk.com/agent/tickets/848)).
* Remove the outdated `iaa-pdf-api` example.

We should also update the multi-buildpack info, probably both here and at https://cloud.gov/docs/getting-started/concepts/#buildpacks, but I'm not sure whether to link to https://docs.cloudfoundry.org/buildpacks/use-multiple-buildpacks.html or https://github.com/cloudfoundry/multi-buildpack for instructions (feel free to add a commit or comment).