### PR TITLE
Fix `aws-elasticsearch` typo

### DIFF
--- a/_docs/services/elasticsearch56.md
+++ b/_docs/services/elasticsearch56.md
@@ -7,7 +7,7 @@ name: "elasticsearch56"
 description: "Elasticsearch version 5.6: a distributed, RESTful search and analytics engine"
 ---
 
-Note - this service is being deprecated in favor of the [aws-elascticsearch]({{ site.baseurl }}{% link _docs/services/aws-elasticsearch.md %}).
+Note - this service is being deprecated in favor of the [aws-elasticsearch]({{ site.baseurl }}{% link _docs/services/aws-elasticsearch.md %}).
 
 
 cloud.gov offers [Elasticsearch](https://www.elastic.co/) 5.6 as a service.


### PR DESCRIPTION
## Changes proposed in this pull request:
-
-
-

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)


## Security Considerations
[Note the any security considerations here, or make note of why there are none]
