### PR TITLE
Add custom domain service in DNSSEC explanation

### DIFF
--- a/content/docs/compliance/domain-standards.md
+++ b/content/docs/compliance/domain-standards.md
@@ -29,6 +29,6 @@ cloud.gov does not currently support DNSSEC on `cloud.gov` domains. For example,
 
 If you need DNSSEC for your custom domain, you are responsible for configuring DNSSEC in your DNS system. cloud.gov can't configure DNSSEC for you because cloud.gov does not have access to your DNS system. 
 
-cloud.gov supports mapping your DNSSEC-enabled custom domain to your applications hosted on cloud.gov -- see [DNSSEC support]({{< relref "docs/services/cdn-route.md#dnssec-support" >}}).
+cloud.gov supports mapping your DNSSEC-enabled custom domain to your applications hosted on cloud.gov -- see [DNSSEC support for the CDN service]({{< relref "docs/services/cdn-route.md#dnssec-support" >}}) and [DNSSEC support for the custom domain service]({{< relref "docs/services/custom-domains.md#dnssec-support" >}}).
 
 *Additional details are available the cloud.gov System Security Plan, including controls SC-20, SC-21, SC-22, and SC-23.*


### PR DESCRIPTION
Found a place in the docs where we forgot to add the second type of custom domain service.