### PR TITLE
consolidate typo PRs and update docs on instance sharing

### DIFF
--- a/_docs/deployment/managed-services.md
+++ b/_docs/deployment/managed-services.md
@@ -37,7 +37,7 @@ Create a new service instance by specifying a service, plan, and a name of your 
 
 ### Sharing service instances
 
-Sharing of service instances allows customers to share service instances between spaces inside their organization as a way to consolidate service instance usage and avoid data duplication in their service instances.  Customers need to be aware that sharing service instances between spaces has limitations and can expose data in those service instances across environment boundaries.  Please see [Sharing Service Instances](https://docs.cloudfoundry.org/devguide/services/sharing-instances.html) for more information on limitations and security concerns.
+Sharing of service instances allows users to share service instances between spaces inside their organization as a way to consolidate service instance usage and avoid data duplication in their service instances.  Users need to be aware that sharing service instances between spaces has limitations and can expose data in those service instances across environment boundaries.  Please see [Sharing Service Instances](https://docs.cloudfoundry.org/devguide/services/sharing-instances.html) for more information on limitations and security concerns.
 
 ```
 % cf share-service SERVICE-INSTANCE -s OTHER-SPACE [-o OTHER-ORG]

--- a/_docs/deployment/managed-services.md
+++ b/_docs/deployment/managed-services.md
@@ -3,7 +3,7 @@ title: Managed services
 parent: deployment
 layout: docs
 sidenav: true
-redirect_from: 
+redirect_from:
   - /docs/apps/managed-services/
   - /overview/pricing/managed-services
   - /overview/pricing/other-services/
@@ -35,9 +35,17 @@ Create a new service instance by specifying a service, plan, and a name of your 
 % cf create-service SERVICE_NAME PLAN_NAME INSTANCE_NAME
 ```
 
+### Sharing service instances
+
+Sharing of service instances allows customers to share service instances between spaces inside their organization as a way to consolidate service instance usage and avoid data duplication in their service instances.  Customers need to be aware that sharing service instances between spaces has limitations and can expose data in those service instances across environment boundaries.  Please see [Sharing Service Instances](https://docs.cloudfoundry.org/devguide/services/sharing-instances.html) for more information on limitations and security concerns.
+
+```
+% cf share-service SERVICE-INSTANCE -s OTHER-SPACE [-o OTHER-ORG]
+```
+
 ### Bind the service instance
 
-For services that apply to an application ([Elasticsearch]({{ site.baseurl }}{% link _docs/services/elasticsearch56.md %}), [Redis]({{ site.baseurl }}{% link _docs/services/redis.md %}), [relational databases (RDS)]({{ site.baseurl }}{% link _docs/services/relational-database.md %}), and [S3]({{ site.baseurl }}{% link _docs/services/s3.md %})), the service instance must be bound to the application which will access it. (The [CDN service]({{ site.baseurl }}{% link _docs/services/cdn-route.md %}), [identity provider]({{ site.baseurl }}{% link _docs/services/cloud-gov-identity-provider.md %}), and [service account]({{ site.baseurl }}{% link _docs/services/cloud-gov-service-account.md %}) have different instructions, available in their service documentation.) 
+For services that apply to an application ([Elasticsearch]({{ site.baseurl }}{% link _docs/services/elasticsearch56.md %}), [Redis]({{ site.baseurl }}{% link _docs/services/redis.md %}), [relational databases (RDS)]({{ site.baseurl }}{% link _docs/services/relational-database.md %}), and [S3]({{ site.baseurl }}{% link _docs/services/s3.md %})), the service instance must be bound to the application which will access it. (The [CDN service]({{ site.baseurl }}{% link _docs/services/cdn-route.md %}), [identity provider]({{ site.baseurl }}{% link _docs/services/cloud-gov-identity-provider.md %}), and [service account]({{ site.baseurl }}{% link _docs/services/cloud-gov-service-account.md %}) have different instructions, available in their service documentation.)
 
 Binding to an application can be done in a single step by adding a binding to the application's `manifest.yml`, for example:
 

--- a/_docs/services/aws-elasticsearch.md
+++ b/_docs/services/aws-elasticsearch.md
@@ -8,7 +8,7 @@ description: "AWS Elasticsearch version 7.4: a distributed, RESTful search and a
 status: "Production Ready"
 ---
 
-cloud.gov is prod to offer [aws-elasticsearch](https://www.elastic.co/) 7.4 as a service hosted in AWS Elasticsearch
+cloud.gov is proud to offer [aws-elasticsearch](https://www.elastic.co/) 7.4 as a service hosted in AWS Elasticsearch
 
 ## Changes
 

--- a/_docs/services/elasticsearch56.md
+++ b/_docs/services/elasticsearch56.md
@@ -7,7 +7,7 @@ name: "elasticsearch56"
 description: "Elasticsearch version 5.6: a distributed, RESTful search and analytics engine"
 ---
 
-Note - this service is being deprecated in favor of the [aws-elascticsearch]({{ site.baseurl }}{% link _docs/services/aws-elasticsearch.md %}).
+Note - this service is being deprecated in favor of the [aws-elasticsearch]({{ site.baseurl }}{% link _docs/services/aws-elasticsearch.md %}).
 
 
 cloud.gov offers [Elasticsearch](https://www.elastic.co/) 5.6 as a service.

--- a/_docs/services/redis.md
+++ b/_docs/services/redis.md
@@ -9,7 +9,7 @@ redirect_from:
 - /docs/services/redis32
 ---
 
-Note - this service is being deprecated in favor of the [aws-elascticahe]({{ site.baseurl }}{% link _docs/services/aws-elasticache.md %}).
+Note - this service is being deprecated in favor of the [aws-elasticache]({{ site.baseurl }}{% link _docs/services/aws-elasticache.md %}).
 
 cloud.gov offers [Redis](http://www.redis.io/) 3.2 as a service.
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Typo fixes
- Add segment for instance sharing under deployment/managed services

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/fixes_and_sharing)

Consolidated and closed PRs being done in this PR:
- https://github.com/cloud-gov/cg-site/pull/1819
- https://github.com/cloud-gov/cg-site/pull/1818
- https://github.com/cloud-gov/cg-site/pull/1817

## Security Considerations
n/a
