### PR TITLE
elasticsearch56 plan name example command fix

### DIFF
--- a/content/docs/services/elasticsearch56.md
+++ b/content/docs/services/elasticsearch56.md
@@ -24,7 +24,7 @@ Plan Name | Description |
 To create a service instance run the following command:
 
 ```sh
-cf create-service elasticsearch56 medium my-elastic-service
+cf create-service elasticsearch56 medium-ha my-elastic-service
 ```
 
 ### Shard/replica configuration for high availability


### PR DESCRIPTION
The elasticsearch56 plan name appears to have changed from `medium` to `medium-ha`. It was changed in one place on the page, but not everywhere. I was following instructions from a project that was still using `medium` and was receiving this error `The plan medium could not be found for service elasticsearch56`. I came here to find the official plan names and noticed the inconsistencies on the page.

I'm very new to cloud.gov, so please double check.