### PR TITLE
No sensitive info in support emails

### DIFF
--- a/content/docs/help.md
+++ b/content/docs/help.md
@@ -13,11 +13,15 @@ If you have a U.S. federal government email address, you can [get access to a fr
 
 ### Support for people who use cloud.gov
 
-Email [**cloud-gov-support@gsa.gov**](mailto:cloud-gov-support@gsa.gov?body=What%20are%20you%20trying%20to%20do%3F%0A%0AWhat%20do%20you%20expect%20to%20happen%3F%0A%0AWhat%20actually%20happened%3F%0A%0AAttach%20relevant%20logs%20or%20screenshots%20%28remove%20sensitive%20information%29%3A). We provide support during business hours for U.S. East and West Coasts. We don't guarantee support outside those hours, though we're always monitoring for issues that might affect customers.
+Email [**support@cloud.gov**](mailto:support@cloud.gov?body=What%20are%20you%20trying%20to%20do%3F%0A%0AWhat%20do%20you%20expect%20to%20happen%3F%0A%0AWhat%20actually%20happened%3F%0A%0AAttach%20relevant%20logs%20or%20screenshots%20%28remove%20sensitive%20information%29%3A). We provide support during business hours for U.S. East and West Coasts. We don't guarantee support outside those hours, though we're always monitoring for issues that might affect customers.
 
-If you need help with an application security incident, the request should come from the System Owner or Org Manager, to help us validate the request.
+If you need help with an application security incident, the request should come from the System Owner or Org Manager, to help us validate the request. You should not include any of the following in your email:
 
-You should not include any passwords or sensitive environment variables in your email (we don't need them to help you, and you should keep them protected).
+* passwords 
+* sensitive environment variables or configuration details
+* specific vulnerablities or exploits
+
+We don’t need such details in our support system to be able to help you.
 
 ### Report a vulnerability
 


### PR DESCRIPTION
Addresses part of https://github.com/18F/cg-private/issues/125

## Changes proposed in this pull request:

- expanded guidance from JAB per: "FedRAMP will not accept data or metadata of the following types in the external services: incident , configuration and vulnerability."

## security considerations

Improve compliance by reminding folks not to post sensitive stuff to our support