### PR TITLE
Fix typo in aws-elasticsearch link

### DIFF
--- a/_docs/services/elasticsearch56.md
+++ b/_docs/services/elasticsearch56.md
@@ -7,7 +7,7 @@ name: "elasticsearch56"
 description: "Elasticsearch version 5.6: a distributed, RESTful search and analytics engine"
 ---
 
-Note - this service is being deprecated in favor of the [aws-elascticsearch]({{ site.baseurl }}{% link _docs/services/aws-elasticsearch.md %}).
+Note - this service is being deprecated in favor of the [aws-elasticsearch]({{ site.baseurl }}{% link _docs/services/aws-elasticsearch.md %}).
 
 
 cloud.gov offers [Elasticsearch](https://www.elastic.co/) 5.6 as a service.


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fix typo in aws-elasticsearch link

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)


## Security Considerations
None - just text
