### PR TITLE
Portfolio assessment

### DIFF
--- a/content/overview/overview/portfolio-analysis.md
+++ b/content/overview/overview/portfolio-analysis.md
@@ -9,6 +9,7 @@ weight: 16
 cloud.gov is suitable for a wide range of applications, including websites and non-website applications for internal and public uses.
 
 Here's a process you can follow to identify the applications in your portfolio ready to move to cloud.gov.
+<!--more-->
 
 ## Identify applications with a compatible security impact level
 - FISMA Low
@@ -75,6 +76,6 @@ Ideal applications follow as many of the [12-Factor App](https://12factor.net/) 
     - This is supported, but adds complexity because you may need to coordinate with your agency's network security staff and cloud.gov staff.
 
 ## What now?
-Now that you have a list of applications which are compatible with cloud.gov, and a sense of which will require more effort or are more complex, identify those which have the highest cost-of-delay… That is, the systems which will deliver the most benefit and which will reduce operational and security overhead the most by being in the cloud. You may need to work with your agency leadership to come to a consensus about where there's the most pain to be relieved or the most gain to be received, from the mission and financial rather than (technical) side.
+Now that you have a sense of which applications are compatible with cloud.gov, and which will require more effort or are more complex, identify those which have the highest cost-of-delay... That is, the systems which will deliver the most benefit and which will reduce operational and security overhead the most by being in the cloud. You may need to work with your agency leadership to come to a consensus about where there's the most pain to be relieved or the most gain to be received, from the mission and financial rather than (technical) side.
 
 The cloud.gov team can help you evaluate which of your applications are easier to migrate to cloud.gov, as well as how to approach more complex applications that require more modification. For help interpreting this list or evaluating specific cases, please email the cloud.gov team for help with your evaluation at cloud-gov-inquiries@gsa.gov.

--- a/content/overview/overview/portfolio-analysis.md
+++ b/content/overview/overview/portfolio-analysis.md
@@ -65,7 +65,7 @@ Ideal applications follow as many of the [12-Factor App](https://12factor.net/) 
   - Applications that rely on a durable filesystem to share state between requests will be supported in FY19. An [experimental service]({{< relref "volume-services" >}}) supports evaluating these applications on cloud.gov now.
 1. **Port binding**: Does the application listen for requests over HTTP on a single port?
   - Applications that only accept requests over straight TCP are also possible, but may require additional work on the cloud.gov side to get going.
-1. **Concurrency**: Does the application scale horizontally without special configuration?
+1. **Concurrency**: Does the application scale correctly without modification when you run additional instances of it behind a load-balancer?
   - Applications that require instances to be aware of each other are also possible, but may require additional work to configure correctly.
 1. **Disposability**: Can the application start quickly and shutdown gracefully?
 1. **Dev/prod parity**: Does the application exclude environment-sensitive code?

--- a/content/overview/overview/portfolio-analysis.md
+++ b/content/overview/overview/portfolio-analysis.md
@@ -11,6 +11,8 @@ cloud.gov is suitable for a wide range of applications, including websites and n
 Here's a process you can follow to identify the applications in your portfolio ready to move to cloud.gov.
 <!--more-->
 
+For help interpreting this list or evaluating specific cases, please email the cloud.gov team for help with your evaluation at cloud-gov-inquiries@gsa.gov. The cloud.gov team can help you evaluate whether you application is easy to migrate to cloud.gov, as well as how to approach more complex applications that require more modification. 
+
 ## Identify applications with a compatible security impact level
 - FISMA Low
 - FISMA Moderate
@@ -77,5 +79,3 @@ Ideal applications follow as many of the [12-Factor App](https://12factor.net/) 
 
 ## What now?
 Now that you have a sense of which applications are compatible with cloud.gov, and which will require more effort or are more complex, identify those which have the highest cost-of-delay... That is, the systems which will deliver the most benefit and which will reduce operational and security overhead the most by being in the cloud. You may need to work with your agency leadership to come to a consensus about where there's the most pain to be relieved or the most gain to be received, from the mission and financial rather than (technical) side.
-
-The cloud.gov team can help you evaluate which of your applications are easier to migrate to cloud.gov, as well as how to approach more complex applications that require more modification. For help interpreting this list or evaluating specific cases, please email the cloud.gov team for help with your evaluation at cloud-gov-inquiries@gsa.gov.

--- a/content/overview/overview/portfolio-analysis.md
+++ b/content/overview/overview/portfolio-analysis.md
@@ -1,0 +1,80 @@
+---
+menu:
+  overview:
+    parent: overview
+title: What applications are supported?
+weight: 16
+---
+
+cloud.gov is suitable for a wide range of applications, including websites and non-website applications for internal and public uses.
+
+Here's a process you can follow to identify the applications in your portfolio ready to move to cloud.gov.
+
+## Identify applications with a compatible security impact level
+- FISMA Low
+- FISMA Moderate
+- Department of Defense Impact Level 2 (DoD CC SRG IL2)
+<!-- The abbreviation used in the line above is intended to make this page easier for search engines to find. --> 
+
+## Identify applications with a supported technology stack
+
+**Operating systems**: Linux (64-bit ABI)
+
+**Application runtime options**:
+
+- Go
+- Java
+- .NET Core (note not .NET Framework!)
+- Node.js
+- PHP
+- Python
+- Ruby
+- Static HTML+JS+CSS
+- 64-bit Linux binary (including compiled C and C++ applications)
+
+**Backing services**:
+
+- **Relational databases**:
+  - MySQL
+  - Oracle
+  - Postgresql
+  - SQL Server (available FY19)
+- **NoSQL databases**:
+  - Mongo (available FY19)
+- **Search engines**:
+  - Elasticsearch
+- **Cache/queues**:
+  - Redis
+- **Blob stores**:
+  - S3
+
+## Identify applications already suited to cloud operations
+Once you have a list of applications with a compatible impact level and technology stack, use these criteria to sort that list from those applications already ideally suited to running in a PaaS environment to those which are likely to require modification.
+
+Ideal applications follow as many of the [12-Factor App](https://12factor.net/) guidelines as possible. The more of the following questions you can answer with "yes", the better.
+
+1. **Codebase**: Is the codebase tracked in version control?
+1. **Dependencies**: Are dependencies explicitly listed (such as package manager manifest)?
+1. **Configuration**: Can the configuration be retrieved from environment variables?
+1. **Backing services**: Does the application retry or fail gracefully if a service it connects to is unavailable?
+1. **Build, release, run**: Can you build the deployment artifacts outside of the deployment environment, for example in a continuous deployment system?
+1. **Processes**: Does the application keep its state in a backing service, rather than shared memory or filesystem?
+  - Applications that rely on a durable filesystem to share state between requests will be supported in FY19. An [experimental service]({{< relref "volume-services" >}}) supports evaluating these applications on cloud.gov now.
+1. **Port binding**: Does the application listen for requests over HTTP on a single port?
+  - Applications that only accept requests over straight TCP are also possible, but may require additional work on the cloud.gov side to get going.
+1. **Concurrency**: Does the application scale horizontally without special configuration?
+  - Applications that require instances to be aware of each other are also possible, but may require additional work to configure correctly.
+1. **Disposability**: Can the application start quickly and shutdown gracefully?
+1. **Dev/prod parity**: Does the application exclude environment-sensitive code?
+1. **Logs**: Does the application emit logs as a streams of single events (eg timestamped on single lines or JSON stanzas)?
+1. **Administrative processes**: Can you run maintenance/management tasks as one-off processes?
+
+## Watch out for networking complexity
+
+- Does the application need to access services that reside in a private network (for example in your data center or in another cloud service provider)?
+    - This is supported, but adds complexity because you may need to coordinate with your agency's network security staff and cloud.gov staff.
+
+## What now?
+Now that you have a list of applications which are compatible with cloud.gov, and a sense of which will require more effort or are more complex, identify those which have the highest cost-of-delay… That is, the systems which will deliver the most benefit and which will reduce operational and security overhead the most by being in the cloud. You may need to work with your agency leadership to come to a consensus about where there's the most pain to be relieved or the most gain to be received, from the mission and financial rather than (technical) side.
+
+The cloud.gov team can help you evaluate which of your applications are easier to migrate to cloud.gov, as well as how to approach more complex applications that require more modification. For help interpreting this list or evaluating specific cases, please email the cloud.gov team for help with your evaluation at cloud-gov-inquiries@gsa.gov.

--- a/content/overview/overview/portfolio-analysis.md
+++ b/content/overview/overview/portfolio-analysis.md
@@ -52,7 +52,7 @@ Here's a process you can follow to identify the applications in your portfolio r
 ## Evaluate applications for cloud operations readiness
 Once you have a list of applications with a compatible impact level and technology stack, use these criteria to sort that list from those applications already ideally suited to running in a PaaS environment to those which are likely to require modification.
 
-Ideal applications follow as many of the [12-Factor App](https://12factor.net/) guidelines as possible. The more of the following questions you can answer with "yes", the better. (Note these criteria aren't cloud.gov-specific! Applications that follow these guidelines are easier to migrate between modern hosting environments.)
+Ideal applications follow as many of the [12-Factor App](https://12factor.net/) guidelines as possible. The more of the following questions you can answer with "yes", the better. Applications that follow these guidelines are easier to migrate between modern hosting environments; the guidelines aren't cloud.gov-specific except as noted!
 
 1. **Codebase**: Is the codebase tracked in version control?
 1. **Dependencies**: Are dependencies explicitly listed (such as package manager manifest)?

--- a/content/overview/overview/portfolio-analysis.md
+++ b/content/overview/overview/portfolio-analysis.md
@@ -49,10 +49,10 @@ Here's a process you can follow to identify the applications in your portfolio r
 - **Blob stores**:
   - S3
 
-## Identify applications already suited to cloud operations
+## Evaluate applications for cloud operations readiness
 Once you have a list of applications with a compatible impact level and technology stack, use these criteria to sort that list from those applications already ideally suited to running in a PaaS environment to those which are likely to require modification.
 
-Ideal applications follow as many of the [12-Factor App](https://12factor.net/) guidelines as possible. The more of the following questions you can answer with "yes", the better.
+Ideal applications follow as many of the [12-Factor App](https://12factor.net/) guidelines as possible. The more of the following questions you can answer with "yes", the better. (Note these criteria aren't cloud.gov-specific! Applications that follow these guidelines are easier to migrate between modern hosting environments.)
 
 1. **Codebase**: Is the codebase tracked in version control?
 1. **Dependencies**: Are dependencies explicitly listed (such as package manager manifest)?

--- a/content/overview/overview/using-cloudgov-paas.md
+++ b/content/overview/overview/using-cloudgov-paas.md
@@ -3,7 +3,7 @@ menu:
   overview:
     parent: overview
 title: What you can do with the cloud.gov platform
-weight: 20
+weight: 13
 aliases:
   - /docs/intro/overview/using-cloudgov-paas
   - /intro/overview/using-cloudgov-paas

--- a/content/overview/overview/who-can-use-cloudgov.md
+++ b/content/overview/overview/who-can-use-cloudgov.md
@@ -12,36 +12,10 @@ aliases:
   - /overview/overview/who-can-use-cloudgov/
 ---
 
-cloud.gov is suitable for a wide range of applications, including websites and non-website applications for internal and public uses.
+cloud.gov is suitable for hosting applications built on behalf of a U.S. government organization.
 
-## Good fit for cloud.gov
+Customers pay for cloud.gov through the federal Interagency Agreement (IAA/MOU) process (see [how to purchase]({{< relref "start-using-cloudgov" >}})). *U.S. local, state, tribal, or territory government organizations are not able to use cloud.gov at this time.*
+<!-- If this describes your team, [sign up for updates](/#updates) so that we can notify you if we add other options. -->
+ 
+You should have a technical person or people (employees and/or contractors) available who will manage your applications on cloud.gov. They should be capable of [evaluating your application for suitability to cloud.gov]({{< relref "portfolio-analysis" >}}). They will need to be able to install the [cloud.gov command line interface]({{< relref "setup" >}}) (compatible with Windows, Mac, and Linux) on their client workstation to interact with cloud.gov.
 
-- You have a technical team (employees and/or contractors) that can push applications to cloud.gov. (See technical requirements below.)
-- Your application is for a United States federal government organization.
-- You understand that cloud.gov is a product under active development and will see changes in the future.
-- Your application is FISMA Moderate or lower.
-- You can pay for cloud.gov through the federal Interagency Agreement (IAA/MOU) process (see [how to purchase]({{< relref "overview/pricing/start-using-cloudgov.md" >}})).
-
-### Technical requirements
-
-- Your team can install the [cloud.gov command line interface]({{< relref "docs/getting-started/setup.md" >}}) (compatible with Windows, Mac, and Linux).
-- Your application can read configuration from the environment.
-- Your application uses one stateless process at a time (that can be horizontally scaled).
-- Your application listens to a single port.
-- Your application's dependencies are explicitly declared (such as `requirements.txt` for Python).
-### Optional but recommended
-
-- Your organization can integrate your identity system with cloud.gov over SAML.
-- Your application doesn't rely on the filesystem for storing its state.
-    - An [experimental service]({{< relref "docs/services/volume-services.md" >}}) supports filesystem-dependent applications.
-- Your application can follow the [12-Factor App guidelines](https://12factor.net/).
-
-## Not a good fit
-
-- Your application requires proprietary databases not listed in our [database service documentation]({{< relref "docs/services/relational-database.md" >}}).
-- Your team is unable to use the [federal Interagency Agreement process]({{< relref "overview/pricing/start-using-cloudgov.md" >}}) for payment. For example, this may apply for teams working for U.S. local, state, tribal, or territory government organizations.
-<!-- If this applies to your team, [sign up for updates](/#updates) so that we can notify you if we add other options. -->
-
-## Cannot use cloud.gov
-
-- The applications you're building are not on behalf of a U.S. government organization.


### PR DESCRIPTION
This removes the technical elements from the "who can use it?" page and slims that down to just talk about suitable customers and users.  It also adds a page to help people identify if their applications would work well on cloud.gov.