### PR TITLE
Make ATO inheritance guidance more accurate

### DIFF
--- a/content/overview/security/fedramp-tracker.md
+++ b/content/overview/security/fedramp-tracker.md
@@ -27,7 +27,7 @@ For DoD teams: the Defense Information Systems Agency (DISA) categorizes [FedRAM
 
 Your agency still needs to grant your system an Authority to Operate, but FedRAMP has done the labor-intensive work of reviewing cloud.gov's security posture and endorsed it, which reduces the compliance work you need to do. Your agency's authorizing official can request the P-ATO documentation package from FedRAMP and accept that endorsement for your own system. See [ATO process]({{< relref "docs/compliance/ato-process.md" >}}) for the typical workflow.
 
-Here's how it works: Every "moderate" impact federal system is required to account for a baseline of about 325 controls before it can be granted an ATO. Once cloud.gov's P-ATO is reviewed and accepted, many of those requirements are already implemented and documented. Of the remaining requirements, responsibility for most of the rest are shared between cloud.gov and your application, and only a few are fully yours.
+Here's how it works: Every "moderate" impact federal system is required to account for a baseline of about 325 controls before it can be granted an ATO. Once cloud.gov's P-ATO is reviewed and accepted, many of those requirements are already implemented and documented. Of the remaining requirements, responsibility for most of the rest are shared between cloud.gov and your application, and only some of them are fully yours.
 
 Here's an example of a control breakdown for a simple moderate-impact system hosted on cloud.gov:
 

--- a/content/overview/security/fedramp-tracker.md
+++ b/content/overview/security/fedramp-tracker.md
@@ -25,18 +25,16 @@ For DoD teams: the Defense Information Systems Agency (DISA) categorizes [FedRAM
 
 ## How you can use this P-ATO
 
-FedRAMP is like an outfitter for cloud services. Your agency still needs to grant the system you want to build an Authority to Operate but FedRAMP has done the labor intensive work of reviewing cloud.gov's security posture and endorsed it. Your agency's authorizing official can request the P-ATO documentation package from FedRAMP and accept that endorsement for your own system.
+Your agency still needs to grant your system an Authority to Operate, but FedRAMP has done the labor-intensive work of reviewing cloud.gov's security posture and endorsed it, which reduces the compliance work you need to do. Your agency's authorizing official can request the P-ATO documentation package from FedRAMP and accept that endorsement for your own system. See [ATO process]({{< relref "docs/compliance/ato-process.md" >}}) for the typical workflow.
+
+Here's how it works: Every "moderate" impact federal system is required to account for a baseline of about 325 controls before it can be granted an ATO. Once cloud.gov's P-ATO is reviewed and accepted, many of those requirements are already implemented and documented. Of the remaining requirements, responsibility for most of the rest are shared between cloud.gov and your application, and only a few are fully yours.
+
+Here's an example of a control breakdown for a simple moderate-impact system hosted on cloud.gov:
 
 ![Graph showing the breakdown of how many controls are fully covered by cloud.gov.](/img/fedramp-moderate-controls.png)
 
-Here's how it works: Every "moderate" impact federal system is required to account for a baseline of 325 controls before it can be granted an ATO. Your agency may choose to do more than that, but once cloud.gov's P-ATO is reviewed and accepted, 269 of those requirements are already implemented and documented. Of the remaining requirements, responsibility for 41 of them is shared between cloud.gov and your application, and 15 are fully yours.
-
-*By reducing the overhead of the approval process, cloud.gov allows you to focus on reviewing the parts of your system specific to your agency's mission.*
-
-## Documents for the ATO process
-
-If you want to use cloud.gov, [**request the P-ATO documentation package from FedRAMP**](https://s3.amazonaws.com/sitesusa/wp-content/uploads/sites/482/2015/03/FedRAMP-Package-Request-Form_V4_06192014.pdf) (the Package ID for that form is F1607067912). You can also view the [FedRAMP Marketplace page for cloud.gov](https://marketplace.fedramp.gov/#/product/18f-cloudgov?sort=productName).
-
 The [**Control Implementation Summary + Customer Responsibility Matrix + Control-by-Control Inheritance (.xlsx)**](/resources/cloud.gov-CIS-Worksheet.xlsx) (last updated November 7, 2018) is a summary of each Low and Moderate security control and whether it is handled by cloud.gov, shared responsibility, or customer responsibility. It includes guidance on which controls a customer system can fully or partially inherit from cloud.gov.
 
-When you're ready to start the P-ATO review process for cloud.gov, see [ATO process]({{< relref "docs/compliance/ato-process.md" >}}) for an overview of the typical workflow.
+## Start the ATO process
+
+If you want to use cloud.gov, [**request the P-ATO documentation package from FedRAMP**](https://s3.amazonaws.com/sitesusa/wp-content/uploads/sites/482/2015/03/FedRAMP-Package-Request-Form_V4_06192014.pdf) (the Package ID for that form is F1607067912). You can also view the [FedRAMP Marketplace page for cloud.gov](https://marketplace.fedramp.gov/#/product/18f-cloudgov?sort=productName).


### PR DESCRIPTION
In this change, I made clear that the diagram of control inheritance is an example instead of a guarantee, and I moved the Control Implementation Summary download right next to it.

Being very precise about this is important because people with a lot of compliance experience simply won't take us seriously if we appear to be exaggerating the control inheritance that we offer (even accidentally).

I also removed a few sentences that didn't seem necessary.