### PR TITLE
use "memory quota" instead of "usage"

### DIFF
--- a/content/docs/pricing/pricing-model.md
+++ b/content/docs/pricing/pricing-model.md
@@ -11,7 +11,7 @@ aliases:
 
 cloud.gov is available to teams working on behalf of federal agencies. The pricing model is based on full cost recovery.
 
-The current cloud.gov pricing model has two components: **access package** and **resource usage**. Find the current costs of a package that suits your needs on our [pricing page](/pricing/).
+The current cloud.gov pricing model has two components: **access package** and **memory quota**. Find the current costs of a package that suits your needs on our [pricing page](/pricing/).
 
 ## Comparison with private sector pricing
 

--- a/content/docs/pricing/quotas.md
+++ b/content/docs/pricing/quotas.md
@@ -17,7 +17,7 @@ cloud.gov usage is billed by org memory quota.
 
 The cost is $130 per GB of memory reserved per month, with no limit except the quota you set.
 
-You set your usage quota **in advance**. This helps you control the maximum amount that your team will spend, and helps us avoid over-provisioning resources that won’t be used.
+You set your memory quota **in advance**. This helps you control the maximum amount that your team will spend, and helps us avoid over-provisioning resources that won’t be used.
 
 ([Sandboxes]({{< relref "docs/pricing/free-limited-sandbox.md" >}}) offer resource usage for free, but it is capped at 1 GB of RAM.)
 

--- a/content/updates/2019-08-26-changes-to-cloud-gov-services-and-prices.md
+++ b/content/updates/2019-08-26-changes-to-cloud-gov-services-and-prices.md
@@ -17,7 +17,7 @@ Plan  | Previous monthly price | New monthly price  |
 `FISMA Moderate` | $7,500.00/month |  $9,300.00/month |
 
 
-**Usage fees**
+**Memory quota cost**
 
 Resource  | Previous monthly price | New monthly price  |
 --------- | ----------- | -----
@@ -30,7 +30,7 @@ Resource  | Previous monthly price | New monthly price  |
 
 - RDS, S3, Elasticsearch, and Redis will now run on “high-availability” servers, providing you with additional stability and redundancy.
 
-- Previously, cloud.gov provided RDS, S3, Elasticsearch, and Redis at no additional cost for a “limited time.” We will continue to provide these services at no additional cost as long as your usage remains below the following limits. If you expect to need larger amounts of storage, contact cloud-gov-inquiries@gsa.gov. At higher amounts, we will charge you for the additional IaaS costs. 
+- Previously, cloud.gov provided RDS, S3, Elasticsearch, and Redis at no additional cost for a “limited time.” We will continue to provide these services at no additional cost as long as your memory quota remains below the following limits. If you expect to need larger amounts of storage, contact cloud-gov-inquiries@gsa.gov. At higher amounts, we will charge you for the additional IaaS costs. 
 
 
      | Previous storage limit | New storage limit

--- a/layouts/pricing/index.html
+++ b/layouts/pricing/index.html
@@ -162,7 +162,7 @@
       <section class="usa-grid">
         <h2 id="estimate-your-monthly-cost"><a href="#estimate-your-monthly-cost">Estimate your monthly cost</a></h2>
         <p>
-          Monthly costs are based on the package fee (i.e., Prototyping, FISMA Low, FISMA Moderate) plus memory usage. Usage costs are based on the amount of memory (RAM) that you reserve for your system (<sup>$</sup>130/GB RAM per month).
+          Monthly costs are based on the package fee (i.e., Prototyping, FISMA Low, FISMA Moderate) plus memory usage. Memory quota cost are based on the amount of memory (RAM) that you reserve for your system (<sup>$</sup>130/GB RAM per month).
         </p>
         <p class="footnote">
           Most cloud.gov customers typically reserve 4–8 GB of memory to cover multiple applications across development, staging, and production environments.
@@ -179,7 +179,7 @@
           FISMA Low <span><sup>$</sup>2070</span>
         </p>
         <h4>
-          Memory Usage Cost
+          Memory Quota Cost
         </h4>
         <p class="pricing-line-item">
           [ 1 GB + 2 GB + 1 GB ] x <sup>$</sup>130 <span><sup>$</sup>520</span>


### PR DESCRIPTION
- to provide more consistent and clearer language, usage is now referred to as memory quota