### PR TITLE
More design documentation after migrating domains-broker development over to CredHub

### DIFF
--- a/content/docs/ops/design/secrets.md
+++ b/content/docs/ops/design/secrets.md
@@ -232,6 +232,47 @@ delete the `credhub-import-*` file from the `s3://cloud-gov-varz/` bucket.
 aws s3 rm s3://cloud-gov-varz/credhub-import-file.yml
 ```
 
+#### CredHub credential types
+
+CredHub only [supports specific
+types](https://docs.cloudfoundry.org/credhub/credential-types.html#cred-types).
+If a cloud.gov operator needs to store a different type of credential, such as
+an array. It's required to modify the structure of the manifest using an opsfile
+and storing the key of the array in the CredHub database. An generic example is
+described below:
+
+```yaml
+  - name: nfstestserver
+    release: nfs-volume
+    properties:
+      nfstestserver:
+        # value stored in secrets file as an array
+        export_volumes: ((nfstestserver-volumes))
+```
+
+Modify the manifest using an opsfile so that the secret included the
+`export_volumes` property in the value.
+
+```yaml
+  - name: nfstestserver
+    release: nfs-volume
+    properties:
+      nfstestserver: ((nfstestserver-volumes))
+
+```
+
+This credential will then be stored in CredHub as a JSON type.
+
+```sh
+credhub set \
+  -n /bosh/deploy/nfstestserver-volumes \
+  -t json \
+  -v '{ "export_volumes": [ "val1", "val2" ] }'
+```
+
+When it is retrieved from CredHub it will be a YAML array with a key of
+`export_volumes`.
+
 ### Deploying services before CredHub credentials exist
 
 > To Be Decided

--- a/content/docs/ops/design/secrets.md
+++ b/content/docs/ops/design/secrets.md
@@ -322,6 +322,13 @@ This custom absolute path is best described as:
 - `${original-secret-name}` would be the original name of the secret being moved
   over to this custom absolute path.
 
+The `${generalized-deployment-name}` should be named after the producer of the
+secret, e.g. where the secret is set or configured. In the case of Cloud Foundry
+UAA client secrets, it's the `cf` deployment name. Consumers of the credential
+should never be considered for the `${generalized-deployment-name}`. In order to
+create a custom absolute path for a credential, cloud.gov operators must
+understand the consumer/producer relationship of the dependencies of the
+software they're deploying.
 
 ### Deploying services before CredHub credentials exist
 

--- a/content/docs/ops/design/secrets.md
+++ b/content/docs/ops/design/secrets.md
@@ -158,7 +158,25 @@ Concourse, and CredHub.
 
 ## Bootstrapping CredHub
 
-> To Be Decided
+Deploying anything  before there is a CredHub available on the BOSH director
+you're deploying to requires you to deploy CredHub manually using established
+`operations` and `variables` files that leverage BOSH interpolate.
+
+Require TLS
+
+Get the CA certificate for the database you're connecting to
+
+### Troubleshooting CredHub deployment
+
+Below are some scenarios that were encountered during the bootstrapping of
+CredHub.
+
+#### Database
+
+When deploying CredHub, ensure that the database is not modified in any way
+before the initial migration that CredHub performs on the first deployment. If
+the database is modified, the initial migration will fail and you must recreate
+the database using `cg-provision`.
 
 ### Deploying services before CredHub credentials exist
 

--- a/content/docs/ops/design/secrets.md
+++ b/content/docs/ops/design/secrets.md
@@ -169,7 +169,12 @@ group and that you are deploying CredHub with `datastorage.require_tls` set to
 ### Generating import file
 
 To ease the import of secrets into a fresh deployment of CredHub, take the
-`common/secrets.yml` file run it through Pivotal's `vars-to-credhub` tool.
+`common/secrets.yml` file run [it through Pivotal's `vars-to-credhub`
+tool](https://github.com/pivotalservices/vars-to-credhub).
+
+> Note that `vars-to-credhub` only supports valid CredHub variable types. If the
+> tool errors on the YAML structure of the secrets file, refer to the
+> documentation below on [CredHub variable types](#credhub-variable-types)
 
 Get the name from the BOSH director using `bosh environment`.
 
@@ -232,7 +237,7 @@ delete the `credhub-import-*` file from the `s3://cloud-gov-varz/` bucket.
 aws s3 rm s3://cloud-gov-varz/credhub-import-file.yml
 ```
 
-#### CredHub credential types
+#### CredHub variable types
 
 CredHub only [supports specific
 types](https://docs.cloudfoundry.org/credhub/credential-types.html#cred-types).

--- a/content/docs/ops/design/secrets.md
+++ b/content/docs/ops/design/secrets.md
@@ -181,7 +181,7 @@ credhub-import-${bosh-director-name}-${bosh-deployment-name}.yml
 
 Inspect this file for types and names that will need to be updated in the BOSH
 operation and variable files. Once this has been verified by a cloud.gov
-operator. Upload this file into CredHub using the import command.
+operator.  Then upload this file to the s3 vars bucket.  Then using the aws client in the respective bosh deployment, download the credential import file to the jumpbox environment.  Upload this file into CredHub using the Credhub CLI import command.
 
 ```sh
 credhub import \

--- a/content/docs/ops/design/secrets.md
+++ b/content/docs/ops/design/secrets.md
@@ -158,7 +158,7 @@ Concourse, and CredHub.
 
 ## Bootstrapping CredHub
 
-Deploying anything  before there is a CredHub available on the BOSH director
+Deploying anything before there is a CredHub available on the BOSH director
 you're deploying to requires you to deploy CredHub manually using established
 `operations` and `variables` files that leverage BOSH interpolate.
 


### PR DESCRIPTION
This body of work encompasses updates to the CredHub design document that could only be answered by actually deploying CredHub and moving a some deployments over to CredHub. ~~Sections include **Bootstrapping CredHub** and **Operator Tooling for Importing** ~~and possibly **Rotating Secrets**~~.~~