### PR TITLE
Add info on restoring AWS brokered services

### DIFF
--- a/_docs/ops/contingency-plan.md
+++ b/_docs/ops/contingency-plan.md
@@ -93,6 +93,11 @@ cloud.gov depends on several external services.  In the event one or more of the
 ### GitHub
 If GitHub becomes unavailable, the live cloud.gov will continue to operate in its current state. The disruption would only impact the team's ability to update cloud.gov.
 
+### Brokered AWS Services
+
+If customer services provided through our cloud.gov brokers are unavailable or suffer data loss, we've documented
+restoration processes in our [internal AWS contingency runbook](https://github.com/cloud-gov/runbooks/aws-contingency.md)
+
 #### Disruption lasting less than 7 days
 Cloud Operations will postpone any non-critical updates to the platform until the disruption is resolved.  If a critical update **must** be deployed, Cloud Operations will:
 

--- a/_docs/ops/contingency-plan.md
+++ b/_docs/ops/contingency-plan.md
@@ -96,8 +96,7 @@ If GitHub becomes unavailable, the live cloud.gov will continue to operate in it
 ### Brokered AWS Services
 
 If customer services provided through our cloud.gov brokers are unavailable or suffer data loss, we've documented
-restoration processes in our [internal AWS contingency runbook](https://github.com/cloud-gov/runbooks/aws-contingency.md)
-
+restoration processes in our [internal AWS contingency runbook](https://github.com/cloud-gov/internal-docs/blob/master/runbooks/aws-contingency.md)
 #### Disruption lasting less than 7 days
 Cloud Operations will postpone any non-critical updates to the platform until the disruption is resolved.  If a critical update **must** be deployed, Cloud Operations will:
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add snippet for brokered aws services
- This is for aws redis/elasticsearch SCR CP-2, etc.

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/peterb/aws-contingency)


## Security Considerations
[Note the any security considerations here, or make note of why there are none]
