### PR TITLE
Update blog pagination per page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -201,7 +201,7 @@ pagination:
   # The default document collection to paginate if nothing is specified ('posts' is default)
   collection: "posts"
   # How many objects per paginated page, used to be `paginate` (default: 0, means all)
-  per_page: 3
+  per_page: 8
   # The permalink structure for the paginated pages (this can be any level deep)
   permalink: "/page/:num/" # Pages are index.html inside this folder (default)
   #permalink: '/page/:num.html' # Pages are simple html files


### PR DESCRIPTION
## Changes proposed in this pull request:
- Increase from 3 posts per page to 8 (any other number of posts per page welcome)

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/apb/increase-blog-pagination/news/)

## Security Considerations
none
