### PR TITLE
Link from pricing page to VPN backhaul description

### DIFF
--- a/layouts/pricing/index.html
+++ b/layouts/pricing/index.html
@@ -347,7 +347,7 @@
         <!-- <ul class="horizontal-list medium"> -->
         <ul class="column-single">
           <li>
-            <strong>Isolated and dedicated capacity with VPN backhaul</strong>
+            <strong><a href="/docs/apps/experimental/private-egress/">Isolated and dedicated capacity with VPN backhaul</a></strong>
           </li>
           <li>
             <strong>Manage apps in your data center using cloud.gov</strong>


### PR DESCRIPTION
Not sure how to get Hugo magic linking to work in layouts, so I'm following the rest of the file and just doing a relative URL.