### PR TITLE
Updated 'Getting Started' documentation

### DIFF
--- a/content/docs/getting-started/concepts.md
+++ b/content/docs/getting-started/concepts.md
@@ -73,12 +73,12 @@ cf target -o ORGNAME -s SPACENAME
 
 All apps need to use a "buildpack" specific to their language, which sets up dependencies for their language stack. There are [standard buildpacks for most languages](https://docs.cloudfoundry.org/buildpacks/), and Cloud Foundry usually auto-detects and auto-applies the appropriate one when you deploy an app (one exception is that it doesn't auto-apply the special [binary buildpack](https://docs.cloudfoundry.org/buildpacks/binary/index.html)). We strongly encourage you to use the standard buildpacks. cloud.gov supports these standard buildpacks and provides security updates for them. (You'll need to redeploy or restage your application to pick up buildpack updates. You're also responsible for supporting and security-patching the application itself.)
 
-In the rare case where Cloud Foundry doesn't correctly auto-detect the buildpack, or if you want to use a binary buildpack or [custom buildpack]({{< relref "docs/apps/custom-buildpacks.md">}}), you can specify a buildpack in the [application manifest](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) (as below) or with the `-b` flag.
+In the rare case where Cloud Foundry doesn't correctly auto-detect the buildpack, or if you want to use a binary buildpack or [custom buildpack]({{< relref "docs/apps/custom-buildpacks.md">}}), you can specify a buildpack in the [application manifest](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) (as below) or with the `-b` flag. To reference a buildpack in a manifest, you may specifying using a name:
 
     buildpacks:
       - python_buildpack
 
-Or a URL:
+Or with a URL:
 
     buildpacks:
       - https://github.com/cloudfoundry/ruby-buildpack.git

--- a/content/docs/getting-started/concepts.md
+++ b/content/docs/getting-started/concepts.md
@@ -73,15 +73,18 @@ cf target -o ORGNAME -s SPACENAME
 
 All apps need to use a "buildpack" specific to their language, which sets up dependencies for their language stack. There are [standard buildpacks for most languages](https://docs.cloudfoundry.org/buildpacks/), and Cloud Foundry usually auto-detects and auto-applies the appropriate one when you deploy an app (one exception is that it doesn't auto-apply the special [binary buildpack](https://docs.cloudfoundry.org/buildpacks/binary/index.html)). We strongly encourage you to use the standard buildpacks. cloud.gov supports these standard buildpacks and provides security updates for them. (You'll need to redeploy or restage your application to pick up buildpack updates. You're also responsible for supporting and security-patching the application itself.)
 
-In the rare case where Cloud Foundry doesn't correctly auto-detect the buildpack, or if you want to use a binary buildpack or [custom buildpack]({{< relref "docs/apps/custom-buildpacks.md">}}), you can specify a buildpack in the [application manifest](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) (as below) or with the `-b` flag. To reference it, use either the buildpack name:
+In the rare case where Cloud Foundry doesn't correctly auto-detect the buildpack, or if you want to use a binary buildpack or [custom buildpack]({{< relref "docs/apps/custom-buildpacks.md">}}), you can specify a buildpack in the [application manifest](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) (as below) or with the `-b` flag.
 
-    buildpack: python_buildpack
+    buildpacks:
+      - python_buildpack
 
 Or a URL:
 
-    buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
+    buildpacks:
+      - https://github.com/cloudfoundry/ruby-buildpack.git
 
 **Multiple languages:** If your application requires multiple languages, we recommend evaluating these strategies to simplify your application:
+
 * Can you split your project into smaller applications that work together, so that you can use one language for each application and deploy each one separately?
 * Can you initiate long-running processes or schedule periodic jobs from outside your application [using the Tasks capability](https://docs.cloudfoundry.org/devguide/using-tasks.html)?
 * Can you [build your static assets using CI]({{< relref "assets.md#build-assets-on-ci" >}}) prior to pushing your application, so that only the final built assets are deployed on cloud.gov?

--- a/content/docs/getting-started/your-first-deploy.md
+++ b/content/docs/getting-started/your-first-deploy.md
@@ -33,7 +33,7 @@ cf target -o <ORG> -s <SPACE>
 ```
 
 Your `<ORG>` is a Cloud Foundry _organization_ named "sandbox-&lt;agencypart&gt;", where &lt;agencypart&gt; is whatever comes right before `.gov` or `.mil` in your
-e-mail address. For example, this may be `sandbox-gsa` or `sandbox-epa`. In most cases, your `<SPACE>` is the part of your email before the `@`, e.g. `firstname.lastname`. To get a list of your available organizations, type `cf orgs`
+e-mail address. For example, this may be `sandbox-gsa` or `sandbox-epa`. In most cases, your `<SPACE>` is the part of your email before the `@`, e.g. `firstname.lastname`. To get a list of your available organizations, type `cf orgs`.
 
 For example:
 

--- a/content/docs/getting-started/your-first-deploy.md
+++ b/content/docs/getting-started/your-first-deploy.md
@@ -33,7 +33,7 @@ cf target -o <ORG> -s <SPACE>
 ```
 
 Your `<ORG>` is a Cloud Foundry _organization_ named "sandbox-&lt;agencypart&gt;", where &lt;agencypart&gt; is whatever comes right before `.gov` or `.mil` in your
-e-mail address. For example, this may be `sandbox-gsa` or `sandbox-epa`. In most cases, your `<SPACE>` is the part of your email before the `@`, e.g. `firstname.lastname`. 
+e-mail address. For example, this may be `sandbox-gsa` or `sandbox-epa`. In most cases, your `<SPACE>` is the part of your email before the `@`, e.g. `firstname.lastname`. To get a list of your available organizations, type `cf orgs`
 
 For example:
 
@@ -48,7 +48,7 @@ cf target -o sandbox-gsa -s harry.truman
    * **Download:** [`https://github.com/18F/cf-hello-worlds/archive/master.zip`](https://github.com/18F/cf-hello-worlds/archive/master.zip)
 1. Move into that directory, for example: `cd cf-hello-worlds`
 1. Look at the collection of tiny apps, and `cd` into the directory for the language/framework you feel most comfortable with. For example: `cd python-flask`
-1. Deploy the application, where `APPNAME` should be something unique like `FRAMEWORK-YOURNAME` (e.g. `nodejs-aidan`). By default, your `APPNAME` will become part of the route to make your application publicly reachable, usually `https://APPNAME.app.cloud.gov/` or similar, and route names must be unique across the platform.
+1. Deploy the application, where `APPNAME` should be something unique like `FRAMEWORK-YOURNAME` (e.g. `python-truman`). By default, your `APPNAME` will become part of the route to make your application publicly reachable, usually `https://APPNAME.app.cloud.gov/` or similar, and route names must be unique across the platform.
 
     ```sh
     cf push APPNAME


### PR DESCRIPTION
* Added command to list available organizations, to allow the user to query this without having to access the dashboard.
* Modified sample app name to match the previous examples for consistency. Introducing a different name and framework could be slightly confusing.