### PR TITLE
Remove unneeded compliance section

### DIFF
--- a/content/docs/services/cdn-route.md
+++ b/content/docs/services/cdn-route.md
@@ -40,12 +40,6 @@ Name | Required | Description | Default
 
 This service is similar to the [custom domain service]({{< relref "docs/services/custom-domains.md" >}}), but with an additional feature: CDN caching support using [AWS CloudFront](https://aws.amazon.com/cloudfront/).
 
-### Compliance impact
-
-When you use cloud.gov in general, your application inherits the compliance of the cloud.gov FedRAMP P-ATO, which inherits compliance from the AWS GovCloud FedRAMP P-ATO. This service is a little different. When you use this service, you opt into using an AWS service (CloudFront) that is not in an AWS FedRAMP P-ATO boundary (see [Services in Scope](https://aws.amazon.com/compliance/services-in-scope/)).
-
-You are responsible for obtaining appropriate authorization from your agency to use CloudFront for your system. The appropriate steps depend on your agency; they may include discussing this with your Authorizing Official and documenting it as part of your ATO (for example as part of [SC-12](https://nvd.nist.gov/800-53/Rev4/control/SC-12) or [SA-9](https://nvd.nist.gov/800-53/Rev4/control/SA-9)).
-
 ### Technical considerations
 
 Before setting up this service, review [how the CDN works](#more-about-how-the-cdn-works).


### PR DESCRIPTION
I don't think this section is needed any longer as CloudFront is actually part of services FedRAMP'ed - https://aws.amazon.com/compliance/services-in-scope/