### PR TITLE
Fix `aws-elasticache` typo

### DIFF
--- a/_docs/services/redis.md
+++ b/_docs/services/redis.md
@@ -9,7 +9,7 @@ redirect_from:
 - /docs/services/redis32
 ---
 
-Note - this service is being deprecated in favor of the [aws-elascticahe]({{ site.baseurl }}{% link _docs/services/aws-elasticache.md %}).
+Note - this service is being deprecated in favor of the [aws-elasticache]({{ site.baseurl }}{% link _docs/services/aws-elasticache.md %}).
 
 cloud.gov offers [Redis](http://www.redis.io/) 3.2 as a service.
 


### PR DESCRIPTION
## Changes proposed in this pull request:
-
-
-

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)


## Security Considerations
[Note the any security considerations here, or make note of why there are none]
