### PR TITLE
Remove reference to fake UAA

### DIFF
--- a/content/docs/apps/leveraging-authentication.md
+++ b/content/docs/apps/leveraging-authentication.md
@@ -122,6 +122,14 @@ If you (or a user of your app) ever need to modify or revoke the permissions of
 third-party applications that you've granted access through the cloud.gov UAA,
 visit [https://login.fr.cloud.gov/profile](https://login.fr.cloud.gov/profile).
 
+## Using a development UAA server
+
+During development, you may want to authenticate against a local UAA server
+so you can test as multiple users, skip 2-factor authentication,
+and view UAA logs. Running UAA in [Docker](https://www.docker.com) can simplify this,
+and you can see an example of this in 
+
+and allowing for offline development, it also makes the OAuth handshake
 ## Using the fake UAA server
 
 During development, you may want to authenticate against a local server

--- a/content/docs/apps/leveraging-authentication.md
+++ b/content/docs/apps/leveraging-authentication.md
@@ -127,16 +127,11 @@ visit [https://login.fr.cloud.gov/profile](https://login.fr.cloud.gov/profile).
 During development, you may want to authenticate against a local UAA server
 so you can test as multiple users, skip 2-factor authentication,
 and view UAA logs. Running UAA in [Docker](https://www.docker.com) can simplify this,
-and you can see an example of this in 
+and you can follow an example of this in the [cloud.gov demonstrations repository](https://github.com/18F/cg-demos/blob/master/cg-identity/README.md#2-run-a-local-uaa-server-for-local-development).
 
-and allowing for offline development, it also makes the OAuth handshake
-## Using the fake UAA server
+## Demonstrating the cloud.gov identity provider
 
-During development, you may want to authenticate against a local server
-running [cg-fake-uaa](https://github.com/18F/cg-fake-uaa), a minimal
-"fake" version of the cloud.gov UAA server. Aside from making login easier
-and allowing for offline development, it also makes the OAuth handshake
-easier to debug.
+You can go through the process of setting up a simple application, written in Node.js, to use the cloud.gov identity provider in the [cloud.gov demonstrations repository](https://github.com/18F/cg-demos/blob/master/cg-identity/README.md#1-run-an-application-in-cloudgov-that-uses-the-identity-provider).
 
 ## Resources
 


### PR DESCRIPTION
The purpose of this PR is to remove reference to the cg-fake-uaa so I can deprecate that repository.

There may be good reason to move the content in the README.md, https://github.com/18F/cg-demos/blob/master/cg-identity/README.md, to cg-site, but it made sense for me, today, to have README live next to the `uaa.yml` and `id-example.js` code that enables the demos.

