### PR TITLE
clarify PM procedure

### DIFF
--- a/content/docs/ops/service-disruption-guide.md
+++ b/content/docs/ops/service-disruption-guide.md
@@ -66,7 +66,7 @@ A postmortem is not necessary to close, and it does not have to happen immediate
 
 ## Ensure a postmortem happens
 
-The person who closes the event should then put a card on the component-owning squad’s board in the urgent lane about holding a retrospective discussion and writing the public postmortem.
+The person who closes the event should then put a card on the component-owning squad’s board in the urgent lane about holding a retrospective discussion and writing the public postmortem.  The card's acceptance criteria should be that the retrospective discussion has happened, and that the public postmortem that resulted has been posted.
 
 For non-security-sensitive work, work to resolve root causes does not have to be completely done before we post the postmortem.
 


### PR DESCRIPTION
To me, this looked like the card was about holding the PM, and the work that fell out of it were separate issues.  This clarifies that posting the public PM was part of the card, not just work that fell out of it.