### PR TITLE
Update custom domain diagram for custom domain service

### DIFF
--- a/content/docs/apps/custom-domains.md
+++ b/content/docs/apps/custom-domains.md
@@ -36,7 +36,7 @@ end
 
 Public((Public user)) -->|HTTPS| A-DNS(Agency DNS: appB.agency.gov)
 Public((Public user)) -->|HTTPS| CG-DNS(cloud.gov DNS: appA_agency.app.cloud.gov)
-A-DNS -->|HTTPS| CDN(CDN)
+A-DNS -->|HTTPS| CDN("Custom domain service")
 CG-DNS -->Router
 CDN -->Router
 Router -->AppA


### PR DESCRIPTION
Replacing the box that says "CDN" with "Custom domain service". There's not enough horizontal room to put in the ideal description of "CDN service or custom domain service" (and putting in `<br>` doesn't work). "Custom domain service" at least makes more sense than "CDN", because (1) it explains that a service is doing the job of this box, and (2) we document the "CDN service" as being just like the custom domain service plus CDN.