### PR TITLE
remove dates and just say its not approved

### DIFF
--- a/content/docs/apps/experimental/behavior-monitoring.md
+++ b/content/docs/apps/experimental/behavior-monitoring.md
@@ -7,7 +7,7 @@ title: Dynamic behavior monitoring
 
 [**This is an experimental feature.**]({{< relref "docs/apps/experimental/experimental.md" >}})
 
-_Note: As of March 2018, this feature is not yet available, pending FedRAMP approval. If you want to use this feature, [contact support]({{< relref "docs/help.md" >}}) and our team will let you know our estimated timeline for approval._
+_Note: This feature is not yet available and pending FedRAMP approval. If you want to use this feature, [contact support]({{< relref "docs/help.md" >}}) and our team will let you know our estimated timeline for approval._
 
 cloud.gov uses a range of [security features](https://docs.cloudfoundry.org/concepts/container-security.html) to prevent application containers from interfering with other containers or with the hosts they run on. As an additional security measure, cloud.gov will also automatically monitor application containers for suspicous behavior using [Sysdig Falco](https://sysdig.com/opensource/falco/).
 

--- a/content/docs/apps/experimental/mongodb.md
+++ b/content/docs/apps/experimental/mongodb.md
@@ -13,9 +13,9 @@ aliases:
 
 ## Plans
 
-Service Name | Plan Name | Description | Price
+Service Name | Plan Name | Description | 
 ------------ | --------- | ----------- | -----
-`mongodb36` | `standard` | MongoDB instance with 10 GB storage | Free in Alpha
+`mongodb36` | `standard` | MongoDB instance with 10 GB storage | 
 
 Note: MongoDB plans run a single instance and will be briefly unavailable during platform maintenance; this service should not be used for production applications.
 

--- a/content/docs/apps/experimental/restricting-users-to-trusted-ip-ranges.md
+++ b/content/docs/apps/experimental/restricting-users-to-trusted-ip-ranges.md
@@ -11,7 +11,7 @@ This feature only limits requests to cloud.gov services, such as the cloud.gov A
 
 ### Contact support to configure restrictions for your domain
 
-_Note: As of October 2017, this feature is not yet available, pending FedRAMP approval. If you want to configure this feature, create a ticket and our team will let you know our estimated timeline for approval._
+_Note: This feature is not yet available and pending FedRAMP approval. If you want to configure this feature, create a ticket and our team will let you know our estimated timeline for approval._
 
 Create a [support ticket](mailto:cloud-gov-support@gsa.gov?body=Email%20domain%3A%0A%0AEgress%20IP%20ranges%3A%0A%0AAgency%20CIO%3A%0A) specifying the IP address ranges that are valid for your domain. Because address restriction applies to all cloud.gov users from your email domain, we will request confirmation from your agency CIO before changing the configuration.
 


### PR DESCRIPTION
It's unnecessary to have date-level status updates. These services are in experimentation mode until they are not.