### PR TITLE
free-sandox redirects need trailing slash for anchors

### DIFF
--- a/_docs/pricing/free-limited-sandbox.md
+++ b/_docs/pricing/free-limited-sandbox.md
@@ -5,8 +5,8 @@ sidenav: true
 title: Try a free sandbox space
 weight: -10
 redirect_from:
-  - /overview/pricing/free-limited-sandbox
-  - /docs/pricing/free-limited-sandbox
+  - /overview/pricing/free-limited-sandbox/
+  - /docs/pricing/free-limited-sandbox/
 ---
 
 A sandbox is a free space that you can use to see if cloud.gov might suit your team’s needs. From the [setup process]({{ site.baseurl }}{% link _docs/getting-started/setup.md %}) through [deploying an app]({{ site.baseurl }}{% link _docs/getting-started/your-first-deploy.md %}), it works similarly to other spaces that are included in [paid access packages]({{ site.baseurl }}/pricing/), with [some limitations](#sandbox-limitations).


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Redirects need trailing slash for anchors
- Fixes 404 for link in email:  https://cloud.gov/overview/pricing/free-limited-sandbox/#to-keep-in-mind-before-you-try-your-sandbox 

Thanks to Anthony Martini (github username to come)

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/peterb/sbox-redirs)


## Security Considerations

None. 
