### PR TITLE
change homepage Pricing link 

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -20,7 +20,7 @@
         <a href="/overview/overview/what-is-cloudgov/">Platform overview</a>
       </li>
       <li>
-        <a href="/pricing/">Pricing</a>
+        <a href="/pricing/">Packages and pricing</a>
       </li>
       <li>
         <a href="/overview/technology/responsibilities/">Security and compliance</a>


### PR DESCRIPTION
really tiny language tweak changing `Pricing` on the home page to `Packages and pricing` to make it clearer what to expect to  see on the page and also to help differentiate between the two links for the purpose of analyzing our analytics data.