### PR TITLE
Clarify that CloudFront is in AWS P-ATO.

### DIFF
--- a/_docs/services/cdn-route.md
+++ b/_docs/services/cdn-route.md
@@ -42,7 +42,7 @@ This service is similar to the [custom domain service]({{ site.baseurl }}/docs/s
 
 ### Compliance impact
 
-When you use cloud.gov in general, your application inherits the compliance of the cloud.gov FedRAMP P-ATO, which inherits compliance from the AWS GovCloud FedRAMP P-ATO. This service is a little different. When you use this service, you opt into using an AWS service (CloudFront) that is not in an AWS FedRAMP P-ATO boundary (see [Services in Scope](https://aws.amazon.com/compliance/services-in-scope/)).
+When you use cloud.gov in general, your application inherits the compliance of the cloud.gov FedRAMP P-ATO, which inherits compliance from the AWS GovCloud FedRAMP P-ATO. This service is a little different. When you use this service, you opt into using an AWS service (CloudFront) that is not in the cloud.gov FedRAMP P-ATO boundary, but is in the AWS Commerical FedRAMP P-ATO boundary (see [Services in Scope](https://aws.amazon.com/compliance/services-in-scope/)).
 
 You are responsible for obtaining appropriate authorization from your agency to use CloudFront for your system. The appropriate steps depend on your agency; they may include discussing this with your Authorizing Official and documenting it as part of your ATO (for example as part of [SC-12](https://nvd.nist.gov/800-53/Rev4/control/SC-12) or [SA-9](https://nvd.nist.gov/800-53/Rev4/control/SA-9)).
 


### PR DESCRIPTION
#1508 can't yet be accepted because CloudFront isn't yet in the cloud.gov boundary. We can specify it is FedRAMP-authorized, and still needs a separate ATO from the provisioning agency.

## Changes proposed in this pull request:


## security considerations

None
