### PR TITLE
Organize language support info together

### DIFF
--- a/content/docs/apps/frameworks.md
+++ b/content/docs/apps/frameworks.md
@@ -16,7 +16,17 @@ cloud.gov uses [buildpacks]({{< relref "docs/getting-started/concepts.md#buildpa
 
 ## Supported languages and frameworks
 
+### Fully maintained language support
+
 cloud.gov supports applications written in Go, Java, Node.js, .NET Core, PHP, Python, and Ruby. cloud.gov also supports applications that rely on a static binary that uses the 64-bit Linux kernel ABI, or that consist of static HTML, CSS, and Javascript assets. See the [Cloud Foundry system (supported) buildpacks list](http://docs.cloudfoundry.org/buildpacks/#system-buildpacks) for details.
+
+### Other languages
+
+You can use a custom buildpack to use other languages. See [custom buildpacks]({{< relref "docs/apps/custom-buildpacks.md" >}}) for more information about this feature. Cloud Foundry has a list of [community buildpacks](http://docs.cloudfoundry.org/buildpacks/#community-buildpacks) that you can use as custom buildpacks, along with [documentation for building your own custom buildpacks](http://docs.cloudfoundry.org/buildpacks/developing-buildpacks.html).
+
+### Not supported
+
+cloud.gov cannot run applications that use .NET Framework, or application binaries that require access to Microsoft Windows kernel or system APIs.
 
 ## Sample applications to deploy
 
@@ -36,13 +46,3 @@ Several cloud.gov customers have their code available as open source for review 
 * [Federalist](https://github.com/18F/federalist): NodeJS and Docker workers in cloud.gov with S3 and RDS backends.
 * [NSF Beta Drupal](https://github.com/18F/nsf): Drupal 8 with setup for Docker local development, and cloud.gov staging/live environments.
 * [Forest Service e-Permitting](https://github.com/18F/fs-permit-platform): Permitting service in NodeJS with PostgreSQL.
-
-## Other languages
-
-You can use a custom buildpack to support other languages. See [custom buildpacks]({{< relref "docs/apps/custom-buildpacks.md" >}}) for more information about this feature.
-
-Cloud Foundry has a list of [community buildpacks](http://docs.cloudfoundry.org/buildpacks/#community-buildpacks) that you can use as custom buildpacks, along with [documentation for building your own custom buildpacks](http://docs.cloudfoundry.org/buildpacks/developing-buildpacks.html).
-
-## Cannot run
-
-cloud.gov cannot run applications that use .NET Framework, or application binaries that require access to Microsoft Windows kernel or system APIs.


### PR DESCRIPTION
Consolidating together the list of supported languages, so that people can compare that info all together before they get to the sample apps.