### PR TITLE
Add `my-org` to `create-domain` command in docs

### DIFF
--- a/_docs/services/external-domain-service.md
+++ b/_docs/services/external-domain-service.md
@@ -113,8 +113,8 @@ Note that only these error codes can be customized: 400, 403, 404, 405, 414, 416
 
 3. Create the cf domain for each of the domains you are adding to the service:
    ```
-   $ cf create-domain example.gov
-   $ cf create-domain www.example.gov
+   $ cf create-domain my-org example.gov
+   $ cf create-domain my-org www.example.gov
    ```
 
 4. Map the routes to your app. There are several ways to do this, documented [here](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#map-route). For example:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add my-org in command for create-domain in external domain docs

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/create-domain-org)


## Security Considerations
None
