### PR TITLE
add reference to CDN service + cloudfront to SSL/TLS docs

### DIFF
--- a/_docs/compliance/domain-standards.md
+++ b/_docs/compliance/domain-standards.md
@@ -26,7 +26,7 @@ You are responsible for setting up HSTS preloading for your [custom domain]({{ s
 ### SSL/TLS Implementation
 
 Clients connect to cloud.gov through [AWS load balancers](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html)
- which implement the `ELBSecurityPolicy-TLS-1-2-2017-01` SSL/TLS policy. Our TLS implementation and cipher suites are consistent with [White House Office of Management and Budget's M-15-13](https://https.cio.gov/), the Department of Homeland Security's [Binding Operational Directive 18-01](https://cyber.dhs.gov/bod/18-01/), and the [NIST Guidelines for TLS Implementations](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r2.pdf). Some SSL/TLS scanners will nonetheless return results flagging the following ciphers as "weak":
+ which implement the `ELBSecurityPolicy-TLS-1-2-2017-01` SSL/TLS policy, and, when using the CDN Service, through [Amazon CloudFront distributions]](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html#secure-connections-supported-ciphers), which implement the `TLSv1.2_2018` policy. Our TLS implementation and cipher suites are consistent with [White House Office of Management and Budget's M-15-13](https://https.cio.gov/), the Department of Homeland Security's [Binding Operational Directive 18-01](https://cyber.dhs.gov/bod/18-01/), and the [NIST Guidelines for TLS Implementations](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r2.pdf). Some SSL/TLS scanners will nonetheless return results flagging the following ciphers as "weak":
 
 ```
    TLS_RSA_WITH_AES_128_CBC_SHA256 (0x003C)


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add reference to CDN service to SSL/TLS cipher note

## security considerations
None