### PR TITLE
Add max width class to page layout container

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,9 @@ GEM
       sprockets (>= 3.3, < 4.1.beta)
     jekyll-feed (0.13.0)
       jekyll (>= 3.7, < 5.0)
+    jekyll-last-modified-at (1.3.0)
+      jekyll (>= 3.7, < 5.0)
+      posix-spawn (~> 0.3.9)
     jekyll-paginate-v2 (2.0.0)
       jekyll (~> 3.0)
     jekyll-redirect-from (0.16.0)
@@ -94,6 +97,7 @@ GEM
     parallel (1.19.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    posix-spawn (0.3.15)
     public_suffix (4.0.5)
     rack (2.2.3)
     rainbow (3.0.0)
@@ -126,6 +130,7 @@ DEPENDENCIES
   jekyll (~> 3.8)
   jekyll-assets (~> 3.0)
   jekyll-feed (~> 0.6)
+  jekyll-last-modified-at
   jekyll-paginate-v2 (= 2.0)
   jekyll-redirect-from
   jekyll-seo-tag

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,20 +6,8 @@ layout: default
 This template is for a single page that does not have a date associated with it. For example, an about page.
 {% endcomment %}
 
-<div class="usa-layout-docs usa-section">
-  <div class="grid-container">
-    <div class="grid-row grid-gap">
-      {% if page.sidenav == true %}
-      {% include sidenav.html %}
-      {% endif %}
-      <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">
-        {{ content }}
-        
-        <div class="grid-row">
-          <div class="grid-col flex-4"></div>
-          <div class="grid-col flex-1"><p><a href="{{ site.github_url }}/edit/master/{{ page.relative_path }}">Suggest edits</a></p></div>
-        </div>
-      </div>
-    </div>
+<div class="usa-layout-docs usa-section {{ page.bg-color-class }}">
+  <div class="grid-container maxw-desktop">
+    {{ content }}
   </div>
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,7 +7,7 @@ This is used in blog posts. The index page can be found at blog/index.html
 {% endcomment %}
 
 <div class="usa-layout-docs usa-section">
-  <div class="grid-container">
+  <div class="grid-container maxw-desktop">
     <div class="grid-row grid-gap">
       <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">
         <h2 class="title">{{page.title}}</h2>

--- a/_pages/pricing.md
+++ b/_pages/pricing.md
@@ -1,187 +1,186 @@
 ---
 title: Pricing
-layout: default
+layout: page
 sidenav: false
+bg-color-class: bg-accent-warm-light
 redirect_from:
 - /docs/pricing/pricing-model/
 ---
-<div class="usa-content bg-accent-warm-light">
-   <section class="grid-container usa-section">
-      <div class="grid-row grid-gap">
-         <div class="tablet:grid-col-9">
-            <p class="text-uppercase margin-bottom-0">Pricing</p>
-            <h1 class="margin-top-1 font-sans-3xl">
-               Deliver great services with compliance and infrastructure automated behind the scenes.
-            </h1>
-            <p class="usa-intro">
-               <a href="{{site.mailto}}">Contact us</a> for answers to your questions and help with an estimate, or to start an Interagency Agreement purchase.
-            </p>
-         </div>
+<div class="usa-content">
+  <section class="usa-section">
+    <div class="grid-row grid-gap">
+      <div class="tablet:grid-col-9">
+        <p class="text-uppercase margin-bottom-0">Pricing</p>
+        <h1 class="margin-top-1 font-sans-3xl">
+          Deliver great services with compliance and infrastructure automated behind the scenes.
+        </h1>
+        <p class="usa-intro">
+          <a href="{{site.mailto}}">Contact us</a> for answers to your questions and help with an estimate, or to start an Interagency Agreement purchase.
+        </p>
       </div>
-   </section>
-   <section class="grid-container usa-section">
-      <div class="grid-row products-pricing">
-         {% for product in site.data.pricing %}
-         <div class="desktop:grid-col">
-            <div class="intro">
-               {% asset "{{ product.image }}" class="square-15" %}
-               <h2>{{ product.package_name }}</h2>
-            </div>
-            <table class="usa-table usa-table--borderless">
-               <tbody>
-                  <tr>
-                     <td class="intro-info">
-                        {{ product.description }}
-                     </td>
-                  </tr>
-                  <tr>
-                     <td class="intro-info">
-                        {{ product.price }}
-                     </td>
-                  </tr>
-                  <tr>
-                     <td class="small-info">
-                        {{ product.memory }}
-                     </td>
-                  </tr>
-                  <tr>
-                     <td class="small-info">
-                        {{ product.production }}
-                     </td>
-                  </tr>
-                  <tr>
-                     <td class="small-info">
-                        {{ product.domain_names }}
-                     </td>
-                  </tr>
-                  <tr>
-                     <td>
-                        <span class="font-sans-2xs">{{ product.sign_up }}</span>
-                     </td>
-                  </tr>
-               </tbody>
-            </table>
-         </div>
-         {% endfor %}
+    </div>
+  </section>
+  <section class="usa-section">
+    <div class="grid-row products-pricing">
+      {% for product in site.data.pricing %}
+      <div class="desktop:grid-col">
+        <div class="intro">
+          {% asset "{{ product.image }}" class="square-15" %}
+          <h2>{{ product.package_name }}</h2>
+        </div>
+        <table class="usa-table usa-table--borderless">
+          <tbody>
+            <tr>
+              <td class="intro-info">
+                {{ product.description }}
+              </td>
+            </tr>
+            <tr>
+              <td class="intro-info">
+                {{ product.price }}
+              </td>
+            </tr>
+            <tr>
+              <td class="small-info">
+                {{ product.memory }}
+              </td>
+            </tr>
+            <tr>
+              <td class="small-info">
+                {{ product.production }}
+              </td>
+            </tr>
+            <tr>
+              <td class="small-info">
+                {{ product.domain_names }}
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <span class="font-sans-2xs">{{ product.sign_up }}</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
-   </section>
-   <section class="grid-container usa-section">
-      <div class="grid-row grid-gap">
-         <div class="tablet:grid-col-7 pricing-calculations usa-prose">
-            <a href="#estimate-your-monthly-cost"></a>
-            <h2 id="estimate-your-monthly-cost">Estimate your monthly cost</h2>
-            <p>
-               Monthly costs are based on the package fee (i.e., Prototyping, FISMA Low, FISMA Moderate) plus memory usage. Memory quota cost are based on the amount of memory (RAM) that you reserve for your system (<sup>$</sup>130/GB RAM per month).
-            </p>
-            <p class="footnote">
-               Most cloud.gov customers typically reserve 4–8 GB of memory to cover multiple applications across development, staging, and production environments.
-            </p>
-            <h3>Example</h3>
-            <p>
-               Suppose you have a FISMA Low app that requires 1 GB of memory. You will need 1 instance in dev, 1 instance in staging, and 2 in production.
-            </p>
-         </div>
+      {% endfor %}
+    </div>
+  </section>
+  <section class="usa-section">
+    <div class="grid-row grid-gap">
+      <div class="tablet:grid-col-7 pricing-calculations usa-prose">
+        <a href="#estimate-your-monthly-cost"></a>
+        <h2 id="estimate-your-monthly-cost">Estimate your monthly cost</h2>
+        <p>
+          Monthly costs are based on the package fee (i.e., Prototyping, FISMA Low, FISMA Moderate) plus memory usage. Memory quota cost are based on the amount of memory (RAM) that you reserve for your system (<sup>$</sup>130/GB RAM per month).
+        </p>
+        <p class="footnote">
+          Most cloud.gov customers typically reserve 4–8 GB of memory to cover multiple applications across development, staging, and production environments.
+        </p>
+        <h3>Example</h3>
+        <p>
+          Suppose you have a FISMA Low app that requires 1 GB of memory. You will need 1 instance in dev, 1 instance in staging, and 2 in production.
+        </p>
       </div>
-      <div class="grid-row grid-gap">
-         <div class="diagram tablet:grid-col margin-y-5">
-            {% asset pricing-example-FY20 %}
-         </div>
+    </div>
+    <div class="grid-row grid-gap">
+      <div class="diagram tablet:grid-col margin-y-5">
+        {% asset pricing-example-FY20 %}
       </div>
-      <div class="grid-row grid-gap">
-         <div class="tablet:grid-col-6 pricing-calculations usa-prose">
-            <h4>
-               Access Fee
-            </h4>
-            <p class="pricing-line-item">
-               FISMA Low <span><sup>$</sup>2070</span>
-            </p>
-            <h4>
-               Memory Quota Cost
-            </h4>
-            <p class="pricing-line-item">
-               [ 1 GB + 2 GB + 1 GB ] x <sup>$</sup>130 <span><sup>$</sup>520</span>
-            </p>
-            <p class="pricing-total">
-               Total monthly cost <span><sup>$</sup>2590</span>
-            </p>
-         </div>
+    </div>
+    <div class="grid-row grid-gap">
+      <div class="tablet:grid-col-6 pricing-calculations usa-prose">
+        <h4>
+          Access Fee
+        </h4>
+        <p class="pricing-line-item">
+          FISMA Low <span><sup>$</sup>2070</span>
+        </p>
+        <h4>
+          Memory Quota Cost
+        </h4>
+        <p class="pricing-line-item">
+          [ 1 GB + 2 GB + 1 GB ] x <sup>$</sup>130 <span><sup>$</sup>520</span>
+        </p>
+        <p class="pricing-total">
+          Total monthly cost <span><sup>$</sup>2590</span>
+        </p>
       </div>
-   </section>
-   <section class="usa-section grid-container">
-      <div class="grid-row grid-gap">
-         <div class="tablet:grid-col-7 usa-prose">
-            <h2>All use of cloud.gov includes:</h2>
-            <h3>Standard Services</h3>
-         </div>
+    </div>
+  </section>
+  <section class="usa-section">
+    <div class="grid-row grid-gap">
+      <div class="tablet:grid-col-7 usa-prose">
+        <h2>All use of cloud.gov includes:</h2>
+        <h3>Standard Services</h3>
       </div>
-      <div class="grid-row grid-gap">
-         <div class="tablet:grid-col-6 usa-prose">
-            <ul class="column-single">
-               <li>
-                  FedRAMP JAB-authorized hosting
-               </li>
-               <li>
-                  Self-service provisioning of services
-               </li>
-               <li>
-                  Self-service management of spaces and user access
-               </li>
-               <li>
-                  Self-service deployment of apps
-               </li>
-               <li>
-                  Basic technical and compliance support (during business hours)
-               </li>
-               <li>
-                  Documentation/tutorial material
-               </li>
-               <li>
-                  Continuous platform-level scanning and security updates
-               </li>
-               <li>
-                  Single-sign-on with your SAML identity provider
-               </li>
-               <li>
-                  Access to premium add-on services
-               </li>
-               <li>
-                  CDN route service (supporting caching, custom domains, and auto-renewing TLS certificates)
-               </li>
-            </ul>
-         </div>
-         <div class="tablet:grid-col-6 usa-prose">
-            <ul class="column-single">
-               <li>
-                  S3 object store -  5TB included<br><i>  $100/month per additional terabyte</i>
-               </li>
-               <li>
-                  Postgres, MySQL, Oracle database - 1TB included<br><i>$300/month per additional additional terabyte</i>
-               </li>
-               <li>
-                  Elasticsearch RESTful search and analytics - 10 GB included<br><i>$100/month per additional gigabyte</i>
-               </li>
-               <li>
-                  Redis in-memory data store - 10GB included<br><i>$100/month per additional gigabyte</i>
-               </li>
-            </ul>
-         </div>
+    </div>
+    <div class="grid-row grid-gap">
+      <div class="tablet:grid-col-6 usa-prose">
+        <ul class="column-single">
+          <li>
+            FedRAMP JAB-authorized hosting
+          </li>
+          <li>
+            Self-service provisioning of services
+          </li>
+          <li>
+            Self-service management of spaces and user access
+          </li>
+          <li>
+            Self-service deployment of apps
+          </li>
+          <li>
+            Basic technical and compliance support (during business hours)
+          </li>
+          <li>
+            Documentation/tutorial material
+          </li>
+          <li>
+            Continuous platform-level scanning and security updates
+          </li>
+          <li>
+            Single-sign-on with your SAML identity provider
+          </li>
+          <li>
+            Access to premium add-on services
+          </li>
+          <li>
+            CDN route service (supporting caching, custom domains, and auto-renewing TLS certificates)
+          </li>
+        </ul>
       </div>
-   </section>
-   <section class="usa-section">
-      <div class="grid-container">
-         <div class="grid-row grid-gap">
-            <div class="tablet:grid-col-7 usa-prose">
-               <h2>Additional information:</h2>
-               <ul class="column-single">
-                  <li>
-                     We can provision high-performance instances of Postgres, MySQL, and Oracle databases. <a href="mailto:inquiries@cloud.gov">Contact us</a> for more information.
-                  </li>
-                  <li>
-                     You’re responsible for operating and securing your own code and are responsible for complying with your agency’s requirements, which typically includes getting an ATO for your system.
-                  </li>
-               </ul>
-            </div>
-         </div>
+      <div class="tablet:grid-col-6 usa-prose">
+        <ul class="column-single">
+          <li>
+            S3 object store -  5TB included<br><i>  $100/month per additional terabyte</i>
+          </li>
+          <li>
+            Postgres, MySQL, Oracle database - 1TB included<br><i>$300/month per additional additional terabyte</i>
+          </li>
+          <li>
+            Elasticsearch RESTful search and analytics - 10 GB included<br><i>$100/month per additional gigabyte</i>
+          </li>
+          <li>
+            Redis in-memory data store - 10GB included<br><i>$100/month per additional gigabyte</i>
+          </li>
+        </ul>
       </div>
-   </section>
+    </div>
+  </section>
+  <section class="usa-section">
+    <div class="grid-row grid-gap">
+      <div class="tablet:grid-col-7 usa-prose">
+        <h2>Additional information:</h2>
+        <ul class="column-single">
+          <li>
+            We can provision high-performance instances of Postgres, MySQL, and Oracle databases. <a href="mailto:inquiries@cloud.gov">Contact us</a> for more information.
+          </li>
+          <li>
+            You’re responsible for operating and securing your own code and are responsible for complying with your agency’s requirements, which typically includes getting an ATO for your system.
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
 </div>

--- a/_pages/sign-up.md
+++ b/_pages/sign-up.md
@@ -3,7 +3,7 @@ title: Sign up
 layout: wide
 ---
 <section class="usa-graphic-list usa-section usa-section--dark sign-up-intro">
-<div class="grid-container">
+<div class="grid-container maxw-desktop">
 <div class="tablet:grid-col-7"  markdown="1">
 # Try cloud.gov for free
 
@@ -15,7 +15,7 @@ layout: wide
 </section>
 
 <section class="usa-section padding-y-8">
-<div class="grid-container">
+<div class="grid-container maxw-desktop">
 <div class="tablet:grid-col-7 usa-prose"  markdown="1">
 ## 1. <br />Get trial access and a free sandbox space
 
@@ -27,7 +27,7 @@ Federal employees and contractors with an email ending in .mil, .gov, or .fed.us
 </section>
 
 <section class="bg-accent-warm-light usa-section padding-y-8">
-<div class="grid-container grid-row">
+<div class="grid-container maxw-desktop grid-row">
 <div class="tablet:grid-col-7 usa-prose"  markdown="1">
 ## 2.<br />Go build in your sandbox
 
@@ -46,7 +46,7 @@ If you've run into any issues, please [contact support at cloud.gov](mailto:supp
 <ul>
         <li>
         <a href="{{ site.baseurl }}/docs/getting-started/code-samples/">Sample applications in .Net Core, PHP, Python, R, Ruby, NodeJS and Clojure</a>
-        </li>  
+        </li>
         <li>
         <a href="https://github.com/cloudfoundry-samples">Cloud Foundry community collection of sample applications</a>
         </li>
@@ -65,7 +65,7 @@ If you've run into any issues, please [contact support at cloud.gov](mailto:supp
 </section>
 
 <section class="usa-section want-more">
-<div class="grid-container grid-row">
+<div class="grid-container maxw-desktop grid-row">
 <div class="tablet:grid-col-7 usa-prose"  markdown="1">
 ## 3. <br />Want more?
 

--- a/_pages/support-packages.md
+++ b/_pages/support-packages.md
@@ -1,102 +1,104 @@
 ---
 title: Support Packages
-layout: default
+layout: page
 sidenav: false
+bg-color-class: bg-accent-warm-light
 ---
-<div class="usa-content bg-accent-warm-light">
-   <section class="grid-container usa-section">
-      <div class="grid-row grid-gap">
-         <div class="tablet:grid-col-9">
-            <p class="text-uppercase margin-bottom-0">{{ page.title }}</p>
-            <h1 class="margin-top-1 font-sans-3xl">
-               Help your team on a broader range of issues with dedicated engineering resources to resolving technical issues.
-            </h1>
-            <p class="usa-intro">
-               <a href="{{site.mailto}}">Contact us</a> if you’re interested in learning more. We can schedule time to discuss this further with your team.
-            </p>
-         </div>
+
+<div class="usa-content">
+  <section class="usa-section">
+    <div class="grid-row grid-gap">
+      <div class="tablet:grid-col-9">
+        <p class="text-uppercase margin-bottom-0">{{ page.title }}</p>
+        <h1 class="margin-top-1 font-sans-3xl">
+          Help your team on a broader range of issues with dedicated engineering resources to resolving technical issues.
+        </h1>
+        <p class="usa-intro">
+          <a href="{{site.mailto}}">Contact us</a> if you’re interested in learning more. We can schedule time to discuss this further with your team.
+        </p>
       </div>
-   </section>
-   <section class="grid-container usa-section">
-      <div class="grid-row products-pricing">
-         {% for product in site.data.support-packages %}
-         <div class="desktop:grid-col">
-            <div class="intro">
-               {% asset "{{ product.image }}" class="square-15" %}
-               <h2>{{ product.package_name }}</h2>
-            </div>
-            <table class="usa-table usa-table--borderless">
-               <tbody>
-                  <tr>
-                     <td class="intro-info">
-                        {{ product.description }}
-                     </td>
-                  </tr>
-                  <tr>
-                     <td class="intro-info">
-                        {{ product.price }}
-                     </td>
-                  </tr>
-                  <tr>
-                     <td class="small-info">
-                        {{ product.hours }}
-                     </td>
-                  </tr>
-               </tbody>
-            </table>
-         </div>
-         {% endfor %}
+    </div>
+  </section>
+  <section class="usa-section">
+    <div class="grid-row products-pricing">
+      {% for product in site.data.support-packages %}
+        <div class="desktop:grid-col">
+          <div class="intro">
+            {% asset "{{ product.image }}" class="square-15" %}
+            <h2>{{ product.package_name }}</h2>
+          </div>
+          <table class="usa-table usa-table--borderless">
+            <tbody>
+              <tr>
+                <td class="intro-info">
+                  {{ product.description }}
+                </td>
+              </tr>
+              <tr>
+                <td class="intro-info">
+                  {{ product.price }}
+                </td>
+              </tr>
+              <tr>
+                <td class="small-info">
+                  {{ product.hours }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      {% endfor %}
+    </div>
+  </section>
+  <section class="usa-section">
+    <div class="grid-row grid-gap">
+      <div class="tablet:grid-col-9 pricing-calculations usa-prose">
+        <a href="#estimate-your-monthly-cost"></a>
+        <h2 id="estimate-your-monthly-cost">Easy to get started</h2>
+        <p class="font-body-md">
+          Since these support packages are billed as labor, we can add these packages
+          to your existing agreement with only a minor modification to the IAA.
+        </p>
       </div>
-   </section>
-   <section class="grid-container usa-section">
-      <div class="grid-row grid-gap">
-         <div class="tablet:grid-col-9 pricing-calculations usa-prose">
-            <a href="#estimate-your-monthly-cost"></a>
-            <h2 id="estimate-your-monthly-cost">Easy to get started</h2>
+    </div>
+  </section>
+  <section class="usa-section">
+    <div class="grid-row grid-gap">
+      <div class="tablet:grid-col-9 usa-prose">
+        <h2>FAQ</h2>
+      </div>
+    </div>
+    <div class="grid-row grid-gap">
+      <div class="tablet:grid-col-9 usa-prose">
+        <ol class="column-single">
+          <li class="font-serif-lg">
+            <h3>What happens to the money that is not used within the fiscal year or period of performance?</h3>
             <p class="font-body-md">
-               Since these support packages are billed as labor, we can add these packages
-               to your existing agreement with only a minor modification to the IAA.
+              Any money that is not used will be returned to the agency through the "deobligation" process.
             </p>
-         </div>
+          </li>
+          <li class="font-serif-lg">
+            <h3>
+              If an agency does not use all the allocated support hours, would they be able to reduce paid support hours for future years?
+            </h3>
+            <p class="font-body-md">
+              Yes, we see support hours as a good way for an agency to get started with the platform. Once your team is comfortable with the platform, you should reduce the number of paid support hours.
+            </p>
+          </li>
+          <li class="font-serif-lg">
+            <h3>Is there a way to roll over unused hours to the next fiscal year?</h3>
+            <p class="font-body-md">
+              Yes, it's possible. But that depends on the agency's authority and funds. For example, some money can cross fiscal year ("no-year money") while other funds must be used within a set time frame ("3-year money").
+            </p>
+          </li>
+          <li class="font-serif-lg">
+            <h3>What are the limits of the paid support packages?</h3>
+            <p class="font-body-md">
+              We will not do direct development on the agency's application. We will only help, analyze, and assist.
+            </p>
+          </li>
+        </ol>
       </div>
-   </section>
-   <section class="usa-section grid-container">
-      <div class="grid-row grid-gap">
-         <div class="tablet:grid-col-9 usa-prose">
-            <h2>FAQ</h2>
-         </div>
-      </div>
-      <div class="grid-row grid-gap">
-         <div class="tablet:grid-col-9 usa-prose">
-            <ol class="column-single">
-               <li class="font-serif-lg">
-                  <h3>What happens to the money that is not used within the fiscal year or period of performance?</h3>
-                  <p class="font-body-md">
-                     Any money that is not used will be returned to the agency through the "deobligation" process.
-                  </p>
-               </li>
-               <li class="font-serif-lg">
-                  <h3>
-                     If an agency does not use all the allocated support hours, would they be able to reduce paid support hours for future years?
-                  </h3>
-                  <p class="font-body-md">
-                     Yes, we see support hours as a good way for an agency to get started with the platform. Once your team is comfortable with the platform, you should reduce the number of paid support hours.
-                  </p>
-               </li>
-               <li class="font-serif-lg">
-                  <h3>Is there a way to roll over unused hours to the next fiscal year?</h3>
-                  <p class="font-body-md">
-                    Yes, it's possible. But that depends on the agency's authority and funds. For example, some money can cross fiscal year ("no-year money") while other funds must be used within a set time frame ("3-year money").
-                  </p>
-               </li>
-               <li class="font-serif-lg">
-                  <h3>What are the limits of the paid support packages?</h3>
-                  <p class="font-body-md">
-                    We will not do direct development on the agency's application. We will only help, analyze, and assist.
-                  </p>
-               </li>
-            </ol>
-         </div>
-      </div>
-   </section>
+    </div>
+  </section>
 </div>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 permalink: /
-layout: default
+layout: page
 title: Home
 redirect_from:
   - /docs/deployment/experimental/behavior-monitoring/
@@ -12,30 +12,25 @@ redirect_from:
 ---
 
 <section class="usa-section">
-    <div class="grid-container site-welcome">
-        <h1 class="tablet:grid-col-10">You don't have to build your tech from the ground up.</h1>
-        <p class="usa-intro tablet:grid-col-8">
-          cloud.gov helps government agencies buy, build, and authorize modern cloud services.
-        </p>
-        
-        <div class="grid-row grid-gap">
-          <div class="tablet:grid-col-5 usa-prose bar-top">
-            <p><a href="{{ site.baseurl }}/docs/overview/what-is-cloudgov/" class="cg-arrow">Platform overview</a></p>
-            <p><a href="{{ site.baseurl }}/pricing/" class="cg-arrow">Packages and pricing</a></p>
-            <p><a href="{{ site.baseurl }}/docs/overview/enterprise-approach-to-cloud/" class="cg-arrow">Enterprise accounts</a></p>
-            <p><a href="{{ site.baseurl }}/docs/technology/responsibilities/" class="cg-arrow">Security and compliance</a></p>            
-          </div>
-        </div>
-    
+  <div class="site-welcome">
+    <h1 class="tablet:grid-col-10">You don't have to build your tech from the ground up.</h1>
+    <p class="usa-intro tablet:grid-col-8">
+      cloud.gov helps government agencies buy, build, and authorize modern cloud services.
+    </p>
 
-    
-    
+    <div class="grid-row grid-gap">
+      <div class="tablet:grid-col-5 usa-prose bar-top">
+        <p><a href="{{ site.baseurl }}/docs/overview/what-is-cloudgov/" class="cg-arrow">Platform overview</a></p>
+        <p><a href="{{ site.baseurl }}/pricing/" class="cg-arrow">Packages and pricing</a></p>
+        <p><a href="{{ site.baseurl }}/docs/overview/enterprise-approach-to-cloud/" class="cg-arrow">Enterprise accounts</a></p>
+        <p><a href="{{ site.baseurl }}/docs/technology/responsibilities/" class="cg-arrow">Security and compliance</a></p>
+      </div>
     </div>
+  </div>
 </section>
 
 <section class="usa-section why-cloud">
   <a name="Product"></a>
-  <div class="grid-container">
     <div class="grid-row">
       <h2>Why cloud.gov?</h2>
     </div>
@@ -65,110 +60,105 @@ redirect_from:
             </p>
       </div>
     </div>
-  </div>
 </section>
 
 <section class="usa-section is-cloud-right">
-<div class="grid-container">
   <div class="grid-row grid-gap">
     <div class="tablet:grid-col">
       <h2>Is cloud.gov right for you?</h2>
     </div>
   </div>
   <div class="grid-row grid-gap">
-  <div class="tablet:grid-col usa-prose bar-top">
-    <h3>cloud.gov is great for:</h3>
-    <ul>
-      <li>
-        Easily building new, cloud-native applications
-      </li>
-      <li>
-        Migrating applications to make them scale easily and reduce costs
-      </li>
-      <li>
-        Advancing your agency's use of the cloud through a FedRAMP-authorized platform
-      </li>
-    </ul>
-  </div>
-  <div class="tablet:grid-col usa-prose bar-top">
-    <h3>We’re a great fit when:</h3>
-    <ul>
-      <li>
-        Your team (either in-house or on contract) serves a federal government organization
-      </li>
-      <li>
-        You or your teams can use the IAA/MOU process to pay GSA for cloud.gov
-      </li>
-      <li>
-        Your applications are Moderate impact level or lower
-      </li>
-    </ul>
-  </div>
-  <div class="tablet:grid-col usa-prose bar-top">
-    <h3>Learn more:</h3>
-    <ul class="home-list">
+    <div class="tablet:grid-col usa-prose bar-top">
+      <h3>cloud.gov is great for:</h3>
+      <ul>
+        <li>
+          Easily building new, cloud-native applications
+        </li>
+        <li>
+          Migrating applications to make them scale easily and reduce costs
+        </li>
+        <li>
+          Advancing your agency's use of the cloud through a FedRAMP-authorized platform
+        </li>
+      </ul>
+    </div>
+    <div class="tablet:grid-col usa-prose bar-top">
+      <h3>We’re a great fit when:</h3>
+      <ul>
+        <li>
+          Your team (either in-house or on contract) serves a federal government organization
+        </li>
+        <li>
+          You or your teams can use the IAA/MOU process to pay GSA for cloud.gov
+        </li>
+        <li>
+          Your applications are Moderate impact level or lower
+        </li>
+      </ul>
+    </div>
+    <div class="tablet:grid-col usa-prose bar-top">
+      <h3>Learn more:</h3>
+      <ul class="home-list">
 
-      <li>
-        <a href="https://www.youtube.com/watch?v=G3fk3cJci0I" class="cg-arrow"><i class="fa fa-fw fa-video-camera" aria-hidden="true"></i> Video: Intro to the platform</a>
-      </li>
-      <li>
-        <a href="https://www.youtube.com/watch?v=zrq7lGEwIZY" class="cg-arrow"><i class="fa fa-fw fa-video-camera" aria-hidden="true"></i> Video: Common questions</a>
-      </li>
-      <li>
-        <a href="https://www.youtube.com/watch?v=LKb0liZyepA&feature=emb_logo" class="cg-arrow"><i class="fa fa-fw fa-video-camera" aria-hidden="true"></i> Video: What is cloud.gov?</a>
-      </li>      
-      <li>
-        <a href="{{ site.baseurl }}/resources/cloudgov-overview-2018.pdf" class="cg-arrow"><i class="fa fa-fw fa-file-pdf-o" aria-hidden="true"></i> PDF: Product overview</a>
-      </li>
-      <li>
-        <a href="{{ site.baseurl }}/resources/cloudgov-customers.pdf" class="cg-arrow"><i class="fa fa-fw fa-file-pdf-o" aria-hidden="true"></i> PDF: Customer stories</a>
-      </li>
-    </ul>
-  </div>
-</div>
+        <li>
+          <a href="https://www.youtube.com/watch?v=G3fk3cJci0I" class="cg-arrow"><i class="fa fa-fw fa-video-camera" aria-hidden="true"></i> Video: Intro to the platform</a>
+        </li>
+        <li>
+          <a href="https://www.youtube.com/watch?v=zrq7lGEwIZY" class="cg-arrow"><i class="fa fa-fw fa-video-camera" aria-hidden="true"></i> Video: Common questions</a>
+        </li>
+        <li>
+          <a href="https://www.youtube.com/watch?v=LKb0liZyepA&feature=emb_logo" class="cg-arrow"><i class="fa fa-fw fa-video-camera" aria-hidden="true"></i> Video: What is cloud.gov?</a>
+        </li>
+        <li>
+          <a href="{{ site.baseurl }}/resources/cloudgov-overview-2018.pdf" class="cg-arrow"><i class="fa fa-fw fa-file-pdf-o" aria-hidden="true"></i> PDF: Product overview</a>
+        </li>
+        <li>
+          <a href="{{ site.baseurl }}/resources/cloudgov-customers.pdf" class="cg-arrow"><i class="fa fa-fw fa-file-pdf-o" aria-hidden="true"></i> PDF: Customer stories</a>
+        </li>
+      </ul>
+    </div>
   </div>
 </section>
 
 <section class="usa-section packages">
-  <div class="grid-container">
-    <div class="grid-row grid-gap">
-      <div class="tablet:grid-col">
-        <h2>Packages</h2>
-      </div>
+  <div class="grid-row grid-gap">
+    <div class="tablet:grid-col">
+      <h2>Packages</h2>
     </div>
-    <div class="grid-row grid-gap">
-      <div class="tablet:grid-col usa-prose bar-top">
-        <h3>Sandbox space</h3>
-        <p>
-          <a href="{{ site.baseurl }}/pricing/">Sandbox spaces</a> are free. All you need is a federal email address &mdash; no paperwork, no hassle.
-        </p>
-        <p>
-          <a href="{{ site.baseurl }}/sign-up/" class="cg-arrow">Get a free trial sandbox</a>
-        </p>
-      </div>
-      <div class="tablet:grid-col usa-prose bar-top">
-        <h3>Prototyping packages</h3>
-        <p>
-          Upgrade to a <a href="{{ site.baseurl }}/pricing/">prototyping package</a> and develop new apps in a production-ready environment. $1,550 per month for full access for unlimited users.
-        </p>
-        <p>
-          <a href="{{ site.baseurl }}/pricing/" class="cg-arrow">Learn about purchasing</a>
-        </p>
-      </div>
-      <div class="tablet:grid-col usa-prose bar-top">
-        <h3>Production packages</h3>
-        <p>
-          Production packages range from $2,070 per month for a FISMA Low system to $9,300 per month for a FISMA Moderate system.
-        </p>
-        <p>
-          <a href="{{ site.baseurl }}/pricing/"  class="cg-arrow">Learn about purchasing</a>
-        </p>
-      </div>
+  </div>
+  <div class="grid-row grid-gap">
+    <div class="tablet:grid-col usa-prose bar-top">
+      <h3>Sandbox space</h3>
+      <p>
+        <a href="{{ site.baseurl }}/pricing/">Sandbox spaces</a> are free. All you need is a federal email address &mdash; no paperwork, no hassle.
+      </p>
+      <p>
+        <a href="{{ site.baseurl }}/sign-up/" class="cg-arrow">Get a free trial sandbox</a>
+      </p>
+    </div>
+    <div class="tablet:grid-col usa-prose bar-top">
+      <h3>Prototyping packages</h3>
+      <p>
+        Upgrade to a <a href="{{ site.baseurl }}/pricing/">prototyping package</a> and develop new apps in a production-ready environment. $1,550 per month for full access for unlimited users.
+      </p>
+      <p>
+        <a href="{{ site.baseurl }}/pricing/" class="cg-arrow">Learn about purchasing</a>
+      </p>
+    </div>
+    <div class="tablet:grid-col usa-prose bar-top">
+      <h3>Production packages</h3>
+      <p>
+        Production packages range from $2,070 per month for a FISMA Low system to $9,300 per month for a FISMA Moderate system.
+      </p>
+      <p>
+        <a href="{{ site.baseurl }}/pricing/"  class="cg-arrow">Learn about purchasing</a>
+      </p>
     </div>
   </div>
 </section>
 
-<section class="usa-section grid-container ">
+<section class="usa-section">
   <div class="grid-row">
     <h2>Who we work with</h2>
     <a name="Customers"></a>
@@ -206,52 +196,50 @@ redirect_from:
 </section>
 
 <section class="usa-section partner-cards margin-bottom-8">
-  <div class="grid-container">
-    <div class="grid-row grid-gap">
-      <div class="tablet:grid-col partner-card">
-        <h5>
-          <a href="https://regulations.atf.gov/" class="usa-link usa-link--external">ATF eRegs</a>
-        </h5>
-        {% asset ATF-logo.svg %}
-        Bureau of Alcohol, Tobacco, Firearms, and Explosives
-      </div>
-      <div class="tablet:grid-col partner-card">
-        <h5>
-          <a href="https://www.everykidinapark.gov/" class="usa-link usa-link--external">Every Kid in a Park</a>
-        </h5>
-        {% asset DOI-logo.svg %}
-        Department of the Interior
-      </div>
-      <div class="tablet:grid-col partner-card">
-        <h5>
-          <a href="https://collegescorecard.ed.gov/" class="usa-link usa-link--external">College Scorecard</a>
-        </h5>
-          {% asset Dept-of-Education-logo.svg %}
-          Department of Education
-      </div>
+  <div class="grid-row grid-gap">
+    <div class="tablet:grid-col partner-card">
+      <h5>
+        <a href="https://regulations.atf.gov/" class="usa-link usa-link--external">ATF eRegs</a>
+      </h5>
+      {% asset ATF-logo.svg %}
+      Bureau of Alcohol, Tobacco, Firearms, and Explosives
     </div>
-      <div class="grid-row grid-gap">
-      <div class="tablet:grid-col partner-card">
-        <h5>
-          <a href="https://crime-data-explorer.fr.cloud.gov/" class="usa-link usa-link--external">Crime Data Explorer</a>
-        </h5>
-        {% asset FBI-logo.svg %}
-        Federal Bureau of Investigation
-      </div>
-      <div class="tablet:grid-col partner-card">
-        <h5>
-          <a href="https://www.airnow.gov/" class="usa-link usa-link--external">AirNow</a>
-        </h5>
-        {% asset EPA-logo.svg %}
-        Environmental Protection Agency
-      </div>
-      <div class="tablet:grid-col partner-card">
-        <h5>
-          <a href="https://analytics.usa.gov" class="usa-link usa-link--external">Analytics.usa.gov</a>
-        </h5>
-          {% asset GSA-logo.svg %}
-          General Services Administration
-      </div>
+    <div class="tablet:grid-col partner-card">
+      <h5>
+        <a href="https://www.everykidinapark.gov/" class="usa-link usa-link--external">Every Kid in a Park</a>
+      </h5>
+      {% asset DOI-logo.svg %}
+      Department of the Interior
+    </div>
+    <div class="tablet:grid-col partner-card">
+      <h5>
+        <a href="https://collegescorecard.ed.gov/" class="usa-link usa-link--external">College Scorecard</a>
+      </h5>
+        {% asset Dept-of-Education-logo.svg %}
+        Department of Education
+    </div>
+  </div>
+    <div class="grid-row grid-gap">
+    <div class="tablet:grid-col partner-card">
+      <h5>
+        <a href="https://crime-data-explorer.fr.cloud.gov/" class="usa-link usa-link--external">Crime Data Explorer</a>
+      </h5>
+      {% asset FBI-logo.svg %}
+      Federal Bureau of Investigation
+    </div>
+    <div class="tablet:grid-col partner-card">
+      <h5>
+        <a href="https://www.airnow.gov/" class="usa-link usa-link--external">AirNow</a>
+      </h5>
+      {% asset EPA-logo.svg %}
+      Environmental Protection Agency
+    </div>
+    <div class="tablet:grid-col partner-card">
+      <h5>
+        <a href="https://analytics.usa.gov" class="usa-link usa-link--external">Analytics.usa.gov</a>
+      </h5>
+        {% asset GSA-logo.svg %}
+        General Services Administration
     </div>
   </div>
 </section>

--- a/news/index.html
+++ b/news/index.html
@@ -8,12 +8,11 @@ pagination:
 ---
 
 <div id="blog" class="usa-graphic-list usa-section usa-section--dark sign-up-intro">
-  <div class="grid-container">
+  <div class="grid-container maxw-desktop">
     <h1 class="margin-0">cloud.gov news</h1>
-    
   </div>
 </div>
-<div class="grid-container padding-bottom-2">
+<div class="grid-container padding-bottom-2 maxw-desktop">
   <div class="grid-row">
     <div class="desktop:grid-col-8 usa-prose padding-right-4">
       <!-- This loops through the paginated posts -->
@@ -78,7 +77,7 @@ pagination:
         </div>
       </div>
     </div>
-    
+
   </div>
   <div class="grid-row padding-top-4 tablet:padding-x-4 margin-bottom-4">
     <a class="usa-link" href="#blog">Return to top</a>


### PR DESCRIPTION
Align left with header for non documentation pages without side navigation elements.

## Changes proposed in this pull request:
- Add max width class desktop to page layout
- Change layout template for home, posts, pricing, and support package pages
- Clean up spacing on affected pages

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/apb-adjust-page-width/)

## Security Considerations
- none