### PR TITLE
Stop referring to vestigial DB name field

### DIFF
--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -305,7 +305,7 @@ $ cf service-key spring-oracle spring-oracle-key
 Getting key spring-oracle-key for service instance spring-oracle ...
 
 {
-  "db_name": "ORCL",
+  "name": "ORCL",
   "host": "cg-aws-broker-prod.RANDOMSTRING.us-gov-west-1.rds.amazonaws.com",
   "password": "secretpassword",
   "port": "1521",
@@ -348,7 +348,7 @@ myapp_guid=$(cf app --guid hello-doe)
 
 creds=$(cf curl /v2/apps/$myapp_guid/env | jq -r '[.system_env_json.VCAP_SERVICES."aws-rds"[0].credentials | .username, .password] | join(":")')
 
-dbname=$(cf curl /v2/apps/$myapp_guid/env | jq -r '.system_env_json.VCAP_SERVICES."aws-rds"[0].credentials | .db_name')
+dbname=$(cf curl /v2/apps/$myapp_guid/env | jq -r '.system_env_json.VCAP_SERVICES."aws-rds"[0].credentials | .name')
 
 psql postgres://$creds@localhost:5432/$dbname
 


### PR DESCRIPTION
As a consequence of https://github.com/cloud-gov/aws-broker/pull/97 , the `db_name` field is vestigial and only present for backward-compatibility. 

## Changes proposed in this pull request:
- This change makes the docs refer instead to `name`, which is the same attribute name used by other DB brokers out there in the Cloud Foundry community.

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)


## Security Considerations
None, see the PR referenced above for the security implications in the direct context of the change.