### PR TITLE
From SLA search, link to service objectives

### DIFF
--- a/_docs/overview/customer-service-objectives.md
+++ b/_docs/overview/customer-service-objectives.md
@@ -10,7 +10,7 @@ redirect_from:
 ---
 
 
-The **goal** of Service Objectives (SO) is to publicize our operating procedures and provide transparency about our operation of Cloud.gov.
+The **goal** of Service Objectives (SO) is to publicize our operating procedures and provide transparency about our operation of Cloud.gov. We publish our SOs in lieu of establishing a Service Level Agreement (SLA).
 
 Our **objectives** are: 
 

--- a/_docs/pricing/pricing-terminology.md
+++ b/_docs/pricing/pricing-terminology.md
@@ -23,7 +23,7 @@ A system maps to an [“org” in cloud.gov and Cloud Foundry](http://docs.cloud
 
 ### Support {#support}
 
-“Support” is support to use the platform as intended, on a best-effort basis. We have no existing service-level agreement (SLA). We [publish metrics](https://cloudgov.statuspage.io/) that give agencies the ability to make an informed choice about whether to use cloud.gov or an alternative PaaS solution based on our actual track record.
+“Support” is support to use the platform as intended, on a best-effort basis. We have no existing service-level agreement (SLA). We hold ourselves to [customer service objectives]({{ site.baseurl }}{% link _docs/overview/customer-service-objectives%}) and [publish metrics](https://cloudgov.statuspage.io/) that give agencies the ability to make an informed choice about whether to use cloud.gov or an alternative PaaS solution based on our actual track record.
 
 ### Consulting
 

--- a/_docs/pricing/pricing-terminology.md
+++ b/_docs/pricing/pricing-terminology.md
@@ -23,7 +23,7 @@ A system maps to an [“org” in cloud.gov and Cloud Foundry](http://docs.cloud
 
 ### Support {#support}
 
-“Support” is support to use the platform as intended, on a best-effort basis. We have no existing service-level agreement (SLA). We hold ourselves to [customer service objectives]({{ site.baseurl }}{% link _docs/overview/customer-service-objectives%}) and [publish metrics](https://cloudgov.statuspage.io/) that give agencies the ability to make an informed choice about whether to use cloud.gov or an alternative PaaS solution based on our actual track record.
+“Support” is support to use the platform as intended, on a best-effort basis. We have no existing service-level agreement (SLA). We hold ourselves to [customer service objectives]({{ site.baseurl }}{% link _docs/overview/customer-service-objectives.md %}) and [publish metrics](https://cloudgov.statuspage.io/) that give agencies the ability to make an informed choice about whether to use cloud.gov or an alternative PaaS solution based on our actual track record.
 
 ### Consulting
 


### PR DESCRIPTION
## Changes proposed in this pull request:

If you search for "SLA" on our site, you get this page. So it should link to the nearest thing we have to SLAs, our service objectives.

The service objective page should mention SLA too, since people look for that term.

## security considerations

Doc tweak, not security implications.
