### PR TITLE
Note about disabling SSH for production

### DIFF
--- a/content/docs/apps/production-ready.md
+++ b/content/docs/apps/production-ready.md
@@ -49,7 +49,7 @@ When running an application for development or testing, it is best to have a sep
 Production spaces and apps should be considered "hands-off" for both security and compliance, and all changes made in to running applications should happen in an auditable way. Only allow manual access to the interior of a running application in the event of serious problems. Disabling access to production applications will help you meet your customer responsibilities for control AC-17 of NIST 800-53 requirements in order to receive an Authority to Operate (ATO) from your agency's Authorizing Official (AO).
 
 #### How
-* Use `cf disallow-space-ssh PRODUCTION-SPACE-NAME` for your production space or `cf disable-ssh PRODUCTION-APP-NAME` to [disable SSH access]({{< relref "/docs/apps/using-ssh.md" >}}) for individual running application instances. Then use [event auditing]({{< relref "/docs/compliance/auditing-activity.md" >}}) to audit deployments and further access.
+* Use `cf disallow-space-ssh PRODUCTION-SPACE-NAME` for your production space or `cf disable-ssh PRODUCTION-APP-NAME` to [disable SSH access]({{< relref "docs/apps/using-ssh.md" >}}) for individual running application instances. Then use [event auditing]({{< relref "docs/compliance/auditing-activity.md" >}}) to audit deployments and further access.
 
 ### Health monitoring
 You want to receive alerts about application errors, downtime, and throughput issues.

--- a/content/docs/apps/production-ready.md
+++ b/content/docs/apps/production-ready.md
@@ -46,10 +46,10 @@ When running an application for development or testing, it is best to have a sep
 * As an Org Manager for your organization, use the `cf create-space` command to create new spaces for each environment.
 
 ### Prevent manual alteration of production apps
-Production spaces and apps should be considered "hands-off" for both security and compliance, and all changes made in to running applications should happen in an auditable way. Only allow manual access to the interior of a running application in the event of serious problems.
+Production spaces and apps should be considered "hands-off" for both security and compliance, and all changes made in to running applications should happen in an auditable way. Only allow manual access to the interior of a running application in the event of serious problems. Disabling access to production applications will help you meet your customer responsibilities for control AC-17 of NIST 800-53 requirements in order to receive an Authority to Operate (ATO) from your agency's Authorizing Official (AO).
 
 #### How
-* Use `cf disallow-space-ssh PRODUCTION-SPACE-NAME` or `cf disable-ssh PRODUCTION-APP-NAME` to [disable SSH access]({{< relref "/docs/apps/using-ssh.md" >}}) for your running application instances. Then use [event auditing]({{< relref "/docs/compliance/auditing-activity.md" >}}) to audit deployments and further access.
+* Use `cf disallow-space-ssh PRODUCTION-SPACE-NAME` for your production space or `cf disable-ssh PRODUCTION-APP-NAME` to [disable SSH access]({{< relref "/docs/apps/using-ssh.md" >}}) for individual running application instances. Then use [event auditing]({{< relref "/docs/compliance/auditing-activity.md" >}}) to audit deployments and further access.
 
 ### Health monitoring
 You want to receive alerts about application errors, downtime, and throughput issues.

--- a/content/docs/apps/production-ready.md
+++ b/content/docs/apps/production-ready.md
@@ -45,11 +45,14 @@ When running an application for development or testing, it is best to have a sep
 #### How
 * As an Org Manager for your organization, use the `cf create-space` command to create new spaces for each environment.
 
-### Prevent manual alteration of production apps
-Production spaces and apps should be considered "hands-off" for both security and compliance, and all changes made in to running applications should happen in an auditable way. Only allow manual access to the interior of a running application in the event of serious problems. Disabling access to production applications will help you meet your customer responsibilities for control AC-17 of NIST 800-53 requirements in order to receive an Authority to Operate (ATO) from your agency's Authorizing Official (AO).
+### Prevent non-auditable changes to production apps
+
+All changes made to running production applications should be logged for auditing, which means that those changes should be made using commands in the cloud.gov dashboard, command line interface, or CF API (or automated commands in deployment scripts). By default, cloud.gov also allows [SSH access]({{< relref "docs/apps/using-ssh.md" >}}), which allows making changes that are harder to audit. This means you should disable SSH access to production applications.
+
+You may need to document your restrictions for remote access to your applications for control AC-17 in your System Security Plan, and this is a restriction that you can document.
 
 #### How
-* Use `cf disallow-space-ssh PRODUCTION-SPACE-NAME` for your production space or `cf disable-ssh PRODUCTION-APP-NAME` to [disable SSH access]({{< relref "docs/apps/using-ssh.md" >}}) for individual running application instances. Then use [event auditing]({{< relref "docs/compliance/auditing-activity.md" >}}) to audit deployments and further access.
+* Use `cf disallow-space-ssh PRODUCTION-SPACE-NAME` for your production space or `cf disable-ssh PRODUCTION-APP-NAME` to [disable SSH access]({{< relref "docs/apps/using-ssh.md" >}}) for individual running application instances. Use [event auditing]({{< relref "docs/compliance/auditing-activity.md" >}}) to audit deployments and further access.
 
 ### Health monitoring
 You want to receive alerts about application errors, downtime, and throughput issues.

--- a/content/docs/apps/production-ready.md
+++ b/content/docs/apps/production-ready.md
@@ -45,6 +45,12 @@ When running an application for development or testing, it is best to have a sep
 #### How
 * As an Org Manager for your organization, use the `cf create-space` command to create new spaces for each environment.
 
+### Prevent manual alteration of production apps
+Production spaces and apps should be considered "hands-off" for both security and compliance, and all changes made in to running applications should happen in an auditable way. Only allow manual access to the interior of a running application in the event of serious problems.
+
+#### How
+* Use `cf disallow-space-ssh PRODUCTION-SPACE-NAME` or `cf disable-ssh PRODUCTION-APP-NAME` to [disable SSH access]({{< relref "/docs/apps/using-ssh.md" >}}) for your running application instances. Then use [event auditing]({{< relref "/docs/compliance/auditing-activity.md" >}}) to audit deployments and further access.
+
 ### Health monitoring
 You want to receive alerts about application errors, downtime, and throughput issues.
 

--- a/content/docs/apps/using-ssh.md
+++ b/content/docs/apps/using-ssh.md
@@ -32,7 +32,7 @@ for f in /home/vcap/profile.d/*.sh; do source "$f"; done
 
 ## How to disable SSH access
 
-SSH access is enabled by default. Space Developers can disable SSH access to individual applications, and Space Managers can disable SSH access to all apps running within a space. See [Enabling and Disabling SSH Access](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#enable-disable-ssh) for the commands. Disabling SSH for production spaces will probably be necessary for you to meet your customer responsibilities for AC-17 under NIST 800-53 requirements.
+SSH access is enabled by default. Space Developers can disable SSH access to individual applications, and Space Managers can disable SSH access to all apps running within a space. See [Enabling and Disabling SSH Access](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#enable-disable-ssh) for the commands.
 
 ## SSH version information 
 

--- a/content/docs/apps/using-ssh.md
+++ b/content/docs/apps/using-ssh.md
@@ -32,7 +32,7 @@ for f in /home/vcap/profile.d/*.sh; do source "$f"; done
 
 ## How to disable SSH access
 
-SSH access is enabled by default. Space Developers can disable SSH access to individual applications, and Space Managers can disable SSH access to all apps running within a space. See [Enabling and Disabling SSH Access](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#enable-disable-ssh) for the commands.
+SSH access is enabled by default. Space Developers can disable SSH access to individual applications, and Space Managers can disable SSH access to all apps running within a space. See [Enabling and Disabling SSH Access](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#enable-disable-ssh) for the commands. Disabling SSH for production spaces will probably be necessary for you to meet your customer responsibilities for AC-17 under NIST 800-53 requirements.
 
 ## SSH version information 
 

--- a/content/docs/apps/using-ssh.md
+++ b/content/docs/apps/using-ssh.md
@@ -34,6 +34,8 @@ for f in /home/vcap/profile.d/*.sh; do source "$f"; done
 
 SSH access is enabled by default. Space Developers can disable SSH access to individual applications, and Space Managers can disable SSH access to all apps running within a space. See [Enabling and Disabling SSH Access](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#enable-disable-ssh) for the commands.
 
+You should [disable SSH access for production applications](/docs/apps/production-ready/#prevent-non-auditable-changes-to-production apps) to ensure you can audit changes to those applications.
+
 ## SSH version information 
 
 Application containers use the SSH-2.0 protocol. The SSH service uses the [Cloud Foundry SSH implementation](https://github.com/cloudfoundry/diego-ssh). For more on how Cloud Foundry implements SSH, refer to Cloud Foundry's documentation on [Understanding Application SSH](https://docs.cloudfoundry.org/concepts/diego/ssh-conceptual.html).

--- a/content/docs/compliance/for-assessors.md
+++ b/content/docs/compliance/for-assessors.md
@@ -64,4 +64,4 @@ For details, see SC-28 in the cloud.gov SSP in our [P-ATO documentation package]
 
 Through multi-factor authentication and other means, the cloud.gov team verifies that people logging into cloud.gov legitimately own their accounts. But users don't log in to orgs and spaces, they log into cloud.gov itself. Accordingly, customers don't have direct access to logs of login attempts, but you can ask us to perform specific log searches on your behalf. 
 
-You can use [event auditing]({{< relref "/docs/compliance/auditing-activity.md" >}}) to audit access control changes on orgs and spaces, as well as many other events of interest.
+You can use [event auditing]({{< relref "docs/compliance/auditing-activity.md" >}}) to audit access control changes on orgs and spaces, as well as many other events of interest.

--- a/content/docs/compliance/for-assessors.md
+++ b/content/docs/compliance/for-assessors.md
@@ -62,4 +62,6 @@ For details, see SC-28 in the cloud.gov SSP in our [P-ATO documentation package]
 
 ### Auditing login attempts
 
-Through multi-factor authentication and other means, the cloud.gov team verifies that people logging into cloud.gov legitimately own their accounts. But users don't log in to orgs and spaces, they log into cloud.gov itself. Accordingly, customers don't have direct access to logs of login attempts, but you can ask us to perform specific log searches on your behalf.
+Through multi-factor authentication and other means, the cloud.gov team verifies that people logging into cloud.gov legitimately own their accounts. But users don't log in to orgs and spaces, they log into cloud.gov itself. Accordingly, customers don't have direct access to logs of login attempts, but you can ask us to perform specific log searches on your behalf. 
+
+You can use [event auditing]({{< relref "/docs/compliance/auditing-activity.md" >}}) to audit access control changes on orgs and spaces, as well as many other events of interest.


### PR DESCRIPTION
First commit to help clarify that SSH should be disabled for production spaces/applications.