### PR TITLE
tidy up code blocks

### DIFF
--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -325,9 +325,16 @@ code {
   @include u-bg('accent-warm-light');
   @include u-padding-x('05');
   @include u-padding-y(1px);
+  @include u-font-size("mono", "xs");
+  @include u-display("block");
   border-radius: radius('sm');
   word-wrap: break-word;
   white-space: pre-wrap;
+  line-height: line-height("mono", 1);
+}
+
+code.language-plaintext {
+  @include u-display("inline");
 }
 
 .usa-section.want-more {


### PR DESCRIPTION
## Changes proposed in this pull request:
- make code blocks ...blocks. This changes it from looking like highlighted (highlit?) text to looking like a box
- make code text smaller. Mono fonts appear larger than non-mono, so smaller matches better, and smaller means less ugly wrapping on longish lines

I cannot stress enough that I am not a designer nor a frontend person, so please check the previews and make sure everything looks sane to you :)


:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/code-samples)


## Security Considerations
None