### PR TITLE
Clarify that we ask users before clearing sandboxes for token reset

### DIFF
--- a/content/docs/ops/managing-users.md
+++ b/content/docs/ops/managing-users.md
@@ -24,7 +24,7 @@ If a user logs in using their agency's account system, the only way to reset tha
 
 Follow the process below for users logging in with a cloud.gov account.
 
-If the user requesting a reset has any apps, routes, or services in their sandbox or access to any other spaces or orgs make sure they **[are informed]({{< relref "docs/getting-started/accounts.md#if-you-can-t-access-your-token-codes" >}})** these will be removed.
+If the user requesting a reset has any apps, routes, or services in their sandbox or access to any other spaces or orgs, tell them that **[these will be removed]({{< relref "docs/getting-started/accounts.md#if-you-can-t-access-your-token-codes" >}})** and ask them if we should proceed. If they agree:
 
 1. Remove all apps, routes, and services from the user's sandbox. E.g.:
 


### PR DESCRIPTION
So that we're more consistent with our process for this.