### PR TITLE
Add details of how to set env vars for AWS cli on Windows

### DIFF
--- a/_docs/services/s3.md
+++ b/_docs/services/s3.md
@@ -95,9 +95,11 @@ For interactive file transfer tools, you will usually see a dialog box or form t
 
 For automated or CLI processes, you may want to use the [jq](https://stedolan.github.io/jq/) tool to automate extraction of the necessary values from the service key.
 
-For example, you might want to use the [AWS Command Line Interface](https://aws.amazon.com/cli/) to add, modify, and download files in a bucket. The AWS CLI requires the values above as environment variables. This script will set them:
+For example, you might want to use the [AWS Command Line Interface](https://aws.amazon.com/cli/) to add, modify, and download files in a bucket. The AWS CLI requires the values above as environment variables. If you are using Linux or Mac, this script will set them for you:
 
 ```sh
+#!/bin/bash
+
 SERVICE_INSTANCE_NAME=your-s3-service-instance-name-here
 KEY_NAME=your-service-key-name-here
 
@@ -109,6 +111,8 @@ export AWS_SECRET_ACCESS_KEY=`echo "${S3_CREDENTIALS}" | jq -r .secret_access_ke
 export BUCKET_NAME=`echo "${S3_CREDENTIALS}" | jq -r .bucket`
 export AWS_DEFAULT_REGION=`echo "${S3_CREDENTIALS}" | jq -r '.region'`
 ```
+
+If you are running Windows on your local machine, you can find [instructions on how to set environmental variables using the Windows Command Prompt or PowerShell here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-set).
 
 This will set the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` and `BUCKET_NAME` environment variables, enabling the AWS CLI tool to add, download and modify files as needed:
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add link to detailed instructions for setting env vars for the AWS cli on Windows.
- Current instructions assume Linux or Mac, and many of our partners are Windows users.

Preview link here: https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/aws-cli-s3-config/docs/services/s3/#interacting-with-your-s3-bucket-from-outside-cloudgov

## Security Considerations
None. Content change only.
