### PR TITLE
Add org and quota docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -63,6 +63,11 @@ pygmentsUseClasses = "true"
     pre = "<i class='fa fa-rocket fa-fw'></i>"
     weight = -100
 [[menu.docs]]
+    name = "Managing orgs"
+    identifier = "orgs-spaces"
+    pre = "<i class='fa fa-rocket fa-fw'></i>"
+    weight = -100
+[[menu.docs]]
     name = "Compliance"
     identifier = "compliance"
     pre = "<i class='fa fa-check-square-o fa-fw'></i>"

--- a/content/docs/apps/limits.md
+++ b/content/docs/apps/limits.md
@@ -9,23 +9,7 @@ Org Managers are free to configure your org's [quota]({{< relref "docs/pricing/q
 
 ## Org
 
-To view your [org quota]({{< relref "docs/pricing/quotas.md" >}}):
-
-1. List the details about your org: `cf org <org>`
-2. Find your quota name from the `quota:` property.
-3. View your quota: `cf quota <quota>`
-
-To change your org quota, [ask support](/help/). You can request an increase in number of [application routes]({{< relref "docs/apps/custom-domains.md" >}}) or [service instances]({{< relref "docs/apps/managed-services.md" >}}) with no cost impact. Increasing or decreasing org memory quota changes your usage costs.
-
-### Tracking quota usage
-
-You can use the following `cf` CLI plugins to help identify the right quota to set for your org. They are available from the _CF-Community_ plugin site: `cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org/`
-
-- The [Usage Report plugin](https://github.com/krujos/usagereport-plugin) gives you a report of how your quota is used across visible organizations and spaces. To install: `cf install-plugin 'Usage Report' -r CF-Community`
-
-- The [Statistics plugin](https://github.com/swisscom/cf-statistics-plugin) gives you real-time visibility of the actual memory usage for each application instance compared to the memory limit. To install: `cf install-plugin Statistics -r CF-Community`
-
-You can use these two in combination to get a good sense of where you can lower instance memory limits to make room for more instances elsewhere in your org or just reduce your quota to reduce costs. 
+See more about how to [manage your orgs' quotas]({{< relref "docs/orgs-spaces/limits.md" >}}).
 
 ## Space
 
@@ -64,11 +48,11 @@ The application cannot access more than the specified amount of memory.
 		urls:
 		last uploaded: Wed Jul 22 20:09:56 UTC 2015
 
-		     state     since                    cpu    memory          disk          
-		#0   running   2015-07-30 05:58:11 PM   0.0%   94.6M of 128M   80.4M of 128M      
+		     state     since                    cpu    memory          disk
+		#0   running   2015-07-30 05:58:11 PM   0.0%   94.6M of 128M   80.4M of 128M
 
 
 - Any application which exceeds its memory limit will be automatically restarted. Use `cf events APPNAME` to look for 'out of memory' crashes.
 
-		... description   
+		... description
 		... index: 0, reason: CRASHED, exit_description: out of memory, exit_status: 255

--- a/content/docs/orgs-spaces/dashboard.md
+++ b/content/docs/orgs-spaces/dashboard.md
@@ -1,0 +1,15 @@
+---
+menu:
+  docs:
+    parent: orgs-spaces
+title: Dashboard
+---
+
+## Log into the dashboard (web interface)
+
+The dashboard gives you web-based access to common tasks: [https://dashboard.fr.cloud.gov/](https://dashboard.fr.cloud.gov/)
+
+### Beta dashboard
+
+We will be moving to a new, Stratos-based dashboard in the near future. The dashboard is currently in beta and is available to customers to try out its more-granular and in-depth functionality than the original dashboard: [https://dashboard-beta.fr.cloud.gov/](https://dashboard-beta.fr.cloud.gov/)
+

--- a/content/docs/orgs-spaces/dashboard.md
+++ b/content/docs/orgs-spaces/dashboard.md
@@ -3,13 +3,21 @@ menu:
   docs:
     parent: orgs-spaces
 title: Dashboard
+weight: -100
 ---
+
+The online dashboard gives users web-based access to common tasks, such as managing organization users and permissions, instead of performing actions via the command-line interface (CLI).
 
 ## Log into the dashboard (web interface)
 
-The dashboard gives you web-based access to common tasks: [https://dashboard.fr.cloud.gov/](https://dashboard.fr.cloud.gov/)
+The cloud.gov dashboard is available at: [https://dashboard.fr.cloud.gov/](https://dashboard.fr.cloud.gov/)
 
-### Beta dashboard
+Please note that adding users to organizations may return an error - if so, please use the new dashboard or CLI to perform this action.
 
-We will be moving to a new, Stratos-based dashboard in the near future. The dashboard is currently in beta and is available to customers to try out its more-granular and in-depth functionality than the original dashboard: [https://dashboard-beta.fr.cloud.gov/](https://dashboard-beta.fr.cloud.gov/)
+## New dashboard
 
+Please join us in using our new, Stratos-based dashboard, available to try out at: [https://dashboard-beta.fr.cloud.gov/](https://dashboard-beta.fr.cloud.gov/)
+
+### Managing users via the new dashboard
+
+To manage users and their permissions, visit the "Cloud Foundry" link on the left menu of the dashboard. From there, you can add and edit org and space users and their permissions.

--- a/content/docs/orgs-spaces/limits.md
+++ b/content/docs/orgs-spaces/limits.md
@@ -11,6 +11,8 @@ Org Managers are free to configure your org's [quota]({{< relref "docs/pricing/q
 
 To change your org quota, please have an Org Manager [send a quota change request email](mailto:cloud-gov-inquiries@gsa.gov,cloud-gov-support@gsa.gov?subject=Quota%20change%20request&body=Please%20update%20the%20quota%20for%20the%20following%20organization%3A%0A%0AOrg%20name%3A%20%0AMemory%3A%20%23GB%0AServices%3A%20%23%20or%20no%20change%0ARoutes%3A%20%23%20or%20no%20change"). This email link will pre-populate required information.
 
+You can request an increase in number of [application routes]({{< relref "docs/apps/custom-domains.md" >}}) or [service instances]({{< relref "docs/apps/managed-services.md" >}}) with no cost impact. Increasing or decreasing org memory quota changes your maximum usage costs.
+
 ### View org quota details
 
 To view your [org quota]({{< relref "docs/pricing/quotas.md" >}}):
@@ -18,8 +20,6 @@ To view your [org quota]({{< relref "docs/pricing/quotas.md" >}}):
 1. List the details about your org: `cf org <org>`
 2. Find your quota name from the `quota:` property.
 3. View your quota: `cf quota <quota>`
-
-You can request an increase in number of [application routes]({{< relref "docs/apps/custom-domains.md" >}}) or [service instances]({{< relref "docs/apps/managed-services.md" >}}) with no cost impact. Increasing or decreasing org memory quota changes your maximum usage costs.
 
 ### Tracking quota usage
 

--- a/content/docs/orgs-spaces/limits.md
+++ b/content/docs/orgs-spaces/limits.md
@@ -1,0 +1,32 @@
+---
+menu:
+  docs:
+    parent: orgs-spaces
+title: Manage org quotas
+---
+
+Org Managers are free to configure your org's [quota]({{< relref "docs/pricing/quotas.md" >}}) capacity among your spaces and applications as you see fit. This enables Org Managers to limit usage and corresponding costs.
+
+## Updating a quota
+
+To change your org quota, please have an Org Manager [send a quota change request email](mailto:cloud-gov-inquiries@gsa.gov,cloud-gov-support@gsa.gov?subject=Quota%20change%20request&body=Please%20update%20the%20quota%20for%20the%20following%20organization%3A%0A%0AOrg%20name%3A%20%0AMemory%3A%20%23GB%0AServices%3A%20%23%20or%20no%20change%0ARoutes%3A%20%23%20or%20no%20change"). This email link will pre-populate required information.
+
+### View org quota details
+
+To view your [org quota]({{< relref "docs/pricing/quotas.md" >}}):
+
+1. List the details about your org: `cf org <org>`
+2. Find your quota name from the `quota:` property.
+3. View your quota: `cf quota <quota>`
+
+You can request an increase in number of [application routes]({{< relref "docs/apps/custom-domains.md" >}}) or [service instances]({{< relref "docs/apps/managed-services.md" >}}) with no cost impact. Increasing or decreasing org memory quota changes your maximum usage costs.
+
+### Tracking quota usage
+
+You can use the following `cf` CLI plugins to help identify the right quota to set for your org. They are available from the _CF-Community_ plugin site: `cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org/`
+
+- The [Usage Report plugin](https://github.com/krujos/usagereport-plugin) gives you a report of how your quota is used across visible organizations and spaces. To install: `cf install-plugin 'Usage Report' -r CF-Community`
+
+- The [Statistics plugin](https://github.com/swisscom/cf-statistics-plugin) gives you real-time visibility of the actual memory usage for each application instance compared to the memory limit. To install: `cf install-plugin Statistics -r CF-Community`
+
+You can use these two in combination to get a good sense of where you can lower instance memory limits to make room for more instances elsewhere in your org or just reduce your quota to reduce costs.

--- a/content/docs/orgs-spaces/managing-orgs.md
+++ b/content/docs/orgs-spaces/managing-orgs.md
@@ -1,0 +1,7 @@
+---
+menu:
+  docs:
+    parent: orgs-spaces
+title: Managing orgs and spaces via the dashboard
+---
+

--- a/content/docs/orgs-spaces/managing-orgs.md
+++ b/content/docs/orgs-spaces/managing-orgs.md
@@ -1,7 +1,0 @@
----
-menu:
-  docs:
-    parent: orgs-spaces
-title: Managing orgs and spaces via the dashboard
----
-

--- a/content/docs/orgs-spaces/new-org.md
+++ b/content/docs/orgs-spaces/new-org.md
@@ -1,0 +1,48 @@
+---
+menu:
+  docs:
+    parent: orgs-spaces
+title: Create a new org as an existing customer
+---
+
+## Request a new organization as an existing customer
+
+Existing cloud.gov customers can request an org creation by sending a [new org request email](mailto:cloud-gov-inquiries@gsa.gov,cloud-gov-support@gsa.gov?subject=New%20Org%20Request&body=System%20name%20(e.g.%20org-system)%3A%20%0ASystem%20type%3A%20Prototyping%2C%20FISMA%20Low%2C%20FISMA%20Moderate%0AQuota%3A%20%23GB%0AOrg%20manager%20email%20(project%20manager%20or%20technical%20POC)%3A%20%0ASystem%20owner%20email%20(security%2Fcompliance%20POC)%3A). This email link will pre-populate the required information.
+
+## Required information
+
+To create a new organization through this process, you must be an existing customer and have a current agreement in place. If you'd like to learn more about <>
+
+### Org name
+
+The new organization will be named for both the customer (e.g. "GSA") and the system, such as "CTO" or "18f-federalist". For a prototyping organization, the system name should be "prototyping".
+
+The org and system then are combined with a dash, e.g. "gsa-18f-federalist".
+
+Note: Names cannot contain spaces and should instead use dashes (-).
+
+### System type
+
+The system type is one of the [available packages](/pricing/):
+
+- Prototyping space
+- FISMA Low system
+- FISMA High system
+
+The package and system type reflects the org's intended use and determines price, features, allowable usage, available services, and level of support. For details, see [quota and pricing rates]({{<relref "docs/pricing/quotas.md">}}).
+
+### Quota GB
+
+The quota determines how many GB of memory should initially be available. The quota caps the amount an organization will be charged per month, but an organization is only ever charged for actual usage.
+
+Note: Whole numbers only
+
+### Org Manager email
+
+The Org Manager manages access control for teammates and creates any needed spaces via the [dashboard]({{<relref "dashboard.md">}}).
+
+This should be a person who is responsible for the system and the people who work on it, eg a project manager or technical team lead. An Org Manager should be a person who directly knows who should have access and is willing to maintain those permissions.
+
+### System Owner email
+
+The System Owner is the point-of-contact for any communications about security or compliance issues.

--- a/content/docs/orgs-spaces/new-org.md
+++ b/content/docs/orgs-spaces/new-org.md
@@ -2,16 +2,16 @@
 menu:
   docs:
     parent: orgs-spaces
-title: Create a new org as an existing customer
+title: Create a new org
 ---
 
 ## Request a new organization as an existing customer
 
-Existing cloud.gov customers can request an org creation by sending a [new org request email](mailto:cloud-gov-inquiries@gsa.gov,cloud-gov-support@gsa.gov?subject=New%20Org%20Request&body=System%20name%20(e.g.%20org-system)%3A%20%0ASystem%20type%3A%20Prototyping%2C%20FISMA%20Low%2C%20FISMA%20Moderate%0AQuota%3A%20%23GB%0AOrg%20manager%20email%20(project%20manager%20or%20technical%20POC)%3A%20%0ASystem%20owner%20email%20(security%2Fcompliance%20POC)%3A). This email link will pre-populate the required information.
+To request a new org be created, please [send a new org request email](mailto:cloud-gov-inquiries@gsa.gov,cloud-gov-support@gsa.gov?subject=New%20Org%20Request&body=System%20name%20(e.g.%20org-system)%3A%20%0ASystem%20type%3A%20Prototyping%2C%20FISMA%20Low%2C%20FISMA%20Moderate%0AQuota%3A%20%23GB%0AOrg%20manager%20email%20(project%20manager%20or%20technical%20POC)%3A%20%0ASystem%20owner%20email%20(security%2Fcompliance%20POC)%3A). This email link will pre-populate the required information described below.
 
 ## Required information
 
-To create a new organization through this process, you must be an existing customer and have a current agreement in place. If you'd like to learn more about <>
+To create a new organization through this process, you must be an existing customer and have a current agreement in place.
 
 ### Org name
 

--- a/content/docs/orgs-spaces/new-org.md
+++ b/content/docs/orgs-spaces/new-org.md
@@ -7,7 +7,7 @@ title: Create a new org
 
 ## Request a new organization as an existing customer
 
-To request a new org be created, please [send a new org request email](mailto:cloud-gov-inquiries@gsa.gov,cloud-gov-support@gsa.gov?subject=New%20Org%20Request&body=System%20name%20(e.g.%20org-system)%3A%20%0ASystem%20type%3A%20Prototyping%2C%20FISMA%20Low%2C%20FISMA%20Moderate%0AQuota%3A%20%23GB%0AOrg%20manager%20email%20(project%20manager%20or%20technical%20POC)%3A%20%0ASystem%20owner%20email%20(security%2Fcompliance%20POC)%3A). This email link will pre-populate the required information described below.
+To request a new org be created, please [send a new org request email](mailto:cloud-gov-inquiries@gsa.gov,cloud-gov-support@gsa.gov?subject=New%20Org%20Request&body=System%20name%20(e.g.%20gsa-18f-federalist)%3A%20%0ASystem%20type%3A%20Prototyping%2C%20FISMA%20Low%2C%20FISMA%20Moderate%0AQuota%3A%20%23GB%0AOrg%20manager%20email%20(project%20manager%20or%20technical%20POC)%3A%20%0ASystem%20owner%20email%20(security%2Fcompliance%20POC)%3A). This email link will pre-populate the required information described below.
 
 ## Required information
 


### PR DESCRIPTION
Adds pre-populated mailto links for new org creation and quota change requests. Adds Managing Orgs section for these items as a top-level menu.

<img width="1284" alt="Image showing new Org Request page" src="https://user-images.githubusercontent.com/10235730/71188104-552c9500-224e-11ea-90fa-02b8356aee8a.png">
<img width="1285" alt="Image showing new Quota Change request page" src="https://user-images.githubusercontent.com/10235730/71188105-552c9500-224e-11ea-9593-259238f929d2.png">
