### PR TITLE
AIDE has replaced Tripwire

### DIFF
--- a/_docs/ops/continuous-monitoring.md
+++ b/_docs/ops/continuous-monitoring.md
@@ -107,7 +107,7 @@ The cloud.gov team has implemented a suite of automated components to provide co
 	* Network intrusion detection:
 		* **Snort:** continuously monitors network traffic, signatures, and behaviors, and raises alerts based on defined rules.
 	* Intruder detection / file integrity:
-		* **Tripwire:** Performs file alteration checks on all cloud.gov virtual machines on initial deploy and a daily basis thereafter, and records all data to CloudWatch logs.
+		* **AIDE:** Performs file alteration checks on all cloud.gov virtual machines on initial deploy and an hourly basis thereafter. Violations are shipped to our central alert system.
 	* Patch / vulnerability scanning:
 		* **Nessus:** runs nightly to scan for OS and database vulnerabilities.
 		* **OWASP ZAP:** runs monthly to scan for web application vulnerabilities.


### PR DESCRIPTION
## Changes proposed in this pull request:

- AIDE has replaced Tripwire

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/peterb/account-review-updates)


## Security Considerations

None. Documentation update with publicly-available information.
