### PR TITLE
update compute limit docs to remove references to purchase units and …

### DIFF
--- a/content/docs/apps/limits.md
+++ b/content/docs/apps/limits.md
@@ -39,7 +39,7 @@ Space Developers can specify application limits in your [application manifest](h
 
 `memory: / -m`
 
-The application memory limit. This setting has a dual-purpose, as your application compute limit is derived from its memory limit. This relationship is explained in detail below.
+The application memory limit. This setting has a dual-purpose, as your application compute limit is derived from its memory limit. This relationship is explained in detail [here](https://docs.cloudfoundry.org/concepts/container-security.html#cpu).
 
 `disk_quota / -k`
 
@@ -48,29 +48,6 @@ The maximum amount of disk space available to your app.
 `instances: / -i`
 
 Sets the number of application instances to launch. Each additional instance receives the same memory and disk reservation. An application with a manifest specifying `memory: 256M` and `instances: 4` would reserve 1GB (256M x 4) total.
-
-### Application limit options: memory share equals compute share
-
-As noted above, your application's compute limit is derived from its memory limit. Each application receives a compute share equal to its relative share of memory.
-
-For example, with a 1 unit (3.75GB) quota:
-
-- `memory: 1875`
-	- Guaranteed at least 50% vCPU time.
-	- Offered up to 100% vCPU time.
-	- Limited to 1.875GB of RAM.
-- `memory: 375`
-	- Guaranteed at least 10% vCPU time.
-	- Offered up to 100% vCPU time.
-	- Limited to 375MB of RAM.
-
-**Guaranteed:**
-
-Your application will receive at least this much vCPU time even if there are other applications competing for time.
-
-**Offered:**
-
-Your application can use all available CPU time. If there are other applications competing for time, each application's guaranteed share determines how much time it will receive.
 
 **Limited:**
 


### PR DESCRIPTION
…punt the hard work to cf docs


The current docs explain CPU shares incorrectly, and reference old pricing models no longer in use. 
This points users to the CF docs for CPU share info, and removes references to the old pricing model.