### PR TITLE
Ask people interested in Windows to email us

### DIFF
--- a/content/docs/apps/frameworks.md
+++ b/content/docs/apps/frameworks.md
@@ -28,6 +28,8 @@ You can use a custom buildpack to use other languages. See [custom buildpacks]({
 
 cloud.gov cannot run applications that use .NET Framework, or application binaries that require access to Microsoft Windows kernel or system APIs.
 
+If you're interested in running applications that require .NET Framework or Windows, email [cloud-gov-inquiries@gsa.gov](mailto:cloud-gov-inquiries@gsa.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20project%20or%20your%20questions%20about%20cloud.gov%3A%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A%0AHow%20did%20you%20first%20hear%20about%20cloud.gov%3F), so that our team can learn about your needs and update you when this is available.
+
 ## Sample applications to deploy
 
 You can deploy example applications in many languages and frameworks:


### PR DESCRIPTION
On the page where we explain that we don't support Windows, encourage readers to email us if they're interested in Windows. This may help us gauge interest.