### PR TITLE
Update relational-database.md

### DIFF
--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -21,6 +21,7 @@ Plan Name                | Description                                          
 `medium-psql-redundant`  | Dedicated redundant medium RDS PostgreSQL DB instance                        | AWS RDS Latest   |
 `large-psql`             | Dedicated large RDS PostgreSQL DB instance                                   | AWS RDS Latest   |
 `large-psql-redundant`   | Dedicated redundant large RDS PostgreSQL DB instance                         | AWS RDS Latest   |
+`xlarge-psql-redundant`  | Dedicated redundant xlarge RDS PostgreSQL DB instance                        | AWS RDS Latest   |
 `shared-mysql`           | Shared MySQL database for prototyping (no sensitive or production data)      | 5.6.27           |
 `small-mysql`            | Dedicated small RDS MySQL DB instance                                        | 5.7.21           |
 `medium-mysql`           | Dedicated medium RDS MySQL DB instance                                       | 5.7.21           |
@@ -129,7 +130,7 @@ The cloud.gov team aims to provide clearer status indicators in a future release
 To update an existing service instance run the following command:
 
 ```sh
-cf update-service aws-rds ${SERVICE_NAME} -p ${NEW_SERVICE_PLAN_NAME}
+cf update-service ${SERVICE_NAME} -p ${NEW_SERVICE_PLAN_NAME}
 ```
 
 `${NEW_SERVICE_PLAN_NAME}` can be any of the *dedicated* service plans that are listed above.


### PR DESCRIPTION
## Changes proposed in this pull request:

- Added the xlarge-psql-redundant as part of the cloud.gov plans. It's possible this needs to be added for the mysql redundant plan as well. I was unsure about mysql, so I did not add that to this PR. 

- Updated command for update-service to exclude the service (aws-rds) argument as it was not needed and produced an error when ran.

Note: Thanks for making this new `update-service` capability, it definitely saves us on steps for updating a cloud.gov aws-rds service!