### PR TITLE
Update database backup and restoration guides

### DIFF
--- a/_docs/ops/runbook/restoring-rds.md
+++ b/_docs/ops/runbook/restoring-rds.md
@@ -97,7 +97,9 @@ Finally, rename the new instance to be just `<instance name>` so it matches what
 
 When the restore is completely finished, notify the tenant and ask them to confirm that their application(s) is still functioning properly and that the data is properly restored.  Help them troubleshoot any other issues if there is anything still wrong.
 
-Once we receive confirmation that the restore has been completed successfully, coordinate with the tenant when it is appropriate to remove the old instance, particularly if it is needed for a security audit or forensic analysis.  This is important as we do not want old database instances hanging around, which contribute to extraneous overhead costs.
+Once we receive confirmation that the restore has been completed successfully, we must coordinate with the tenant when it is appropriate to remove the old instance and set a specific date and time to do so, particularly if it is needed for a security audit or forensic analysis.  This is important as we do not want old database instances hanging around, which contribute to extraneous overhead costs.
+
+Work with the tenant to come to a firm agreed upon date and time that the old database instance will be removed.  Be sure to also remind them that no backups or snapshots will be saved either unless they are explicitly requested.
 
 ## Platform Databases
 

--- a/_docs/ops/runbook/restoring-rds.md
+++ b/_docs/ops/runbook/restoring-rds.md
@@ -28,11 +28,11 @@ In order to perform a restore, we need the following information from the custom
 
 Be sure to confirm this information and remind them that a restoration may result in a brief period of downtime with database connectivity.  Ask if they have some way of shutting off access/enabling a maintenance mode of the website and if so, they should do so prior to the restoration process starting.
 
-If the customer agrees to proceed given this information, coordinate with them on the date and time to perform the restore and with which PITR (point in time restore) or snapshot to use.  At the agreed upon date and time, continue with the steps below.
+If the tenant agrees to proceed given this information, coordinate with them on the date and time to perform the restore and with which PITR (point in time restore) or snapshot to use.  At the agreed upon date and time, continue with the steps below.
 
 ### Identify RDS Hostname
 
-Once the tenant agreed to a database restore, identify the RDS instance attached to the application using the information they provided:
+Once the tenant agrees to a database restore, identify the RDS instance attached to the application using the information that they provide:
 
 ```sh
 cf target -s SPACE -o ORGANIZATION
@@ -46,14 +46,13 @@ The JSON containing the environment variables contains the `database identifier`
 Refer to the [RDS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RestoreFromSnapshot.html) for restoring a database.
 
 Prior to restoring, record the configuration settings of the existing instance:
-- Database publicly accessible from the internet (yes/no)
 - Instance size (m4.large, etc.)
 - Multi-zone (yes/no)
 - VPC (dev, staging, etc.)
 - Security Groups
 - Master password (this is the `password` you saw above in the application environment variables)
 
-Copy all of these values and configure them in the restore form to mirror the configuration of the existing database instance.  For the `identifier` name, provide a name like `<instance name>-<date>-restore` to make the instance easy to find.
+Copy all of these values and configure them in the restore form to mirror the configuration of the existing database instance.  For the `identifier` name, provide a name like `<instance name>-<date>-restore` to make the instance easy to find.  Note that the database should never be set to publicly accessible.
 
 Once the restore has finished, confirm the new instance matches the previous configuration.  To update a configuration setting, click 'Modify' from the RDS console instance view and make the required modifications.
 

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -130,6 +130,9 @@ When you do [contact support](mailto:support@cloud.gov) with a database backup r
 - Your organization name
 - The space you are working within
 - The name of the application(s) connected to the database service you need a restoration performed on
+- Phone numbers and contact information if it's an urgent situation
+
+Please do *not* share any passwords or details of any exploit or compromise.  We'll call you if necessary, and we'll never ask you for a password over the phone.
 
 We'll confirm this information and remind you that a restoration may result in a brief period of downtime with database connectivity.  Once we receive confirmation from you to proceed, we'll perform the restore, which results in a new DB instance being created in AWS RDS.  cloud.gov support will take care of renaming the new instance and configuring it with the same VPC and security group as the old instance in AWS so that it can still be found by your bound application(s) once the restoration is complete.
 

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -121,7 +121,11 @@ The contents of the `DATABASE_URL` environment variable contain the credentials 
 
 For shared plans (`shared-psql` and `shared-mysql`), RDS does not back up your data.
 
-For dedicated plans, RDS automatically retains daily backups for 14 days. These backups are AWS RDS storage volume snapshots, backing up the entire DB instance and not just individual databases. If you need to have a database restored using one of these backups, you can [email support](mailto:support@cloud.gov) with the following information:
+For dedicated plans, RDS automatically retains daily backups for 14 days. These backups are AWS RDS storage volume snapshots, backing up the entire DB instance and not just individual databases. If you need to have a database restored using one of these backups, you can [email support](mailto:support@cloud.gov).  For non-emergency situations, please provide at least 48 hours advance notice.
+
+If you have an emergency situation, such as data loss or a compromised system, please [email support](mailto:support@cloud.gov) immediately and inform us of the situation.
+
+When you do [contact support](mailto:support@cloud.gov) with a database backup request, please include the following information:
 
 - Your organization name
 - The space you are working within

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -117,38 +117,44 @@ In short, `cf bind-service` will provide a `DATABASE_URL` environment variable f
 
 The contents of the `DATABASE_URL` environment variable contain the credentials to access your database. Treat the contents of this and all other environment variables as sensitive.
 
+## Backups
+
+For shared plans (`shared-psql` and `shared-mysql`), RDS does not back up your data.
+
+For dedicated plans, RDS automatically retains daily backups for 14 days. These backups are AWS RDS storage volume snapshots, backing up the entire DB instance and not just individual databases. If you need to have a database restored using one of these backups, you can [email support](mailto:support@cloud.gov) with the following information:
+
+- Your organization name
+- The space you are working within
+- The name of the application(s) connected to the database service you need a restoration performed on
+
+We'll confirm this information and remind you that a restoration may result in a brief period of downtime with database connectivity.  Once we receive confirmation from you to proceed, we'll perform the restore, which results in a new DB instance being created in AWS RDS.  cloud.gov support will take care of renaming the new instance and configuring it with the same VPC and security group as the old instance in AWS so that it can still be found by your bound application(s) once the restoration is complete.
+
+When the restore process is completely finished, we'll notify you and ask you to confirm that your application(s) is still functioning properly and that the data is properly restored.  We'll also coordinate with you to determine when it would be appropriate to remove the old instance, particularly if it is needed for something such as a security audit or forensic analysis.
+
+You can also create manual backups using the [export process](#export) described below. In general, you are responsible for making sure that your backup procedures are adequate for your needs; see CP-9 in the cloud.gov SSP.
+
 ## Access the data in the database
 
-There are currently two ways to access the database directly.
+To access a service database, use the [cf-service-connect plugin](https://github.com/18F/cf-service-connect#readme) and the corresponding CLI (command line interface) tools for the database service you are using.
 
-1. [The `cg-migrate-db` plugin](#cg-migrate-db-plugin). It is a self contained
-executable which will interactively assist with accessing the data in the
-database. It supports accessing data from different types of databases.
-1. [Manually accessing the database](#manually-access-a-database). This way
-requires manually downloading the tool(s) needed to access the database.
-
-### cg-migrate-db plugin
-You can access the data in your database via the `cg-migrate-db`
-plugin. See the [repository](https://github.com/18F/cg-migrate-db)
-for instructions on how to install the plugin, backup data, import data,
-download a local copy of the data, and upload a local copy of the data.
-
-### Manually access a database
-
-#### Using cf ssh
-
-To access a service database, use the [cf-service-connect plugin](https://github.com/18F/cf-service-connect#readme).
-
-### Export
-
-#### Create backup
+### Exporting a database
 
 The instructions below are for PostgreSQL, but should be similar for MySQL or others.
 
-First, connect to an instance using the [cf-service-connect plugin](https://github.com/18F/cf-service-connect#readme):
+First, open a terminal and connect to an instance using the [cf-service-connect plugin](https://github.com/cloud-gov/cf-service-connect#usage) to create a SSH tunnel:
 
 ```sh
-$ cf connect-to-service --no-client ${APP_NAME} ${SERVICE_NAME}
+# Find the aws-rds service you are targeting in the services list and make note of the service's name
+$ cf services
+
+# Check to see if a SERVICE_CONNECT service key already exists for the service.
+$ cf service-keys ${SERVICE_NAME}
+
+# If a key exists, remove it first before starting.
+$ cf delete-service-key ${SERVICE_NAME} SERVICE_CONNECT
+
+# Now open the SSH tunnel
+$ cf connect-to-service -no-client ${APP_NAME} ${SERVICE_NAME}
 ...
 Host: localhost
 Port: ...
@@ -157,66 +163,27 @@ Password: ...
 Name: ...
 ```
 
-Without closing the SSH session managed by the cf-service-connect plugin, create the backup file using the parameters provided by the plugin:
+Once the SSH tunnel is created keep it running and open a separate terminal session in another window/tab, then create the backup file using the parameters provided by the plugin in the new terminal session, e.g. (be sure to tailor the backup/export command to your specific needs):
 
 ```sh
-$ pg_dump postgresql://${USERNAME}:${PASSWORD}@${HOST}:${PORT}/${NAME} -f backup.pg
+$ pg_dump -F c --no-acl --no-owner -f backup.pg postgresql://${USERNAME}:${PASSWORD}@${HOST}:${PORT}/${NAME}
 ```
 
-### Download
+This will create the `backup.pg` file on your local machine in whatever your current working directory is.
 
-> [Documentation for using scp and sftp](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#other-ssh-access)
-
-On your local host:
-
-Get your app's GUID:
+When you are finished, you can terminate the SSH tunnel.  You should also clean up the `SERVICE_KEY` created by the cf-service-connect plugin so that you are able to reconnect in the future:
 
 ```sh
-$ cf app {app name} --guid
+$ cf delete-service-key ${SERVICE_NAME} SERVICE_CONNECT
 ```
 
-Obtain a one-time authorization code:
+### Restoring to a local database
 
-```sh
-$ cf ssh-code
-```
-
-Run `sftp` or `scp` to transfer files to/from an application instance.  You must specify port 2222 and supply the app GUID and instance number.  Use the one-time authorization from above as the password.  The username format is `cf:GUID/INSTANCE`.
-
-For example, to connect to instance 0 of the application with GUID 0745e60b-c7f3-49a7-a6c2-878516a34796:
-
-```sh
-$ sftp -P 2222 cf:0745e60b-c7f3-49a7-a6c2-878516a34796/0@ssh.fr.cloud.gov
-cf:0745e60b-c7f3-49a7-a6c2-878516a34796/0@ssh.fr.cloud.gov's password: ******
-Connected to ssh.fr.cloud.gov.
-sftp> get backup.pg
-sftp> quit
-```
-
-### Restore to local database
-
-Load the dump into your local database using the [pg_restore](https://www.postgresql.org/docs/current/static/app-pgrestore.html) tool. If objects exist in a
-local copy of the database already, you might run into inconsistencies when doing a
-`pg_restore`. This pg_restore invocation does not drop all of the objects in the database when loading the
-dump.
+Continuing with the PostgreSQL example and the `backup.pg` file, load the dump into your local database using the [pg_restore](https://www.postgresql.org/docs/current/static/app-pgrestore.html) tool. If objects exist in a local copy of the database already, you might run into inconsistencies when doing a `pg_restore`. This pg_restore invocation does not drop all of the objects in the database when loading the dump:
 
 ```sh
 $ pg_restore --clean --no-owner --no-acl --dbname={database name} backup.pg
 ```
-
-## Backups
-
-For shared plans (`shared-psql` and `shared-mysql`), RDS does not back up your
-data. For dedicated plans, RDS automatically retains daily backups for 14 days.
-These backups are AWS RDS storage volume snapshot, backing up the entire DB
-instance and not just individual databases. You can [email
-support](mailto:support@cloud.gov) to access that backup if you need to
-as a separate RDS instance. You will be responsible for exporting and importing
-the data from this snapshot into your existing database.
-You can also create manual backups using the [export process](#export) described
-above. In general, you are responsible for making sure that your backup
-procedures are adequate for your needs; see CP-9 in the
-cloud.gov SSP.
 
 ## Encryption
 

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -121,7 +121,7 @@ The contents of the `DATABASE_URL` environment variable contain the credentials 
 
 *Please note that these instructions will change in the future as we expand our service offerings and provide more options for customers.*
 
-For shared plans (`shared-psql` and `shared-mysql`), RDS does not back up your data.
+For shared plans (`shared-psql` and `shared-mysql`), cloud.gov and RDS does not back up your data. These are only intended for limited use development and testing instances.
 
 For dedicated plans, RDS automatically retains daily backups for 14 days. These backups are AWS RDS storage volume snapshots, backing up the entire DB instance and not just individual databases. If you need to have a database restored using one of these backups, you can [email support](mailto:support@cloud.gov).  For non-emergency situations, please provide at least 48 hours advance notice.
 
@@ -139,6 +139,8 @@ When you do [contact support](mailto:support@cloud.gov) with a database backup r
 We'll confirm this information and remind you that a restoration may result in a brief period of downtime with database connectivity.  Once we receive confirmation from you to proceed, we'll perform the restore, which results in a new DB instance being created in AWS RDS.  cloud.gov support will take care of renaming the new instance and configuring it with the same VPC and security group as the old instance in AWS so that it can still be found by your bound application(s) once the restoration is complete.
 
 When the restore process is completely finished, we'll notify you and ask you to confirm that your application(s) is still functioning properly and that the data is properly restored.  We'll also coordinate with you to determine when it would be appropriate to remove the old instance, particularly if it is needed for something such as a security audit or forensic analysis.
+
+When we remove the old database instance, we will not retain snapshots or backups of it unless we're explicitly asked to do so.  We'll remind you of this when coordinating a specific date and time to remove the old instance.
 
 You can also create manual backups using the [export process](#exporting-a-database) described below. In general, you are responsible for making sure that your backup procedures are adequate for your needs; see CP-9 in the cloud.gov SSP.
 

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -131,7 +131,7 @@ We'll confirm this information and remind you that a restoration may result in a
 
 When the restore process is completely finished, we'll notify you and ask you to confirm that your application(s) is still functioning properly and that the data is properly restored.  We'll also coordinate with you to determine when it would be appropriate to remove the old instance, particularly if it is needed for something such as a security audit or forensic analysis.
 
-You can also create manual backups using the [export process](#export) described below. In general, you are responsible for making sure that your backup procedures are adequate for your needs; see CP-9 in the cloud.gov SSP.
+You can also create manual backups using the [export process](#exporting-a-database) described below. In general, you are responsible for making sure that your backup procedures are adequate for your needs; see CP-9 in the cloud.gov SSP.
 
 ## Access the data in the database
 

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -119,6 +119,8 @@ The contents of the `DATABASE_URL` environment variable contain the credentials 
 
 ## Backups
 
+*Please note that these instructions will change in the future as we expand our service offerings and provide more options for customers.*
+
 For shared plans (`shared-psql` and `shared-mysql`), RDS does not back up your data.
 
 For dedicated plans, RDS automatically retains daily backups for 14 days. These backups are AWS RDS storage volume snapshots, backing up the entire DB instance and not just individual databases. If you need to have a database restored using one of these backups, you can [email support](mailto:support@cloud.gov).  For non-emergency situations, please provide at least 48 hours advance notice.
@@ -132,7 +134,7 @@ When you do [contact support](mailto:support@cloud.gov) with a database backup r
 - The name of the application(s) connected to the database service you need a restoration performed on
 - Phone numbers and contact information if it's an urgent situation
 
-Please do *not* share any passwords or details of any exploit or compromise.  We'll call you if necessary, and we'll never ask you for a password over the phone.
+**Please *do not* share any passwords or details of any exploit or compromise.**  We'll call you if necessary, and we'll never ask you for a password over the phone.
 
 We'll confirm this information and remind you that a restoration may result in a brief period of downtime with database connectivity.  Once we receive confirmation from you to proceed, we'll perform the restore, which results in a new DB instance being created in AWS RDS.  cloud.gov support will take care of renaming the new instance and configuring it with the same VPC and security group as the old instance in AWS so that it can still be found by your bound application(s) once the restoration is complete.
 

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -148,16 +148,6 @@ The instructions below are for PostgreSQL, but should be similar for MySQL or ot
 First, open a terminal and connect to an instance using the [cf-service-connect plugin](https://github.com/cloud-gov/cf-service-connect#usage) to create a SSH tunnel:
 
 ```sh
-# Find the aws-rds service you are targeting in the services list and make note of the service's name
-$ cf services
-
-# Check to see if a SERVICE_CONNECT service key already exists for the service.
-$ cf service-keys ${SERVICE_NAME}
-
-# If a key exists, remove it first before starting.
-$ cf delete-service-key ${SERVICE_NAME} SERVICE_CONNECT
-
-# Now open the SSH tunnel
 $ cf connect-to-service -no-client ${APP_NAME} ${SERVICE_NAME}
 ...
 Host: localhost
@@ -167,7 +157,15 @@ Password: ...
 Name: ...
 ```
 
-Once the SSH tunnel is created keep it running and open a separate terminal session in another window/tab, then create the backup file using the parameters provided by the plugin in the new terminal session, e.g. (be sure to tailor the backup/export command to your specific needs):
+If this fails to open a SSH tunnel, try deleting any existing `connect-to-service` service keys first:
+
+```sh
+$ cf delete-service-key ${SERVICE_NAME} SERVICE_CONNECT
+```
+
+Then try the previous step again.
+
+Once the SSH tunnel is created, keep it running in that terminal window and open a separate terminal session in another window/tab, then create the backup file using the parameters provided by the plugin in the new terminal session, e.g. (be sure to tailor the backup/export command to your specific needs):
 
 ```sh
 $ pg_dump -F c --no-acl --no-owner -f backup.pg postgresql://${USERNAME}:${PASSWORD}@${HOST}:${PORT}/${NAME}


### PR DESCRIPTION
Resolves https://github.com/cloud-gov/product/issues/1381 - I'm flagging the team for review due to the multiple touch points on the site that are customer and internal facing, but I'd appreciate 👀 especially from @pburkholder and at least one operator.

This changeset updates both the customer documentation and our operator runbook for database backups and restores with AWS RDS.  It clearly lays out how the backup and restoration process works, what information is needed, and how to perform the steps required to complete the work.

Includes work from PR https://github.com/cloud-gov/cg-site/pull/1692 from @apburnes that details how to perform the steps in AWS RDS and verify the restore worked properly.

For customers, there is expanded information on how to connect directly to a database service and perform manual backups for local restores.

## Changes proposed in this pull request:
- Update customer documentation for database backups and restores
- Expand customer documentation for connecting to database services directly and performing manual backups
- Update cloud.gov operator runbook with clearer steps for performing customer database restores

:sunglasses: [PREVIEW URL - Customer Documentation](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/update-db-restore-documentation/docs/services/relational-database/)
:sunglasses: [PREVIEW URL - Operator Runbook](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/update-db-restore-documentation/docs/ops/runbook/restoring-rds/)

## Security Considerations
None; this is public knowledge of existing information that is now consolidated and easier to understand.

However, I did shy away from adding steps on how a customer can perform a database restoration across spaces (environments).  I feel that is a situation better suited for hands-on customer support as there are caveats with copying production data to non-production environments and the fact that there is downtime involved.

I'd rather we educate and walk customers through that process directly first, but I'm not opposed to adding the steps if others feel different (there is at least [one example](https://github.com/fecgov/fec-cms/wiki/Backup-or-Restore-Wagtail-PostgreSQL-database-in-dev,-staging,-or-production) of a customer knowing how to do this already).