### PR TITLE
Fix old links to /docs/services/ w alias

### DIFF
--- a/content/docs/services/intro.md
+++ b/content/docs/services/intro.md
@@ -2,6 +2,8 @@
 menu:
   docs:
     parent: services
+aliases: 
+    - /docs/services/
 title: Introduction
 layout: services
 weight: -1


### PR DESCRIPTION
`cg-dashboard` had several links to cloud.gov/docs/services
and they were report 403. Turns out the Hugo upgrade on 2018-04-26
seemingly caused the 403, as those links used to return the intro page
as seen at:

https://web.archive.org/web/20170720075445/cloud.gov/docs/services/

This is an inelegant fix, but if there are other links out there besides
the ones in cg-dashboard, this fixes those. But it might be a good idea
to either make a real index page, or fix the links in cg-dashboard.