### PR TITLE
Fix version number mention in release notes

### DIFF
--- a/content/updates/2019-07-12-VPN-backhaul-drupal-8-and-new-team-members.md
+++ b/content/updates/2019-07-12-VPN-backhaul-drupal-8-and-new-team-members.md
@@ -40,7 +40,7 @@ Do you want to track which version of your code is running in each of your deplo
 
 ## Updated
 
-We encourage staying up to date with the latest Cloud Foundry Command-Line Interface (CLI) versions. The latest version [You can download the CF CLI update here.](https://github.com/cloudfoundry/cli/releases)
+We encourage staying up to date with the latest Cloud Foundry Command-Line Interface (CLI) versions. The latest version is v6.46.0. [You can download the CF CLI update here.](https://github.com/cloudfoundry/cli/releases)
 
 We routinely update the operating system underneath your applications to ensure your applications are using the latest patched versions. For example, there was a high-severity Ubuntu Linux security vulnerability nicknamed [SACKPanic](https://wiki.ubuntu.com/SecurityTeam/KnowledgeBase/SACKPanic) that was announced on June 18, and we mitigated it by the evening of June 19.
 


### PR DESCRIPTION
We ended up with a missing sentence half instead of the right version number.