### PR TITLE
Remove severable/non-severable language

### DIFF
--- a/content/overview/pricing/pricing-terminology.md
+++ b/content/overview/pricing/pricing-terminology.md
@@ -33,13 +33,9 @@ A system maps to an [“org” in cloud.gov and Cloud Foundry](http://docs.cloud
 
 The “access package” component covers access to the cloud.gov Platform as a Service (PaaS) and [support]({{< relref "#support" >}}) for it to stay up and available in its current form, as well as expanded over time. The access package component is invoiced monthly, and scales along with the number of systems being hosted and the impact level of the systems being launched on the platform, as defined by [Federal Information Processing Standard (FIPS) 199](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.199.pdf).
 
-The access package component is “non-severable” and therefore non-refundable. As a result, a payment in one fiscal year does not expire regardless of the status of the underlying appropriation.
-
 ### Resource usage quota
 
 To support tenant applications and managed service instances, cloud.gov allocates resources (like compute nodes and memory) from an underlying Infrastructure as a Service provider. What we charge for this component covers the costs for the resources that cloud.gov allocates to hosted systems and teams. It also includes a small margin that covers our labor in managing those resources.
-
-Resource usage fees on-demand are understood to be “severable” as they can be controlled in a self-service manner by provisioning more or fewer apps, and therefore must be treated accordingly.
 
 Agencies can purchase reserved capacity via 18F as well, which is understood to be “non-severable”.
 


### PR DESCRIPTION
This is over-precise and not entirely accurate, so let's just remove it as not necessary.