### PR TITLE
Removing Mongo 3.2 from experimental Mongo page

### DIFF
--- a/content/docs/apps/experimental/mongodb.md
+++ b/content/docs/apps/experimental/mongodb.md
@@ -15,7 +15,6 @@ aliases:
 
 Service Name | Plan Name | Description | Price
 ------------ | --------- | ----------- | -----
-`mongodb32` | `standard` | MongoDB instance with 10 GB storage | Free in Alpha
 `mongodb36` | `standard` | MongoDB instance with 10 GB storage | Free in Alpha
 
 Note: MongoDB plans run a single instance and will be briefly unavailable during platform maintenance; this service should not be used for production applications.


### PR DESCRIPTION
We're just going to offer the latest version (3.6).