### PR TITLE
fixed tab container width

### DIFF
--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -92,6 +92,7 @@ blockquote::before {
 .tabs {
   margin-top: 20px;
   padding-top: 15px;
+  max-width: 36em;
 }
 .tabs.ui-tabs {
   border: 1px solid #ccc;


### PR DESCRIPTION
Currently, the tab header background doesn't span the entire width of the container (see https://cloud.gov/docs/apps/managing-teammates/#give-roles-to-a-teammate). This fixes the tab containers so the tab header section is the same width as the container.  

(additional context: https://gsa-tts.slack.com/archives/C4XLJ1JBV/p1518731883000554?thread_ts=1518722399.000321&cid=C4XLJ1JBV)

![tab-fix](https://user-images.githubusercontent.com/471514/36317225-8af94890-130a-11e8-9eaf-52607fcc3d9d.gif)




