### PR TITLE
Fix code block overflow

### DIFF
--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -327,6 +327,7 @@ code {
   @include u-padding-y(1px);
   border-radius: radius('sm');
   word-wrap: break-word;
+  white-space: pre-wrap;
 }
 
 .usa-section.want-more {

--- a/_assets/css/theme/_uswds-theme-spacing.scss
+++ b/_assets/css/theme/_uswds-theme-spacing.scss
@@ -79,7 +79,7 @@ widescreen
 ----------------------------------------
 */
 
-$theme-grid-container-max-width: 'desktop';
+$theme-grid-container-max-width: 'widescreen';
 
 /*
 ----------------------------------------
@@ -87,7 +87,7 @@ Site
 ----------------------------------------
 */
 
-$theme-site-max-width:              'desktop';
-$theme-site-margins-breakpoint:     'desktop';
+$theme-site-max-width:              'widescreen';
+$theme-site-margins-breakpoint:     'widescreen';
 $theme-site-margins-width:          4;
 $theme-site-margins-mobile-width:   2;

--- a/_docs/services/cdn-route.md
+++ b/_docs/services/cdn-route.md
@@ -73,7 +73,10 @@ cf create-domain <org> my.example.gov
 Then, to create a `cdn-route` service instance, run the following command (replace `my-cdn-route` with a name for your service instance, and replace `my.example.gov` with your domain):
 
 ```sh
-cf create-service cdn-route cdn-route my-cdn-route \
+cf create-service \
+    cdn-route \
+    cdn-route \
+    my-cdn-route \
     -c '{"domain": "my.example.gov"}'
 ```
 
@@ -82,7 +85,10 @@ cf create-service cdn-route cdn-route my-cdn-route \
 If you have more than one domain, you can pass a comma-delimited list to the `domain` parameter (just keep in mind that the broker will wait until all domains are CNAME'd, as explained in the next step):
 
 ```sh
-cf create-service cdn-route cdn-route my-cdn-route \
+cf create-service \
+    cdn-route \
+    cdn-route \
+    my-cdn-route \
     -c '{"domain": "my.example.gov,www.my.example.gov"}'
 ```
 

--- a/_docs/services/cloud-gov-identity-provider.md
+++ b/_docs/services/cloud-gov-identity-provider.md
@@ -33,7 +33,10 @@ Note: By default, identity provider service instances use the `openid` scope. Th
 To create an identity provider, bind a [service key](https://docs.cloudfoundry.org/devguide/services/service-keys.html) to the service instance:
 
 ```bash
-cf create-service-key my-uaa-client my-service-key -c '{"redirect_uri": ["https://my.app.cloud.gov/auth", "https://my.app.cloud.gov/logout"]}'
+cf create-service-key \
+    my-uaa-client \
+    my-service-key \
+    -c '{"redirect_uri": ["https://my.app.cloud.gov/auth", "https://my.app.cloud.gov/logout"]}'
 cf service-key my-uaa-client my-service-key
 ```
 

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -105,13 +105,19 @@ cf create-service aws-rds micro-psql my-service-db
 If you want to specify the storage available (in gigabytes) to the instance:
 
 ```sh
-cf create-service aws-rds ${SERVICE_PLAN_NAME} ${SERVICE_NAME} -c '{"storage": 50}'
+cf create-service aws-rds \
+    ${SERVICE_PLAN_NAME} \
+    ${SERVICE_NAME} \
+    -c '{"storage": 50}'
 ```
 
 Using functions in MySQL:
 
 ```sh
-cf create-service aws-rds ${MYSQL_SERVICE_PLAN_NAME} ${SERVICE_NAME} -c '{"enable_functions": true}'
+cf create-service aws-rds \
+    ${MYSQL_SERVICE_PLAN_NAME} \
+    ${SERVICE_NAME} \
+    -c '{"enable_functions": true}'
 ```
 
 ### Instance creation time
@@ -234,7 +240,11 @@ Then try the previous step again.
 Once the SSH tunnel is created, keep it running in that terminal window and open a separate terminal session in another window/tab, then create the backup file using the parameters provided by the plugin in the new terminal session, e.g. (be sure to tailor the backup/export command to your specific needs):
 
 ```sh
-$ pg_dump -F c --no-acl --no-owner -f backup.pg postgresql://${USERNAME}:${PASSWORD}@${HOST}:${PORT}/${NAME}
+$ pg_dump -F c \
+    --no-acl \
+    --no-owner \
+    -f backup.pg \
+    postgresql://${USERNAME}:${PASSWORD}@${HOST}:${PORT}/${NAME}
 ```
 
 This will create the `backup.pg` file on your local machine in whatever your current working directory is.
@@ -354,7 +364,10 @@ Example for app name `hello-doe`
 ```
 myapp_guid=$(cf app --guid hello-doe)
 
-tunnel=$(cf curl /v2/apps/$myapp_guid/env | jq -r '[.system_env_json.VCAP_SERVICES."aws-rds"[0].credentials | .host, .port] | join(":")')
+tunnel=$(cf curl /v2/apps/$myapp_guid/env \
+    | jq -r '[.system_env_json.VCAP_SERVICES."aws-rds"[0].credentials \
+    | .host, .port] \
+    | join(":")')
 
 cf ssh -N -L 5432:$tunnel hello-doe
 ```
@@ -364,9 +377,14 @@ Another window:
 ```
 myapp_guid=$(cf app --guid hello-doe)
 
-creds=$(cf curl /v2/apps/$myapp_guid/env | jq -r '[.system_env_json.VCAP_SERVICES."aws-rds"[0].credentials | .username, .password] | join(":")')
+creds=$(cf curl /v2/apps/$myapp_guid/env \
+    | jq -r '[.system_env_json.VCAP_SERVICES."aws-rds"[0].credentials \
+    | .username, .password] \
+    | join(":")')
 
-dbname=$(cf curl /v2/apps/$myapp_guid/env | jq -r '.system_env_json.VCAP_SERVICES."aws-rds"[0].credentials | .name')
+dbname=$(cf curl /v2/apps/$myapp_guid/env \
+    | jq -r '.system_env_json.VCAP_SERVICES."aws-rds"[0].credentials \
+    | .name')
 
 psql postgres://$creds@localhost:5432/$dbname
 

--- a/_docs/services/s3.md
+++ b/_docs/services/s3.md
@@ -65,7 +65,9 @@ If you get an error, see the [managed service documentation]({{ site.baseurl }}{
 If you need to access multiple S3 buckets using the same access credentials--for example, to copy files from one bucket to another--you can use the `additional_instances` option when binding:
 
 ```sh
-cf bind-service <APP_NAME> <SERVICE_INSTANCE_NAME> -c '{"additional_instances": ["<ADDITIONAL_SERVICE_INSTANCE_NAME>"]}'
+cf bind-service <APP_NAME> \
+    <SERVICE_INSTANCE_NAME> \
+    -c '{"additional_instances": ["<ADDITIONAL_SERVICE_INSTANCE_NAME>"]}'
 ```
 
 The credentials created for this binding will have access to both the bucket managed by `<SERVICE_INSTANCE_NAME>` and `<ADDITIONAL_SERVICE_INSTANCE_NAME>`, and the bucket managed by `<ADDITIONAL_SERVICE_INSTANCE_NAME>` will be listed in the `additional_buckets` field of the credentials.


### PR DESCRIPTION
fixes #1777 
I tested this on my MBP's screen, on my big 4k monitor, and in simulated 1080p, and it looks good to me, but I'm not a designer.

We _should_ also be mindful of this, and wrap code samples with escapes, so copy-paste works better and so samples read more like real code.

## Changes proposed in this pull request:
- set max-width to widescreen. This means that code blocks will overflow
  less often
- set whitespace to pre-wrap on code blocks. This means code blocks can
  wrap
- manually wrap some obviously long lines

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/embiggen)


## Security Considerations
None