### PR TITLE
Move volume services page into services list

### DIFF
--- a/content/docs/ops/volume-service-requests.md
+++ b/content/docs/ops/volume-service-requests.md
@@ -8,12 +8,11 @@ title: Handling volume service requests
 
 Customers occasionally request that a volume of a certain size be created for use via volume services in their space. Here's how to handle those requests.
 
-1. Create a volume with the requested size and a hard-to-guess (ie random long) string for the name
-  1. (procedure here)
-2. Enable the nfs volume service broker in the requested organization 
-  1. (procedure here)
-3. [Enable the `volume-service-testing` isolation segment for their requested organization](https://docs.cloudfoundry.org/adminguide/isolation-segments.html#relationships)
-  1. `cf enable-org-isolation ORG-NAME volume-service-testing`
-4. [Set the isolation segment to `volume-service-testing` for their requested space](https://docs.cloudfoundry.org/adminguide/isolation-segments.html#relationships)
-  1. `cf set-space-isolation-segment ORG-NAME volume-service-testing`
-5. Reply to the support request with the volume name and refer them back to [the instructions]({{< relref "docs/services/volume-services.md" >}}) for next steps.
+1. Create a volume with the requested size and a hard-to-guess (i.e. random long) string for the name
+  1. Generate volume name with `uuidgen` or similar
+  1. Add volume to `nfstestserver.export_volumes` array in nfs server BOSH deployment
+1. Enable the nfs volume service broker in the requested organization
+  1. Add organization to `service-organizations-production` in volume services Concourse pipeline
+1. [Expose the `volume` isolation segment for their requested organization](https://docs.cloudfoundry.org/adminguide/isolation-segments.html#relationships)
+  1. Add organization and space to `volume-targets-production` in Cloud Foundry Concourse pipeline
+1. Reply to the support request with the volume name and refer them back to [the instructions]({{< relref "docs/services/volume-services.md" >}}) for next steps.

--- a/content/docs/ops/volume-service-requests.md
+++ b/content/docs/ops/volume-service-requests.md
@@ -16,4 +16,4 @@ Customers occasionally request that a volume of a certain size be created for us
   1. `cf enable-org-isolation ORG-NAME volume-service-testing`
 4. [Set the isolation segment to `volume-service-testing` for their requested space](https://docs.cloudfoundry.org/adminguide/isolation-segments.html#relationships)
   1. `cf set-space-isolation-segment ORG-NAME volume-service-testing`
-5. Reply to the support request with the volume name and refer them back to [the instructions]({{< relref "docs/apps/experimental/volume-services.md" >}}) for next steps.
+5. Reply to the support request with the volume name and refer them back to [the instructions]({{< relref "docs/services/volume-services.md" >}}) for next steps.

--- a/content/docs/services/volume-services.md
+++ b/content/docs/services/volume-services.md
@@ -3,8 +3,7 @@ menu:
   docs:
     parent: services
 title: Volume services
-name: "volume-services"
-description: "Provision persistent filesystem volumes"
+description: "Existing NFSv3 volumes (see: https://code.cloudfoundry.org/nfs-volume-release/)"
 status: "Experimental"
 aliases: 
     - /docs/apps/experimental/volume-services/

--- a/content/docs/services/volume-services.md
+++ b/content/docs/services/volume-services.md
@@ -1,9 +1,13 @@
 ---
 menu:
   docs:
-    parent: experimental
-
+    parent: services
 title: Volume services
+name: "volume-services"
+description: "Provision persistent filesystem volumes"
+status: "Experimental"
+aliases: 
+    - /docs/apps/experimental/volume-services/
 ---
 
 [**This is an experimental feature.**]({{< relref "docs/apps/experimental/experimental.md" >}}) cloud.gov has enabled experimental support for provisioning persistent filesystem volumes for use by customer applications. This experimental service is provided to help test whether cloud.gov is suitable for hosting applications that depend on a durable filesystem to store their state. See below for caveats and notes about production use.

--- a/content/overview/overview/who-can-use-cloudgov.md
+++ b/content/overview/overview/who-can-use-cloudgov.md
@@ -33,7 +33,7 @@ cloud.gov is suitable for a wide range of applications, including websites and n
 
 - Your organization can integrate your identity system with cloud.gov over SAML.
 - Your application doesn't rely on the filesystem for storing its state.
-    - An [experimental service]({{< relref "docs/apps/experimental/volume-services.md" >}}) supports filesystem-dependent applications.
+    - An [experimental service]({{< relref "docs/services/volume-services.md" >}}) supports filesystem-dependent applications.
 - Your application can follow the [12-Factor App guidelines](https://12factor.net/).
 
 ## Not a good fit

--- a/content/updates/2017-11-20-release-notes-buildpacks-volume-services-other-new-features.md
+++ b/content/updates/2017-11-20-release-notes-buildpacks-volume-services-other-new-features.md
@@ -7,7 +7,7 @@ We’ve been hard at work shipping out new features to help you make your apps b
 ### Added
 
 * Part of keeping your app on cloud.gov secure is [using the latest version of your app’s buildpack]({{< relref "docs/apps/app-maintenance.md" >}}). In addition to keeping you updated in these release notes, we’ll now send you an email notification when a new version of your buildpack is available.
-* We have experimental support for [volume services]({{< relref "docs/apps/experimental/volume-services.md" >}}). Since a cloud.gov app normally has a short-lived file system, this enables you to build an app that requires persistent file storage. [Contact us if you’d like to try this]({{< relref "docs/apps/experimental/volume-services.md#how-to-use-this-service" >}}).
+* We have experimental support for [volume services]({{< relref "docs/services/volume-services.md" >}}). Since a cloud.gov app normally has a short-lived file system, this enables you to build an app that requires persistent file storage. [Contact us if you’d like to try this]({{< relref "docs/apps/experimental/volume-services.md#how-to-use-this-service" >}}).
 * One of our engineers gave us the ability to make [Mermaid diagrams](https://mermaidjs.github.io/) on the cloud.gov website, and we almost got carried away creating visualizations of different parts of the platform. Here are a couple we think will help you out:
   * [A comparison of how apps with custom domains and those with the default \*.app.cloud.gov domain are served to users]({{< relref "docs/apps/custom-domains.md#comparison-of-default-domains-and-custom-domains" >}}).
   * [How to incorporate a CI/CD workflow into your app]({{< relref "docs/apps/continuous-deployment.md#configure-your-service" >}}).

--- a/content/updates/2017-11-20-release-notes-buildpacks-volume-services-other-new-features.md
+++ b/content/updates/2017-11-20-release-notes-buildpacks-volume-services-other-new-features.md
@@ -7,7 +7,7 @@ We’ve been hard at work shipping out new features to help you make your apps b
 ### Added
 
 * Part of keeping your app on cloud.gov secure is [using the latest version of your app’s buildpack]({{< relref "docs/apps/app-maintenance.md" >}}). In addition to keeping you updated in these release notes, we’ll now send you an email notification when a new version of your buildpack is available.
-* We have experimental support for [volume services]({{< relref "docs/services/volume-services.md" >}}). Since a cloud.gov app normally has a short-lived file system, this enables you to build an app that requires persistent file storage. [Contact us if you’d like to try this]({{< relref "docs/apps/experimental/volume-services.md#how-to-use-this-service" >}}).
+* We have experimental support for [volume services]({{< relref "docs/services/volume-services.md" >}}). Since a cloud.gov app normally has a short-lived file system, this enables you to build an app that requires persistent file storage. [Contact us if you’d like to try this]({{< relref "docs/services/volume-services.md#how-to-use-this-service" >}}).
 * One of our engineers gave us the ability to make [Mermaid diagrams](https://mermaidjs.github.io/) on the cloud.gov website, and we almost got carried away creating visualizations of different parts of the platform. Here are a couple we think will help you out:
   * [A comparison of how apps with custom domains and those with the default \*.app.cloud.gov domain are served to users]({{< relref "docs/apps/custom-domains.md#comparison-of-default-domains-and-custom-domains" >}}).
   * [How to incorporate a CI/CD workflow into your app]({{< relref "docs/apps/continuous-deployment.md#configure-your-service" >}}).

--- a/data/services/volume-services.toml
+++ b/data/services/volume-services.toml
@@ -1,0 +1,5 @@
+# Service metadata lives
+# ?
+name = "volume-services"
+description = "Provision persistent filesystem volumes"
+status = "Experimental"

--- a/data/services/volume-services.toml
+++ b/data/services/volume-services.toml
@@ -1,5 +1,6 @@
 # Service metadata lives
-# ?
+# https://github.com/cloudfoundry/nfsbroker/blob/master/nfsbroker/nfsbroker.go#L91-L125 (We only expose the first service and plan.)
+# https://github.com/18F/cg-deploy-volume-services/blob/master/ci/manifest.yml#L6 (name)
 name = "volume-services"
-description = "Provision persistent filesystem volumes"
+description = "Existing NFSv3 volumes (see: https://code.cloudfoundry.org/nfs-volume-release/)"
 status = "Experimental"


### PR DESCRIPTION
The volume services service is available for people to use for prototyping/sandbox apps if they request it, so I suggest we make the documentation more visible, to encourage people to try it out if it may be helpful to them. (All the other features in the "experimental" section aren't available yet to use.)

Needs review: I don't know where to find the actual metadata that the service provides for itself in the CF CLI marketplace, so the details here should be checked against that info. (And we should include a link to that info in the `volume-services.toml` file.)