### PR TITLE
Document s3 policy change

### DIFF
--- a/content/docs/services/s3.md
+++ b/content/docs/services/s3.md
@@ -157,7 +157,10 @@ aws s3api put-bucket-cors --bucket $BUCKET_NAME --cors-configuration file://cors
 You can add additional method types along with HEAD and GET (such as PUT, POST, and DELETE) as needed.
 
 ### Backup and retention
-There is currently no backup process provided for the files stored in your S3 bucket.  Once you run `cf delete-service` on the `<APP_NAME>-s3` service the service will empty the contents of the S3 bucket.  So if you wish to retain these files be sure to copy them to a location of your choosing.
+
+By default, S3 data will stay where it is. You must [empty the bucket](http://docs.aws.amazon.com/AmazonS3/latest/dev/delete-or-empty-bucket.html#empty-bucket-awscli) before `cf delete-service` can be run on the `<APP_NAME>-s3` service.  This however is not a substitute for backups, and it provides no protection from users accidentally deleting the contents.
+
+For sandbox accounts if your sandbox is deleted automatically after 90 days, as per policy, the S3 service and all respective content stored within those S3 services will be cleared.  If you plan on storing important information in your sandbox S3 resources you must implement some type of backup scheme.
 
 You can implement a backup scheme by storing your buckets under /data/year/month/day and keeping multiple copies in S3, using the AWS CLI. Your Org Manager can create a space called "backups", and your team can run the process above again to create backup buckets.
 

--- a/content/docs/services/s3.md
+++ b/content/docs/services/s3.md
@@ -157,7 +157,7 @@ aws s3api put-bucket-cors --bucket $BUCKET_NAME --cors-configuration file://cors
 You can add additional method types along with HEAD and GET (such as PUT, POST, and DELETE) as needed.
 
 ### Backup and retention
-By default, S3 data will stay where it is. You must [empty the bucket](http://docs.aws.amazon.com/AmazonS3/latest/dev/delete-or-empty-bucket.html#empty-bucket-awscli) before `cf delete-service` can be run on the `<APP_NAME>-s3` service.  This however is not a substitute for backups, and it provides no protection from users accidentally deleting the contents.
+There is currently no backup process provided for the files stored in your S3 bucket.  Once you run `cf delete-service` on the `<APP_NAME>-s3` service the service will empty the contents of the S3 bucket.  So if you wish to retain these files be sure to copy them to a location of your choosing.
 
 You can implement a backup scheme by storing your buckets under /data/year/month/day and keeping multiple copies in S3, using the AWS CLI. Your Org Manager can create a space called "backups", and your team can run the process above again to create backup buckets.
 


### PR DESCRIPTION
This documents the change made to s3 broker.
 - essentially when ever `cf delete-service S3-SERVICE` is ran the bucket(s) are cleared and the service deletes automatically.  PR for broker can be found here: https://github.com/cloudfoundry-community/s3-broker/pull/33 .
 - has been tested on staging.