### PR TITLE
Update continuous deployment page to include GitHub Actions

### DIFF
--- a/_docs/management/continuous-deployment.md
+++ b/_docs/management/continuous-deployment.md
@@ -201,7 +201,6 @@ jobs:
           cf_password: ${{ secrets.CG_PASSWORD }}
           cf_org: your-org
           cf_space: your-space
-
 ```
 
 Note the reference to `cloud-gov/cg-cli-tools@master` in the workflow file above. You can use another workflow file as part of your deployment process if you desire, or add additional steps to your workflow by referencing other GitHub actions.

--- a/_docs/management/continuous-deployment.md
+++ b/_docs/management/continuous-deployment.md
@@ -161,7 +161,7 @@ After following the instructions for setting up a [cloud.gov service account](ht
 
 #### Sample workflow
 
-The following is an example of a workflow that uses this action. This example shows how to deploy a simple [].NET Core app](https://github.com/cloud-gov/cf-hello-worlds/tree/master/dotnet-core) to cloud.gov
+The following is an example of a workflow that uses this action. This example shows how to deploy a simple [.NET Core app](https://github.com/cloud-gov/cf-hello-worlds/tree/master/dotnet-core) to cloud.gov
 
 ```yml
 name: .NET Core Deploy

--- a/_docs/management/continuous-deployment.md
+++ b/_docs/management/continuous-deployment.md
@@ -161,7 +161,7 @@ After following the instructions for setting up a [cloud.gov service account](ht
 
 #### Sample workflow
 
-The following is an example of a workflow that uses this action. This example shows how to deploy a [simple .NET Core app](https://github.com/cloud-gov/cf-hello-worlds/tree/master/dotnet-core) to cloud.gov
+The following is an example of a workflow that uses this action. This example shows how to deploy a simple [].NET Core app](https://github.com/cloud-gov/cf-hello-worlds/tree/master/dotnet-core) to cloud.gov
 
 ```yml
 name: .NET Core Deploy


### PR DESCRIPTION
## Changes proposed in this pull request:
- This PR updates the page on continuous deployment to include an example of how to deploy to cloud.gov using GitHub actions.
- A dead link to an example of how to use Jenkins us updated.

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/update-cd-page/docs/management/continuous-deployment/)

## Security Considerations
None. Content change only.
