### PR TITLE
CP / CP-2 for Redis and Elasticsearch

### DIFF
--- a/_docs/ops/contingency-plan.md
+++ b/_docs/ops/contingency-plan.md
@@ -134,7 +134,7 @@ Major services (Cloud Foundry, BOSH, Concourse, and UAA) rely on databases provi
 
 cloud.gov is not dependent on the following services, but we do broker customer provisioning and access to these services, so our customers could be impacted if they were unavailable.  
 
-If a GovCloud service were wholly unavailable, we would broker access to the AWS commercial cloud equivalent, as shown below:
+If a GovCloud service were wholly unavailable, Cloud Operations would, after receiving approval from our Authorizing Official, broker access to the AWS commercial cloud equivalent, as shown below:
 
 Brokered service | Fallback Services | FedRAMP Fallback Status |
 -- | -- | -- |

--- a/_docs/ops/contingency-plan.md
+++ b/_docs/ops/contingency-plan.md
@@ -130,6 +130,17 @@ If all AWS regions are disrupted, Cloud Operations will deploy the system to ano
 #### AWS RDS
 Major services (Cloud Foundry, BOSH, Concourse, and UAA) rely on databases provided by RDS. To restore a database from backup, see [restoring RDS]({{ site.baseurl }}{% link _docs/ops/runbook/restoring-rds.md %}).
 
+#### Brokered AWS services
+
+cloud.gov is not dependent on the following services, but we do broker customer provisioning and access to these service, so our customers could be impacted if they were unavailable.  
+
+If the GovCloud service were wholly unavailable, we would broker access to the AWS commercial cloud equivalent, as shown below:
+
+Brokered service | Fallback Services | FedRAMP Fallback Status |
+-- | -- | -- |
+AWS GovCloud Elasticache for Redis | AWS commercial Elasticache for Redis | Moderate |
+AWS GovCloud Elastisearch | AWS commercial Elastisearch | Moderate |
+
 
 ## How this document works
 

--- a/_docs/ops/contingency-plan.md
+++ b/_docs/ops/contingency-plan.md
@@ -132,9 +132,9 @@ Major services (Cloud Foundry, BOSH, Concourse, and UAA) rely on databases provi
 
 #### Brokered AWS services
 
-cloud.gov is not dependent on the following services, but we do broker customer provisioning and access to these service, so our customers could be impacted if they were unavailable.  
+cloud.gov is not dependent on the following services, but we do broker customer provisioning and access to these services, so our customers could be impacted if they were unavailable.  
 
-If the GovCloud service were wholly unavailable, we would broker access to the AWS commercial cloud equivalent, as shown below:
+If a GovCloud service were wholly unavailable, we would broker access to the AWS commercial cloud equivalent, as shown below:
 
 Brokered service | Fallback Services | FedRAMP Fallback Status |
 -- | -- | -- |


### PR DESCRIPTION
## Changes proposed in this pull request:

- CP-2 for AWS redis/es brokering

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)


## Security Considerations

The services we broker into AWS govcloud are public and non-sensitive.
