### PR TITLE
Update to remove HTTP only comment

### DIFF
--- a/_docs/services/s3.md
+++ b/_docs/services/s3.md
@@ -130,9 +130,7 @@ If you plan to enable "website mode" for the bucket and use it that way, you wil
 
 * `http://${BUCKET_NAME}.s3-website-${AWS_DEFAULT_REGION}.amazonaws.com/`
 
-Note that "website mode" URLs don't support HTTPS, and they aren't appropriate for production use unless fronted by a CloudFront distribution.
-
-Either way, if the bucket is private, attempting to access resources will result in `AccessDenied` errors unless your application generates [pre-signed URLs](http://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html) for objects that need to be shared.
+Note, if the bucket is private, attempting to access resources will result in `AccessDenied` errors unless your application generates [pre-signed URLs](http://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html) for objects that need to be shared.
 
 ### Allowing client-side web access from external applications
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Just a .md update because HTTPS is actually available when using the HTTP option to access an s3 bucket  (i.e. outside of using the s3 protocol itself).

## Security Considerations
None.
