### PR TITLE
AIDE has replaced Tripwire

### DIFF
--- a/_docs/ops/continuous-integration.md
+++ b/_docs/ops/continuous-integration.md
@@ -41,3 +41,8 @@ Staging also runs integration, smoke, and acceptance tests against every incomin
 ## Production
 
 This is where all customer workloads live. All the same rules apply to our production environment: changes must first pass multiple testing steps, a deployment, and then acceptance tests. By the time a change reaches our production environment, changes have been comprehenesively tested in development and staging before being available to customers.
+
+
+Last modified on: {% last_modified_id %}
+[Recent document history](https://github.com/cloud-gov/cg-site/commits/master/_docs/ops/continuous-integration.md) (since 2020-02-05)
+[Older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{%page.name}.md) (before 2020-02-05)

--- a/_docs/ops/continuous-monitoring.md
+++ b/_docs/ops/continuous-monitoring.md
@@ -107,7 +107,7 @@ The cloud.gov team has implemented a suite of automated components to provide co
 	* Network intrusion detection:
 		* **Snort:** continuously monitors network traffic, signatures, and behaviors, and raises alerts based on defined rules.
 	* Intruder detection / file integrity:
-		* **Tripwire:** Performs file alteration checks on all cloud.gov virtual machines on initial deploy and a daily basis thereafter, and records all data to CloudWatch logs.
+		* **AIDE:** Performs file alteration checks on all cloud.gov virtual machines on initial deploy and an hourly basis thereafter. Violations are shipped to our central alert system.
 	* Patch / vulnerability scanning:
 		* **Nessus:** runs nightly to scan for OS and database vulnerabilities.
 		* **OWASP ZAP:** runs monthly to scan for web application vulnerabilities.


### PR DESCRIPTION
## Changes proposed in this pull request:

* AIDE replaces Tripwire

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/peterb/accout-review-updates)


## Security Considerations

None. Already public information.
