### PR TITLE
269 inheritable controls not supported by CIS

### DIFF
--- a/_docs/overview/cloudgov-benefits.md
+++ b/_docs/overview/cloudgov-benefits.md
@@ -28,8 +28,6 @@ cloud.gov enforces an immutable infrastructure. Instead of logging into a live s
 
 cloud.gov has a [Provisional Authority to Operate (P-ATO) at the Moderate impact level from the FedRAMP Joint Authorization Board (JAB)]({{ site.baseurl }}{% link _docs/overview/fedramp-tracker.md %}). When you deploy a system on cloud.gov, you can [leverage this P-ATO](https://www.fedramp.gov/faqs/) as part of your agency ATO.
 
-Out of the 325 security controls required for Moderate-impact systems, cloud.gov handles 269 controls, and 41 controls are a shared responsibility (where cloud.gov provides part of the requirement, and your applications provide the rest). You only need to provide full implementations for the remaining 15 controls, such as ensuring you make data backups and using reliable DNS (Domain Name System) name servers for your websites.
-
 ## 3. Usability
 
 A Platform as a Service (PaaS) like cloud.gov can save you the resources of managing your own cloud deployments, but it has to work the way you need it to work. cloud.gov was built inside a government development environment by government developers. We face similar security and compliance requirements to the ones that other government teams do, and our coworkers on other teams deploy their applications on cloud.gov. We know first-hand that it works for government teams.

--- a/_docs/overview/fedramp-tracker.md
+++ b/_docs/overview/fedramp-tracker.md
@@ -32,7 +32,7 @@ Once that P-ATO is granted, FedRAMP requires cloud.gov to undergo re-assessment 
 
 Your agency still needs to grant your system an Authority to Operate, but FedRAMP has done the labor-intensive work of reviewing cloud.gov's security posture and endorsed it, which reduces the compliance work you need to do. Your agency's authorizing official can request the P-ATO documentation package from FedRAMP and accept that endorsement for your own system. See [ATO process]({{ site.baseurl }}{% link _docs/compliance/ato-process.md %}) for the typical workflow.
 
-Here's how it works: Every "moderate" impact federal system is required to account for a baseline of about 325 controls before it can be granted an ATO. The cloud.gov platform provides you with 269 inheritable controls (179 implemented by our team, 90 that we inherit from Amazon Web Services). Once cloud.gov's P-ATO is reviewed and accepted, many of those requirements are already implemented and documented. Of the remaining requirements, responsibility for most of the rest are shared between cloud.gov and your application, and only some of them are fully yours.
+Here's how it works: Every "moderate" impact federal system is required to account for a baseline of about 325 controls before it can be granted an ATO. Once cloud.gov's P-ATO is reviewed and accepted, many of those requirements are already implemented and documented. Of the remaining requirements, responsibility for most of the rest are shared between cloud.gov and your application, and only some of them are fully yours.
 
 Here's an example of a control breakdown for a simple moderate-impact system hosted on cloud.gov:
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove reference to dated 269 inheritable controls
- That number is [from 2017](https://docs.google.com/document/d/1kDJdaPw7DSBPSa-XH-YsQpJVOmRKSK8sAghNhPFpegE/edit#heading=h.pwjdn2m255at) and is not supported by our current CIS.
- CIS needs updating
- See also  [discussion in Slack for more contex](https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1592257228427500)t

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)


## Security Considerations

Removes outdated documentation, no security implications.
