### PR TITLE
For private egress, give more direct instructions and remove confusing bit of diagram

### DIFF
--- a/content/docs/apps/private-egress.md
+++ b/content/docs/apps/private-egress.md
@@ -9,11 +9,11 @@ title: Connect to your private network
 
 You can set up all or a subset of your applications to communicate securely with an external network. This enables your cloud.gov applications to access services hosted in your agency infrastructure or with other cloud providers.
 
-By default, cloud.gov runs your application instances on a pool of hosts shared by all cloud.gov customers. Application instances run in containers that isolate them from each other, but the hosts are all running in the same network segment. If you open your private external service network for access by cloud.gov applications, you will also permit network access by other cloud.gov customers.
+By default, cloud.gov runs your application instances on a pool of hosts shared by all cloud.gov customers. Application instances run in containers that isolate them from each other, but the hosts are all running in the same network segment. If you used that default setup and wanted to open your private external service network for access by cloud.gov applications, you would also permit network access by other cloud.gov customers, so you should not do that.
 
-To prevent network access by other cloud.gov customers, you can request that cloud.gov establish a dedicated set of hosts for your organization. Applications run by other cloud.gov customers will not run on these hosts. Your applications will still be accessible from the internet and can still connect to any of our offered internal services. cloud.gov will work with you to give these dedicated hosts additional access to your private networks.
+cloud.gov provides a way to prevent network access by other cloud.gov customers. To set this up, [email cloud.gov support](/help/) and request cloud.gov to establish a dedicated set of hosts for your organization. Applications run by other cloud.gov customers will not run on these hosts. Your applications will still be accessible from the internet and can still connect to any of our offered internal services. cloud.gov will work with you to give these dedicated hosts additional access to your private networks.
 
-*You can alternatively [secure communication for a single application and service at a time]({{< relref "docs/apps/static-egress" >}}).*
+Alternatively, if you only need to secure communication for a single application and service at a time, you can [set that up using client-specific credentials]({{< relref "docs/apps/static-egress" >}}).
 
 ## How it works
 
@@ -35,17 +35,12 @@ subgraph AWS GovCloud
         isolated-app[Isolated Applications]
       end
     end
-    subgraph Shared Segment
-      subgraph Shared Hosts
-        normal-app[Default Applications]
-      end
-    end
+
     subgraph cloud.gov Services
       database[Shared Database]
     end
   end
 end
-
   subgraph Customer Responsibility
     customer-vpn-endpoint[Customer VPN Endpoint]
     dlp["Data Loss Prevention Solution"]
@@ -54,18 +49,16 @@ end
     end
   end
 
-
   client--internet-->elb
   elb-->router
   router-->isolated-app
-  router-->normal-app
   isolated-app--shared network rules-->database
-  normal-app--shared network rules-->database
   isolated-app--dedicated network rules-->cg-vpn-endpoint
   cg-vpn-endpoint-- "IPsec (via internet)" ---customer-vpn-endpoint
   customer-vpn-endpoint---dlp
   dlp-->private-service
-  {{< /diagrams >}}
+
+{{< /diagrams >}}
 
 To use this service, you must have an internet-routable IP address to use as the IPsec endpoint for the connection. If you have a firewall in place between the internet and your endpoint, then you will have to open both ingress and egress on UDP port 500 and ESP (IP Protocol 50) to enable the connection. If you are also using NAT behind your firewall, you will also have to enable UDP port 4500.
 


### PR DESCRIPTION
Our JAB folks need us to make clear that an isolated segment is required (not optional) for setting up the network connection. This tries to make that clear by giving more direct recommendations (that you should not connect your agency network to all of cloud.gov) and removing the shared segment from the diagram. We shouldn't merge without review from @mogul.