### PR TITLE
Update docs to leverage scripts and more

### DIFF
--- a/content/docs/ops/runbook/suspending-orgs.md
+++ b/content/docs/ops/runbook/suspending-orgs.md
@@ -4,50 +4,60 @@ menu:
     parent: runbook
 layout: ops
 
-title: Suspending Orgs
+title: Suspending and Removing Orgs
 ---
 
 cloud.gov Operators are responsible for suspending and activating `cf orgs` for
 the platform. The following documentation covers how to do that.
 
-## Suspending
+We do not delete orgs when we are suspending them because it is usually due to a
+lapse in funding rather than a need to delete the org.
+
+## Suspending and stopping applications
 
 Suspending a cloud.gov org is done using the `cf curl` command. A cloud.gov
-Operator sets the status of the org as `suspended`. Please note that
-`${org_name}` must be set to an org name in order for the `--guid` command to
-properly find the org GUID in the sub-shell.
+Operator sets the status of the org as `suspended` and stops all applications in
+all spaces. Use the [`cg-script/suspend-org.sh` script][cg-suspend] in the
+`cg-scripts` repository to suspend orgs and stop applications.
 
-```shell
-org_name="";
-cf curl /v2/organizations/$(cf org ${org_name} --guid) -X PUT -d '{"status":"suspended"}'
-```
+To facilitate the un-suspending of orgs, cloud.gov Operators only stop
+applications and do not remove any routes, domains, services, or
+service-bindings. Suspended orgs are placed into a read-only state which only CF
+admins (cloud.gov Operators) may access or change anything in the org. Read more
+about [suspending orgs and RBAC in this documentation][cf-suspend-org-docs].
 
-## Activating
+[cf-suspend-org-docs]: https://docs.cloudfoundry.org/concepts/roles.html#suspendedroles "RBAC for suspended orgs in Cloud Foundry"
 
-Activating a cloud.gov org is done using the `cf curl` command. A cloud.gov
-Operator sets the status of the org as `active`. Please note that
-`${org_name}` must be set to an org name in order for the `--guid` command to
-properly find the org GUID in the sub-shell.
+## Un-suspending and starting applications
 
+Un-suspending a cloud.gov org is done using the `cf curl` command. A cloud.gov
+Operator sets the status of the org as `active` and starts all applications in
+all spaces. Use the [`cg-script/activate-org.sh` script][cg-activate] in the
+`cg-scripts` repository to un-suspend orgs and start applications.
 
-```shell
-org_name="";
-cf curl /v2/organizations/$(cf org ${org_name} --guid) -X PUT -d '{"status":"active"}'
-```
+[cg-activate]: https://github.com/18F/cg-scripts/blob/master/activate-org.sh
+"Source for activating orgs programmatically"
+[cg-suspend]: https://github.com/18F/cg-scripts/blob/master/suspend-org.sh "Source for suspending orgs programatically"
 
 ## Querying org statuses
 
 Finding which orgs are already suspended is done via the following `cf curl`
 command.
 
-```shell
-cf curl '/v2/organizations?q=status:suspended' | jq -r '(.resources[] | "GUID: " + .metadata.guid, "Status: " + .entity.status, "Name: " + .entity.name)'
+```sh
+cf curl '/v2/organizations?q=status:suspended' | jq -r '(.resources[] | "org GUID: " + .metadata.guid, "org Status: " + .entity.status, "org Name: " + .entity.name)'
 ```
 
 These results may be paginated. Check pagination by using the following
 `cf curl` command. You must change the URL to whatever is in _Previous
 URL_ or _Next URL_ with the previous command to get to the suspended orgs.
 
-```shell
+```sh
 cf curl '/v2/organizations?q=status:suspended' | jq -r '"Total Results: " + (.total_results | tostring), "Total Page: " + (.total_pages | tostring), "Previous URL: " +  .prev_url, "Next URL" +  .next_url'
 ```
+
+## Removing orgs
+
+In cases where orgs need to be deleted, we give customers limited time to export
+their data. Afterwards, we delete the org, spaces, services, and service-keys
+for the given org. Refer to the [CF CLI reference guide.](http://cli.cloudfoundry.org/en-US/cf/)


### PR DESCRIPTION
This patch addresses new cg-scripts and goes further into explaining the
idea of suspending, unsuspending, and deleting orgs.