### PR TITLE
add deprecation note to dead brokers

### DIFF
--- a/_docs/services/cdn-route.md
+++ b/_docs/services/cdn-route.md
@@ -2,13 +2,15 @@
 parent: services
 layout: docs
 sidenav: true
-title: CDN service
+title: CDN service (deprecated)
 name: "cdn-route"
 description: "Custom domains, CDN caching, and TLS certificates with automatic renewal"
 status: "Production Ready"
 ---
 
-Note - this service is being deprecated in favor of the [external domain service]({{ site.baseurl }}{% link _docs/services/external-domain-service.md %}). 
+## Deprecated
+Note - this service has been deprecated. No new instances can be created on this broker, but existing instances will continue to work.
+For new services, please use the [external domain service]({{ site.baseurl }}{% link _docs/services/external-domain-service.md %}).
 
 This service provides:
 

--- a/_docs/services/custom-domains.md
+++ b/_docs/services/custom-domains.md
@@ -2,13 +2,14 @@
 parent: services
 layout: docs
 sidenav: true
-title: Custom domain service
+title: Custom domain service (deprecated)
 name: "custom-domain"
 description: "Custom domains and TLS certificates with automatic renewal"
 status: "Production Ready"
 ---
-
-Note - this service is being deprecated in favor of the [external domain service]({{ site.baseurl }}{% link _docs/services/external-domain-service.md %}).
+## Deprecated
+Note - this service has been deprecated. No new instances can be created on this broker, but existing instances will continue to work.
+For new services, please use the [external domain service]({{ site.baseurl }}{% link _docs/services/external-domain-service.md %}).
 
 This service provides:
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add warning that these brokers can no longer be used


:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/shut-down-old-brokers)


## Security Considerations
None