### PR TITLE
Fix issue with malformed <span>

### DIFF
--- a/_data/pricing.yml
+++ b/_data/pricing.yml
@@ -9,7 +9,7 @@
   image: pricing-sandbox.svg
 - package_name: Prototyping
   description: Self-service workspaces for your organization to build non-production systems.
-  price: <h3><sup>$</sup>1550&#47; month</h3>for entire organization</span>
+  price: <h3><sup>$</sup>1550&#47; month</h3><span>for entire organization</span>
   memory: <sup>$</sup>130 &#47; GB memory per month
   image: pricing-prototype.svg
   production: Non-production systems
@@ -18,7 +18,7 @@
   sign_up: <a href="mailto:inquiries@cloud.gov?subject=Purchasing%20Prototyping%20Package" class="usa-button" id="Prototyping-cta">Contact us</a><br/><a href="/docs/pricing/prototyping/" class="small-link">About Prototyping packages &rarr;</a>
 - package_name: FISMA Low
   description: Production environment ideal for hosting public information.
-  price: <h3><sup>$</sup>2070 &#47; month</h3>FISMA Low system</span>
+  price: <h3><sup>$</sup>2070 &#47; month</h3><span>FISMA Low system</span>
   memory: <sup>$</sup>130 &#47; GB memory per month
   production: One system
   number_of_systems: Multiple environments (e.g. dev, stage, prod) supporting one system


### PR DESCRIPTION
## Changes proposed in this pull request:
- This PR fixes a small issue with the HTML on the pricing page.
- A malformed set of tags causes a raw `</span>` to be displayed in a few places.

<img width="497" alt="broken-span" src="https://user-images.githubusercontent.com/58419/80131963-03cc4380-8569-11ea-86e4-b2c0a3739fce.png">


:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)


## Security Considerations
None. Content change only.
