### PR TITLE
Changed to docs for external domain broker work

### DIFF
--- a/_data/services.yml
+++ b/_data/services.yml
@@ -5,6 +5,9 @@
 - name: cdn-route
   description: "Custom domains, CDN caching, and TLS certificates with automatic renewal"
   status: "Production"
+- name: external-domain-service
+  description: "Custom domains and TLS certificates with automatic renewal"
+  status: "Production"
 - name: cloud-gov-identity-provider
   description: "Authenticate cloud.gov users in your app"
   status:  "Beta"

--- a/_docs/services/cdn-route.md
+++ b/_docs/services/cdn-route.md
@@ -8,9 +8,7 @@ description: "Custom domains, CDN caching, and TLS certificates with automatic r
 status: "Production Ready"
 ---
 
-<!-- If you're improving this page, try to port the improvements to the custom domain service page too, since most of the text is the same -->
-
-Note: This cloud.gov feature has unique [compliance impact](#compliance-impact) considerations. 
+Note - this service is being deprecated in favor of the [external domain service]({{ site.baseurl }}{% link _docs/services/external-domain-service.md %}). 
 
 This service provides:
 
@@ -18,8 +16,7 @@ This service provides:
 1. HTTPS support via free TLS certificates with auto-renewal (using [Let's Encrypt](https://letsencrypt.org/)), so that user traffic is encrypted.
 1. Content Distribution Network (CDN) caching (using [AWS CloudFront](https://aws.amazon.com/cloudfront/)), for fast delivery of content to your users.
 
-If you don't need CDN caching, use the [custom domain service]({{ site.baseurl }}/docs/services/custom-domains/) instead.
-
+This cloud.gov feature has unique [compliance impact](#compliance-impact) considerations. If you don't need CDN caching, use the [external domain service]({{ site.baseurl }}{% link _docs/services/external-domain-service.md %}) instead.
 
 ## Plans
 

--- a/_docs/services/custom-domains.md
+++ b/_docs/services/custom-domains.md
@@ -8,7 +8,7 @@ description: "Custom domains and TLS certificates with automatic renewal"
 status: "Production Ready"
 ---
 
-<!-- If you're improving this page, try to port the improvements to the CDN route service page too, since most of the text is the same -->
+Note - this service is being deprecated in favor of the [external domain service]({{ site.baseurl }}{% link _docs/services/external-domain-service.md %}).
 
 This service provides:
 

--- a/_docs/services/external-domain-service.md
+++ b/_docs/services/external-domain-service.md
@@ -46,11 +46,13 @@ ALIAS records, but not all DNS providers offer ALIAS records. These are limitati
 ## Options
 
 ### `domain` plan
+
 Name      | Required   | Description                   | Default | Example                           |
 ----------|------------|-------------------------------|---------|-----------------------------------|
 `domains` | *Required* | Your custom domain or domains | (None)  | `my-domain.gov,www.my-domain.gov` |
 
 ### `domain-with-cdn` plan
+
 Name      | Required   | Description                   | Default | Example                           |
 ----------|------------|-------------------------------|---------|-----------------------------------|
 `domains` | *Required* | Your custom domain or domains | (None)  | `my-domain.gov,www.my-domain.gov` |

--- a/_docs/services/external-domain-service.md
+++ b/_docs/services/external-domain-service.md
@@ -1,0 +1,25 @@
+---
+parent: services
+layout: docs
+sidenav: true
+title: External domain service
+name: "external-domain-service"
+description: "Custom domains and TLS certificates with automatic renewal"
+status: "Production Ready"
+---
+
+PLACEHOLDER FOR EXTERNAL DOMAIN SERVICE DOCUMENTATION
+
+## Plans
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+## Options
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Morbi quis commodo odio aenean sed adipiscing diam donec adipiscing. Nisl tincidunt eget nullam non nisi est sit. Sed turpis tincidunt id aliquet risus feugiat. Praesent elementum facilisis leo vel fringilla est. Diam maecenas ultricies mi eget mauris pharetra. Aliquet nec ullamcorper sit amet. Blandit libero volutpat sed cras ornare. Enim sed faucibus turpis in eu mi bibendum neque. Enim ut tellus elementum sagittis vitae et. 
+
+Volutpat consequat mauris nunc congue nisi. Tortor at risus viverra adipiscing at in tellus integer. Adipiscing vitae proin sagittis nisl rhoncus mattis rhoncus urna. Dui vivamus arcu felis bibendum ut tristique et egestas. Tellus in hac habitasse platea dictumst vestibulum. Tellus at urna condimentum mattis pellentesque id. Feugiat nisl pretium fusce id. Turpis egestas sed tempus urna et pharetra pharetra massa.
+
+## How to create an instance of this service
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu non sodales neque sodales. Ipsum dolor sit amet consectetur adipiscing. Aenean et tortor at risus. Velit euismod in pellentesque massa placerat duis ultricies lacus. Tortor dignissim convallis aenean et tortor. Amet aliquam id diam maecenas. Nullam eget felis eget nunc. Tincidunt arcu non sodales neque sodales ut etiam. Neque sodales ut etiam sit amet. Donec enim diam vulputate ut pharetra sit. Senectus et netus et malesuada.

--- a/_docs/services/external-domain-service.md
+++ b/_docs/services/external-domain-service.md
@@ -12,7 +12,10 @@ PLACEHOLDER FOR EXTERNAL DOMAIN SERVICE DOCUMENTATION
 
 ## Plans
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+Plan Name         | Plan Description                                                                      |
+------------------|---------------------------------------------------------------------------------------|
+`domain`          | (Coming soon) Custom domain with automatically renewing ssl certificate.              |
+`domain-with-cdn` | Caching distributed CDN with custom domain and automatically renewing ssl certificate |
 
 ## Options
 

--- a/_docs/services/external-domain-service.md
+++ b/_docs/services/external-domain-service.md
@@ -8,7 +8,14 @@ description: "Custom domains and TLS certificates with automatic renewal"
 status: "Production Ready"
 ---
 
-PLACEHOLDER FOR EXTERNAL DOMAIN SERVICE DOCUMENTATION
+This service provides two different plans allowing you to use custom domains for your apps running on cloud.gov.
+
+Both plans offer:
+1. Custom domain support, so that your application can have your domain instead of the default `*.app.cloud.gov` domain.
+1. HTTPS support via free TLS certificates with auto-renewal (using [Let's Encrypt](https://letsencrypt.org/)), so that user traffic is encrypted.
+
+The domain-with-cdn plan also provides Content Distribution Network (CDN) caching (using [AWS CloudFront](https://aws.amazon.com/cloudfront/)), for
+fast delivery of content to your users.
 
 ## Plans
 
@@ -17,12 +24,83 @@ Plan Name         | Plan Description                                            
 `domain`          | (Coming soon) Custom domain with automatically renewing ssl certificate.              |
 `domain-with-cdn` | Caching distributed CDN with custom domain and automatically renewing ssl certificate |
 
+## Before you use the domain-with-cdn plan
+
+### Compliance impact
+
+When you use cloud.gov in general, your application inherits the compliance of the cloud.gov FedRAMP P-ATO, which inherits compliance from the AWS GovCloud FedRAMP P-ATO. This service is a little different. When you use this service, you opt into using an AWS service (CloudFront) that is not in the cloud.gov FedRAMP P-ATO boundary, but is in the AWS Commerical FedRAMP P-ATO boundary (see [Services in Scope](https://aws.amazon.com/compliance/services-in-scope/)).
+
+You are responsible for obtaining appropriate authorization from your agency to use CloudFront for your system. The appropriate steps depend on your agency; they may include discussing this with your Authorizing Official and documenting it as part of your ATO (for example as part of [SC-12](https://nvd.nist.gov/800-53/Rev4/control/SC-12) or [SA-9](https://nvd.nist.gov/800-53/Rev4/control/SA-9)).
+
+### Technical considerations
+
+Before setting up this service, review [how the CDN works](#more-about-how-the-cdn-works)
+
+## CNAME and ALIAS records
+
+This service requires you to create a CNAME or ALIAS record, and these are slightly different. The exact difference is beyond the scope of this article,
+but what is important to note is that if your domain is an `apex` domain, that is it has only one one dot (e.g. `example.gov`, `my-agency.gov`) you cannot use
+ALIAS records, but not all DNS providers offer ALIAS records. These are limitations in the DNS specification, and not specific to this service. 
+
+
 ## Options
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Morbi quis commodo odio aenean sed adipiscing diam donec adipiscing. Nisl tincidunt eget nullam non nisi est sit. Sed turpis tincidunt id aliquet risus feugiat. Praesent elementum facilisis leo vel fringilla est. Diam maecenas ultricies mi eget mauris pharetra. Aliquet nec ullamcorper sit amet. Blandit libero volutpat sed cras ornare. Enim sed faucibus turpis in eu mi bibendum neque. Enim ut tellus elementum sagittis vitae et. 
+### `domain` plan
+Name      | Required   | Description                   | Default | Example                           |
+----------|------------|-------------------------------|---------|-----------------------------------|
+`domains` | *Required* | Your custom domain or domains | (None)  | `my-domain.gov,www.my-domain.gov` |
 
-Volutpat consequat mauris nunc congue nisi. Tortor at risus viverra adipiscing at in tellus integer. Adipiscing vitae proin sagittis nisl rhoncus mattis rhoncus urna. Dui vivamus arcu felis bibendum ut tristique et egestas. Tellus in hac habitasse platea dictumst vestibulum. Tellus at urna condimentum mattis pellentesque id. Feugiat nisl pretium fusce id. Turpis egestas sed tempus urna et pharetra pharetra massa.
+### `domain-with-cdn` plan
+Name      | Required   | Description                   | Default | Example                           |
+----------|------------|-------------------------------|---------|-----------------------------------|
+`domains` | *Required* | Your custom domain or domains | (None)  | `my-domain.gov,www.my-domain.gov` |
+
 
 ## How to create an instance of this service
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu non sodales neque sodales. Ipsum dolor sit amet consectetur adipiscing. Aenean et tortor at risus. Velit euismod in pellentesque massa placerat duis ultricies lacus. Tortor dignissim convallis aenean et tortor. Amet aliquam id diam maecenas. Nullam eget felis eget nunc. Tincidunt arcu non sodales neque sodales ut etiam. Neque sodales ut etiam sit amet. Donec enim diam vulputate ut pharetra sit. Senectus et netus et malesuada.
+1. For each of the domains you want to add to the service, create a DNS CNAME or ALIAS record in the form `_acme-challenge.${DOMAIN}` with a
+   value `_acme-challenge.${DOMAIN}.external-domains-production.cloud.gov`. For example, if you wanted to set up a service for `www.example.gov` and `example.gov`,
+   you'd start by creating the CNAME or ALIAS records for `_acme-challenge.www.example.gov` with value `_acme-challenge.www.example.gov.external-domains-production.cloud.gov`
+   and a record for `_acme-challenge.example.gov` with value `_acme-challenge.example.gov.external-domains-production.cloud.gov`. These will be validated upon
+   service creation, so be sure to set these up ahead of time.
+2. Optional: Complete this step now only for sites that have not yet lauched, or for sites that can withstand downtime. For each of the domains you want to add to
+   the service, create a DNS CNAME or ALIAS record in the form `${DOMAIN}.external-domains-production.cloud.gov`. For example, if you wanted to set up a service for 
+   `www.example.gov` and `example.gov`, you'd create an ALIAS record for `www.example.gov` with value `www.example.gov.external-domains-production.cloud.gov` and an
+   ALIAS record for `example.gov` with value `example.gov.external-domains-production.cloud.gov`
+3. Create the service. For example, with `example.gov` and `www.example.gov`, run:
+   ```
+   $ cf create-service external-domain domain-with-cdn my-cdn -c '{"domains": "example.gov,www.example.gov"}'
+    Creating service instance my-cdn in org my-org / space my-service as me...
+    OK
+
+    Create in progress. Use 'cf services' or 'cf service my-cdn' to check operation status.
+   ``` 
+4. Wait for the service instance to complete provisioning. The `domain-with-cdn` plan may take up to 2 hours to complete provisioning, the `domain` plan should
+   complete within an hour. You can check the status by running `cf service <service instance name>`
+5. If you didn't complete step 2 above, do so now.
+
+
+
+## More about how the CDN works
+
+### Caching
+
+CloudFront [uses](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html)
+your application's `Cache-Control` or `Expires` HTTP headers to determine how
+long to cache content. If your application does not provide these headers,
+CloudFront will use a default timeout of **24 hours**. This can be
+particularly confusing as different requests might be routed to different
+CloudFront Edge endpoints.
+
+While there is no mechanism for cloud.gov users to trigger a cache clear,
+[cloud.gov support]({{ site.baseurl }}/docs/help/) can. Cache invalidation is not
+instantaneous; Amazon recommends expecting a lag time of 10-15 minutes (more if there are
+many distinct endpoints).
+
+### Authentication
+
+Cookies are passed through the CDN by default, meaning that cookie-based authentication will work as expected.
+
+#### Header forwarding
+
+CloudFront forwards a [limited set of headers](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-headers-behavior) by default. 

--- a/_docs/services/external-domain-service.md
+++ b/_docs/services/external-domain-service.md
@@ -45,13 +45,13 @@ ALIAS records, but not all DNS providers offer ALIAS records. These are limitati
 
 ## Options
 
-### `domain` plan
+`domain` plan
 
 Name      | Required   | Description                   | Default | Example                           |
 ----------|------------|-------------------------------|---------|-----------------------------------|
 `domains` | *Required* | Your custom domain or domains | (None)  | `my-domain.gov,www.my-domain.gov` |
 
-### `domain-with-cdn` plan
+`domain-with-cdn` plan
 
 Name      | Required   | Description                   | Default | Example                           |
 ----------|------------|-------------------------------|---------|-----------------------------------|

--- a/_docs/services/external-domain-service.md
+++ b/_docs/services/external-domain-service.md
@@ -45,17 +45,17 @@ ALIAS records, but not all DNS providers offer ALIAS records. These are limitati
 
 ## Options
 
-`domain` plan
+### `domain` plan
 
-Name      | Required   | Description                   | Default | Example                           |
-----------|------------|-------------------------------|---------|-----------------------------------|
-`domains` | *Required* | Your custom domain or domains | (None)  | `my-domain.gov,www.my-domain.gov` |
+Name      | Required   | Description                   | Example                           |
+----------|------------|-------------------------------|-----------------------------------|
+`domains` | *Required* | Your custom domain or domains | `my-domain.gov,www.my-domain.gov` |
 
-`domain-with-cdn` plan
+### `domain-with-cdn` plan
 
-Name      | Required   | Description                   | Default | Example                           |
-----------|------------|-------------------------------|---------|-----------------------------------|
-`domains` | *Required* | Your custom domain or domains | (None)  | `my-domain.gov,www.my-domain.gov` |
+Name      | Required   | Description                   | Example                           |
+----------|------------|-------------------------------|-----------------------------------|
+`domains` | *Required* | Your custom domain or domains | `my-domain.gov,www.my-domain.gov` |
 
 
 ## How to create an instance of this service
@@ -65,10 +65,12 @@ Name      | Required   | Description                   | Default | Example      
    you'd start by creating the CNAME or ALIAS records for `_acme-challenge.www.example.gov` with value `_acme-challenge.www.example.gov.external-domains-production.cloud.gov`
    and a record for `_acme-challenge.example.gov` with value `_acme-challenge.example.gov.external-domains-production.cloud.gov`. These will be validated upon
    service creation, so be sure to set these up ahead of time.
+
 2. Optional: Complete this step now only for sites that have not yet lauched, or for sites that can withstand downtime. For each of the domains you want to add to
    the service, create a DNS CNAME or ALIAS record in the form `${DOMAIN}.external-domains-production.cloud.gov`. For example, if you wanted to set up a service for 
    `www.example.gov` and `example.gov`, you'd create an ALIAS record for `www.example.gov` with value `www.example.gov.external-domains-production.cloud.gov` and an
    ALIAS record for `example.gov` with value `example.gov.external-domains-production.cloud.gov`
+
 3. Create the service. For example, with `example.gov` and `www.example.gov`, run:
    ```
    $ cf create-service external-domain domain-with-cdn my-cdn -c '{"domains": "example.gov,www.example.gov"}'
@@ -77,8 +79,10 @@ Name      | Required   | Description                   | Default | Example      
 
     Create in progress. Use 'cf services' or 'cf service my-cdn' to check operation status.
    ``` 
+
 4. Wait for the service instance to complete provisioning. The `domain-with-cdn` plan may take up to 2 hours to complete provisioning, the `domain` plan should
    complete within an hour. You can check the status by running `cf service <service instance name>`
+   
 5. If you didn't complete step 2 above, do so now.
 
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Doc changes to correspond with work to release new [external domain broker service](https://github.com/cloud-gov/external-domain-broker/issues/63).
- Add deprecation note to the top of the custom domain and CDN service pages.
- Add new page for external domain broker with placeholder text.
- Update service listing YAML file.

## Security Considerations
None - content change only.
