### PR TITLE
re-surface missing Technology pages

### DIFF
--- a/content/docs/technology/iaas.md
+++ b/content/docs/technology/iaas.md
@@ -1,6 +1,6 @@
 ---
 menu:
-  overview:
+  docs:
     parent: technology
 title: Infrastructure under cloud.gov
 weight: 20

--- a/content/docs/technology/iaas.md
+++ b/content/docs/technology/iaas.md
@@ -7,6 +7,7 @@ weight: 20
 aliases:
   - /docs/intro/technology/iaas
   - /intro/technology/iaas
+  - /overview/technology/iaas
 ---
 
 ## The infrastructure underlying cloud.gov

--- a/content/docs/technology/paas-options.md
+++ b/content/docs/technology/paas-options.md
@@ -7,6 +7,7 @@ weight: 30
 aliases:
   - /docs/intro/technology/paas-options
   - /intro/technology/paas-options
+  - /overview/technology/paas-options
 ---
 
 ## Open source

--- a/content/docs/technology/paas-options.md
+++ b/content/docs/technology/paas-options.md
@@ -1,6 +1,6 @@
 ---
 menu:
-  overview:
+  docs:
     parent: technology
 title: Other PaaS choices
 weight: 30

--- a/content/docs/technology/responsibilities.md
+++ b/content/docs/technology/responsibilities.md
@@ -7,6 +7,7 @@ weight: 5
 aliases:
   - /docs/intro/technology/responsibilities
   - /intro/technology/responsibilities
+  - /overview/technology/responsibilities
 ---
 
 As a Platform as a Service, cloud.gov is responsible for maintenance and security of the cloud.gov platform. Customers are responsible for maintenance and security of their custom code running on the platform.

--- a/content/docs/technology/responsibilities.md
+++ b/content/docs/technology/responsibilities.md
@@ -1,6 +1,6 @@
 ---
 menu:
-  overview:
+  docs:
     parent: technology
 title: What the cloud.gov PaaS offers
 weight: 5


### PR DESCRIPTION
I was trying to find [the Responsibilities page](https://cloud.gov/docs/technology/responsibilities/), and links to it from Google and search.gov were broken. Realized that redirects for it and a couple other pages were broken, and that they weren't showing up in the sidebar. There may be other pages with either/both of these issues - might be worth a check.

cc @abbeykos @timothy-spencer 