### PR TITLE
Pdb/disa il guide link

### DIFF
--- a/content/docs/compliance/domain-standards.md
+++ b/content/docs/compliance/domain-standards.md
@@ -27,7 +27,7 @@ You are responsible for setting up HSTS preloading for your [custom domain]({{< 
 
 cloud.gov does not currently support DNSSEC on `cloud.gov` domains. For example, an application at `*.app.cloud.gov` would not support DNSSEC.
 
-[OMB memo M-18-230](https://www.whitehouse.gov/wp-content/uploads/2018/08/M-18-23.pdf) rescinds M-08-23, the OMB memo that originally mandated DNSSEC for federal systems. You should consider carefully whether DNSSEC is still a requirement for your system.
+[OMB memo M-18-230, page 12,](https://www.whitehouse.gov/wp-content/uploads/2018/08/M-18-23.pdf) rescinds M-08-23, the OMB memo that originally mandated DNSSEC for federal systems. You should review that memo and consider whether DNSSEC is still a requirement for your system.
 
 If you do need DNSSEC for your custom domain, you are responsible for configuring DNSSEC in your DNS system. cloud.gov can't configure DNSSEC for you because cloud.gov does not have access to your DNS system. 
 

--- a/content/docs/security/fedramp-tracker.md
+++ b/content/docs/security/fedramp-tracker.md
@@ -21,7 +21,7 @@ The **[Federal Risk and Authorization Management Program (FedRAMP)](https://www.
 
 Once that P-ATO is granted, FedRAMP requires cloud.gov to undergo re-assessment every year and maintain continuous monitoring. This gives your agency ongoing assurance that cloud.gov is compliant.
 
-For DoD teams: the Defense Information Systems Agency (DISA) categorizes [FedRAMP Moderate as equivalent to DISA impact level two](http://iasecontent.disa.mil/cloud/SRG/#3INFORMATIONSECURITYOBJECTIVES/IMPACTLEVELS), and they have issued a DoD Provisional Authorization for cloud.gov at DISA impact level two.
+For DoD teams: the Defense Information Systems Agency (DISA) categorizes [FedRAMP Moderate as equivalent to DISA impact level two](https://dl.dod.cyber.mil/wp-content/uploads/cloud/pdf/Cloud_Computing_SRG_v1r3.pdf) and they have issued a DoD Provisional Authorization for cloud.gov at DISA impact level two.
 
 ## How you can use this P-ATO
 
@@ -37,4 +37,4 @@ The [**Control Implementation Summary + Customer Responsibility Matrix + Control
 
 ## Start the ATO process
 
-If you want to use cloud.gov, [**request the P-ATO documentation package from FedRAMP**](https://s3.amazonaws.com/sitesusa/wp-content/uploads/sites/482/2015/03/FedRAMP-Package-Request-Form_V4_06192014.pdf) (the Package ID for that form is F1607067912). You can also view the [FedRAMP Marketplace page for cloud.gov](https://marketplace.fedramp.gov/#/product/18f-cloudgov?sort=productName).
+If you want to authorize cloud.gov, [**request the P-ATO documentation package from FedRAMP**](https://s3.amazonaws.com/sitesusa/wp-content/uploads/sites/482/2015/03/FedRAMP-Package-Request-Form_V4_06192014.pdf) (the Package ID for that form is F1607067912). You can also view the [FedRAMP Marketplace page for cloud.gov](https://marketplace.fedramp.gov/#/product/18f-cloudgov?sort=productName).


### PR DESCRIPTION
Wow: https://iasecontent.disa.mil/cloud/SRG/#3INFORMATIONSECURITYOBJECTIVES/IMPACTLEVELS is gone and the new site has no useful search. Seems what it used to link to is: https://dl.dod.cyber.mil/wp-content/uploads/cloud/pdf/Cloud_Computing_SRG_v1r3.pdf, but I don't know how to find an everfresh link that's not tied to v1r3. Any ideas?