### PR TITLE
rollback site width to keep menu aligned

### DIFF
--- a/_assets/css/theme/_uswds-theme-spacing.scss
+++ b/_assets/css/theme/_uswds-theme-spacing.scss
@@ -79,7 +79,7 @@ widescreen
 ----------------------------------------
 */
 
-$theme-grid-container-max-width: 'widescreen';
+$theme-grid-container-max-width: 'desktop';
 
 /*
 ----------------------------------------


### PR DESCRIPTION
## Changes proposed in this pull request:
- undo the grid-container widening so the logo, menu, and content stay aligned

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/header-alignment)


## Security Considerations
None