### PR TITLE
Use `{%-` to reduce whitespace

### DIFF
--- a/_includes/doc-registry.html
+++ b/_includes/doc-registry.html
@@ -1,31 +1,31 @@
-{% assign documentation_navigation=site.documentation_navigation %}
-{% for nav_item in documentation_navigation %}
-  <h2> {% if nav_item.icon %}
+{%- assign documentation_navigation=site.documentation_navigation -%}
+{%- for nav_item in documentation_navigation -%}
+  <h2> {%- if nav_item.icon -%}
   <i class='fa fa-fw {{ nav_item.icon }}'></i>
-  {% endif %}
+  {%- endif -%}
   {{ nav_item.name | escape }}
   </h2>
   <ul>
-    {% for docpage in site.docs %}
-      {% if nav_item.identifier == docpage.parent %}
+    {%- for docpage in site.docs -%}
+      {%- if nav_item.identifier == docpage.parent -%}
       <li>
         <a href="{{ docpage.url }}">{{ docpage.title }}</a>
       </li>
-      {% endif %}
-    {% endfor %}
+      {%- endif -%}
+    {%- endfor -%}
   </ul>
-  {% if nav_item.children %}
-  {% for sub_child in nav_item.children %}
+  {%- if nav_item.children -%}
+  {%- for sub_child in nav_item.children -%}
   <h3>{{ sub_child.name }}</h3>
   <ul>
-{% for docpage in site.docs %}
-    {% if sub_child.identifier == docpage.parent %}
+{%- for docpage in site.docs -%}
+    {%- if sub_child.identifier == docpage.parent -%}
     <li>
       <a href="{{ docpage.url }}">{{ docpage.title }}</a>
     </li>
-    {% endif %}
-  {% endfor %}
+    {%- endif -%}
+  {%- endfor -%}
   </ul>
-  {% endfor %}
-  {% endif %}
-{% endfor %}
+  {%- endfor -%}
+  {%- endif -%}
+{%- endfor -%}

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,59 +1,59 @@
-{% comment %}
+{%- comment -%}
 To modify the menu system, you are welcome to edit this HTML directly or you can look inside _config.yml
 where we provide an easy way to manage your navigation system
-{% endcomment %}
+{%- endcomment -%}
 
 <header class="usa-header usa-header--extended" role="banner">
   <div class="usa-navbar">
-    {% include logo.html %}
+    {%- include logo.html -%}
     <button class="usa-menu-btn">Menu</button>
   </div>
   <nav role="navigation" class="usa-nav">
     <div class="usa-nav__inner">
-      <button class="usa-nav__close">{% asset close.svg alt="close" %}</button>
+      <button class="usa-nav__close">{%- asset close.svg alt="close" -%}</button>
       <ul class="usa-nav__primary usa-accordion">
-        {% for nav_item in include.primary_navigation %}
-        {% assign basedir = page.url | remove_first: '/' | split: '/' | first | lstrip %}
-        {% unless nav_item.children %}
-        {% assign linkdir = nav_item.url |  replace: "/", ""  | lstrip %}
+        {%- for nav_item in include.primary_navigation -%}
+        {%- assign basedir = page.url | remove_first: '/' | split: '/' | first | lstrip -%}
+        {%- unless nav_item.children -%}
+        {%- assign linkdir = nav_item.url |  replace: "/", ""  | lstrip -%}
         <li class="usa-nav__primary-item">
-          <a class="usa-nav__link{% if basedir == linkdir %} usa-current{% endif %}"
+          <a class="usa-nav__link{%- if basedir == linkdir -%} usa-current{%- endif -%}"
             href="{{ nav_item.url | prepend: site.baseurl}}"><span>
               {{ nav_item.name | escape }}</span></a>
         </li>
-        {% else %}
-        {% assign nav_id = 'primary-nav-' | append: forloop.index %}
-        {% if page.overview and nav_item.key == 'overview' %}
-          {% assign is_current = page.overview %}
-        {% elsif basedir == nav_item.key and page.overview == nil %}
-          {% assign is_current = true %}
-        {% else %}
-          {% assign is_current = false %}
-        {% endif %}
+        {%- else -%}
+        {%- assign nav_id = 'primary-nav-' | append: forloop.index -%}
+        {%- if page.overview and nav_item.key == 'overview' -%}
+          {%- assign is_current = page.overview -%}
+        {%- elsif basedir == nav_item.key and page.overview == nil -%}
+          {%- assign is_current = true -%}
+        {%- else -%}
+          {%- assign is_current = false -%}
+        {%- endif -%}
         <li class="usa-nav__primary-item">
-          <button class="usa-accordion__button usa-nav__link{% if is_current %} usa-current{% endif %}" aria-expanded="false"
+          <button class="usa-accordion__button usa-nav__link{%- if is_current -%} usa-current{%- endif -%}" aria-expanded="false"
             aria-controls="{{ nav_id }}"><span>{{ nav_item.name | escape }}<span></button>
           <ul id="{{ nav_id }}" class="usa-nav__submenu" hidden>
-            {% for subnav_item in nav_item.children %}
+            {%- for subnav_item in nav_item.children -%}
             <li class="usa-nav__submenu-item">
               <a href="{{ subnav_item.url | prepend: site.baseurl }}">{{ subnav_item.name | escape }}</a>
             </li>
-            {% endfor %}
+            {%- endfor -%}
           </ul>
 
         </li>
-        {% endunless %}
-        {% endfor %}
+        {%- endunless -%}
+        {%- endfor -%}
       </ul>
       <div class="usa-nav__secondary">
         <ul class="usa-nav__secondary-links">
-          {% for nav_item in include.secondary_navigation %}
+          {%- for nav_item in include.secondary_navigation -%}
           <li class="usa-nav__secondary-item">
             <a href="{{ nav_item.url | prepend: site.baseurl }}">{{ nav_item.name | escape }}</a>
           </li>
-          {% endfor %}
+          {%- endfor -%}
         </ul>
-        {% include searchgov/form.html searchgov=site.searchgov %}
+        {%- include searchgov/form.html searchgov=site.searchgov -%}
       </div>
     </div>
   </nav>

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -10,14 +10,14 @@ where we provide an easy way to manage your navigation system
   </div>
   <nav role="navigation" class="usa-nav">
     <div class="usa-nav__inner">
-      <button class="usa-nav__close">{%- asset close.svg alt="close" -%}</button>
+      <button class="usa-nav__close">{% asset close.svg alt="close" %}</button>
       <ul class="usa-nav__primary usa-accordion">
         {%- for nav_item in include.primary_navigation -%}
         {%- assign basedir = page.url | remove_first: '/' | split: '/' | first | lstrip -%}
         {%- unless nav_item.children -%}
         {%- assign linkdir = nav_item.url |  replace: "/", ""  | lstrip -%}
         <li class="usa-nav__primary-item">
-          <a class="usa-nav__link{%- if basedir == linkdir -%} usa-current{%- endif -%}"
+          <a class="usa-nav__link{% if basedir == linkdir %} usa-current{% endif %}"
             href="{{ nav_item.url | prepend: site.baseurl}}"><span>
               {{ nav_item.name | escape }}</span></a>
         </li>
@@ -31,7 +31,7 @@ where we provide an easy way to manage your navigation system
           {%- assign is_current = false -%}
         {%- endif -%}
         <li class="usa-nav__primary-item">
-          <button class="usa-accordion__button usa-nav__link{%- if is_current -%} usa-current{%- endif -%}" aria-expanded="false"
+          <button class="usa-accordion__button usa-nav__link{% if is_current %} usa-current{% endif %}" aria-expanded="false"
             aria-controls="{{ nav_id }}"><span>{{ nav_item.name | escape }}<span></button>
           <ul id="{{ nav_id }}" class="usa-nav__submenu" hidden>
             {%- for subnav_item in nav_item.children -%}

--- a/_includes/searchgov/form.html
+++ b/_includes/searchgov/form.html
@@ -1,13 +1,13 @@
-{% comment %} 
+{%- comment -%} 
   This will redirect the results to /search template which will handle the js loading
-{% endcomment %}
+{%- endcomment -%}
 
-{% if include.searchgov %}
-  {% if include.searchgov.inline == true %}
+{%- if include.searchgov -%}
+  {%- if include.searchgov.inline == true -%}
     <form id="search_form" class="usa-search usa-search--small" action="{{site.baseurl}}/search/" accept-charset="UTF-8" method="get">
-  {% else %}
+  {%- else -%}
     <form id="search_form" class="usa-search usa-search--small" action="{{include.searchgov.endpoint}}/search" accept-charset="UTF-8" method="get">
-  {% endif %}
+  {%- endif -%}
     
   
     <input name="utf8" type="hidden" value="&#x2713;" />
@@ -19,4 +19,4 @@
       <button class="usa-button" type="submit"><span class="usa-sr-only">Search</span></button>
     </div>
   </form>
-{% endif %}
+{%- endif -%}

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -13,8 +13,8 @@ _layouts/page.html layout template, or you can add "sidenav: true" in the front-
       {%- assign url_dirs = page.url | remove_first: '/' | split: '/' -%}
       {%- assign relevant_parent = url_dirs[1] -%}
       <li class="usa-sidenav__item">
-        <a class="usa-sidenav__item--parent-item {%- if relevant_parent == nav_item.identifier -%}usa-current{%- endif -%}"
-        {%- if relevant_parent == nav_item.identifier -%}aria-expanded=true{%- else -%}aria-expanded=false{%- endif -%}
+        <a class="usa-sidenav__item--parent-item {% if relevant_parent == nav_item.identifier %}usa-current{% endif %}"
+        {% if relevant_parent == nav_item.identifier %}aria-expanded=true{% else %}aria-expanded=false{% endif %}
       aria-controls="{{ nav_id }}" >
           {%- if nav_item.icon -%}
           <i class='fa fa-fw {{ nav_item.icon }}'></i>
@@ -22,13 +22,13 @@ _layouts/page.html layout template, or you can add "sidenav: true" in the front-
           {{ nav_item.name | escape }}
         </a>
       
-        <ul class="usa-sidenav__sublist {%- if relevant_parent != nav_item.identifier -%}display-none{%- endif -%}"
+        <ul class="usa-sidenav__sublist {% if relevant_parent != nav_item.identifier %}display-none{% endif %}"
          id="{{ nav_id }}" aria-hidden="true">
         {%- unless nav_item.children -%}
           {%- for docpage in site.docs -%}
           {%- if nav_item.identifier == docpage.parent -%}
           <li class="usa-sidenav__item">
-            <a href="{{ docpage.url | prepend: site.baseurl }}" class="{%- if docpage.url == page.url -%}usa-current{%- endif -%}">{{ docpage.title }}</a>
+            <a href="{{ docpage.url | prepend: site.baseurl }}" class="{% if docpage.url == page.url %}usa-current{% endif %}">{{ docpage.title }}</a>
           </li>
           {%- endif -%}
           {%- endfor -%}
@@ -38,15 +38,15 @@ _layouts/page.html layout template, or you can add "sidenav: true" in the front-
           {%- assign subnav_id = 'side-nav-' | append: subnav_item.identifier -%}
           {%- assign relevant_child = url_dirs[2] -%}
           <li class="usa-sidenav__item">
-            <a class="usa-sidenav__item--parent-item usa-sidenav__sublist--middle-generation {%- if page.parent == subnav_item.identifier -%}usa-current{%- endif -%}"
+            <a class="usa-sidenav__item--parent-item usa-sidenav__sublist--middle-generation {% if page.parent == subnav_item.identifier %}usa-current{% endif %}"
         {%- if page.parent == subnav_item.identifier -%}aria-expanded=true{%- else -%}aria-expanded=false{%- endif -%}
       aria-controls="{{ subnav_id }}" >{{ subnav_item.name | escape }}</a>
-            <ul class="usa-sidenav__sublist  {%- if page.parent != subnav_item.identifier -%}display-none{%- endif -%}"
+            <ul class="usa-sidenav__sublist  {% if page.parent != subnav_item.identifier %}display-none{% endif %}"
             id="{{ subnav_id }}" aria-hidden="true">
               {%- for docpage in site.docs -%}
                   {%- if subnav_item.identifier == docpage.parent -%}
                   <li class="usa-sidenav__item">
-                    <a href="{{ docpage.url | prepend: site.baseurl }}" class="{%- if docpage.url == page.url -%}usa-current{%- endif -%}">{{ docpage.title }}</a>
+                    <a href="{{ docpage.url | prepend: site.baseurl }}" class="{% if docpage.url == page.url %}usa-current{% endif %}">{{ docpage.title }}</a>
                   </li>
                   {%- endif -%}
               {%- endfor -%}

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,64 +1,64 @@
-{% comment %} 
+{%- comment -%} 
 The sidenav is not loaded by default on the main pages. To include this navigation you can either use the
 _layouts/page.html layout template, or you can add "sidenav: true" in the front-matter of your pages
-{% endcomment %}
+{%- endcomment -%}
 
 <aside class="usa-layout-docs-sidenav desktop:grid-col-4 padding-bottom-4">
   <nav>
     <ul class="usa-sidenav">
       
-      {% for nav_item in include.documentation_navigation %}
-      {% assign nav_id = 'side-nav-' | append: nav_item.identifier %}
+      {%- for nav_item in include.documentation_navigation -%}
+      {%- assign nav_id = 'side-nav-' | append: nav_item.identifier -%}
 
-      {% assign url_dirs = page.url | remove_first: '/' | split: '/' %}
-      {% assign relevant_parent = url_dirs[1] %}
+      {%- assign url_dirs = page.url | remove_first: '/' | split: '/' -%}
+      {%- assign relevant_parent = url_dirs[1] -%}
       <li class="usa-sidenav__item">
-        <a class="usa-sidenav__item--parent-item {% if relevant_parent == nav_item.identifier %}usa-current{% endif %}"
-        {% if relevant_parent == nav_item.identifier %}aria-expanded=true{% else %}aria-expanded=false{% endif %}
+        <a class="usa-sidenav__item--parent-item {%- if relevant_parent == nav_item.identifier -%}usa-current{%- endif -%}"
+        {%- if relevant_parent == nav_item.identifier -%}aria-expanded=true{%- else -%}aria-expanded=false{%- endif -%}
       aria-controls="{{ nav_id }}" >
-          {% if nav_item.icon %}
+          {%- if nav_item.icon -%}
           <i class='fa fa-fw {{ nav_item.icon }}'></i>
-          {% endif %}
+          {%- endif -%}
           {{ nav_item.name | escape }}
         </a>
       
-        <ul class="usa-sidenav__sublist {% if relevant_parent != nav_item.identifier %}display-none{% endif %}"
+        <ul class="usa-sidenav__sublist {%- if relevant_parent != nav_item.identifier -%}display-none{%- endif -%}"
          id="{{ nav_id }}" aria-hidden="true">
-        {% unless nav_item.children %}
-          {% for docpage in site.docs %}
-          {% if nav_item.identifier == docpage.parent %}
+        {%- unless nav_item.children -%}
+          {%- for docpage in site.docs -%}
+          {%- if nav_item.identifier == docpage.parent -%}
           <li class="usa-sidenav__item">
-            <a href="{{ docpage.url | prepend: site.baseurl }}" class="{% if docpage.url == page.url %}usa-current{% endif %}">{{ docpage.title }}</a>
+            <a href="{{ docpage.url | prepend: site.baseurl }}" class="{%- if docpage.url == page.url -%}usa-current{%- endif -%}">{{ docpage.title }}</a>
           </li>
-          {% endif %}
-          {% endfor %}
-      {% else %}
+          {%- endif -%}
+          {%- endfor -%}
+      {%- else -%}
         <!-- If section is a grandparent -->
-          {% for subnav_item in nav_item.children %}
-          {% assign subnav_id = 'side-nav-' | append: subnav_item.identifier %}
-          {% assign relevant_child = url_dirs[2] %}
+          {%- for subnav_item in nav_item.children -%}
+          {%- assign subnav_id = 'side-nav-' | append: subnav_item.identifier -%}
+          {%- assign relevant_child = url_dirs[2] -%}
           <li class="usa-sidenav__item">
-            <a class="usa-sidenav__item--parent-item usa-sidenav__sublist--middle-generation {% if page.parent == subnav_item.identifier %}usa-current{% endif %}"
-        {% if page.parent == subnav_item.identifier %}aria-expanded=true{% else %}aria-expanded=false{% endif %}
+            <a class="usa-sidenav__item--parent-item usa-sidenav__sublist--middle-generation {%- if page.parent == subnav_item.identifier -%}usa-current{%- endif -%}"
+        {%- if page.parent == subnav_item.identifier -%}aria-expanded=true{%- else -%}aria-expanded=false{%- endif -%}
       aria-controls="{{ subnav_id }}" >{{ subnav_item.name | escape }}</a>
-            <ul class="usa-sidenav__sublist  {% if page.parent != subnav_item.identifier %}display-none{% endif %}"
+            <ul class="usa-sidenav__sublist  {%- if page.parent != subnav_item.identifier -%}display-none{%- endif -%}"
             id="{{ subnav_id }}" aria-hidden="true">
-              {% for docpage in site.docs %}
-                  {% if subnav_item.identifier == docpage.parent %}
+              {%- for docpage in site.docs -%}
+                  {%- if subnav_item.identifier == docpage.parent -%}
                   <li class="usa-sidenav__item">
-                    <a href="{{ docpage.url | prepend: site.baseurl }}" class="{% if docpage.url == page.url %}usa-current{% endif %}">{{ docpage.title }}</a>
+                    <a href="{{ docpage.url | prepend: site.baseurl }}" class="{%- if docpage.url == page.url -%}usa-current{%- endif -%}">{{ docpage.title }}</a>
                   </li>
-                  {% endif %}
-              {% endfor %}
+                  {%- endif -%}
+              {%- endfor -%}
               </ul>
           </li>
-          {% endfor %}
-        {% endunless %}
+          {%- endfor -%}
+        {%- endunless -%}
         </ul>
       </li>
 
       
-      {% endfor %}
+      {%- endfor -%}
     </ul>
   </nav>
 </aside>

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -39,7 +39,7 @@ _layouts/page.html layout template, or you can add "sidenav: true" in the front-
           {%- assign relevant_child = url_dirs[2] -%}
           <li class="usa-sidenav__item">
             <a class="usa-sidenav__item--parent-item usa-sidenav__sublist--middle-generation {% if page.parent == subnav_item.identifier %}usa-current{% endif %}"
-        {%- if page.parent == subnav_item.identifier -%}aria-expanded=true{%- else -%}aria-expanded=false{%- endif -%}
+        {% if page.parent == subnav_item.identifier %}aria-expanded=true{% else %}aria-expanded=false{% endif %}
       aria-controls="{{ subnav_id }}" >{{ subnav_item.name | escape }}</a>
             <ul class="usa-sidenav__sublist  {% if page.parent != subnav_item.identifier %}display-none{% endif %}"
             id="{{ subnav_id }}" aria-hidden="true">


### PR DESCRIPTION
Per @ccostino finding [https://mathieubuisson.github.io/reducing-whitespace-jekyll-html/](https://mathieubuisson.github.io/reducing-whitespace-jekyll-html/)

this change reduces a sample page , configuration-management, from
102kb to 44kb.

## Changes proposed in this pull request:

- Use Liquid templating tags with `-` to reduce whitespace
-

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/peterb/bye-blanks)


## Security Considerations

None
