### PR TITLE
clarify service account role assignment

### DIFF
--- a/_docs/services/cloud-gov-service-account.md
+++ b/_docs/services/cloud-gov-service-account.md
@@ -14,10 +14,12 @@ To set up your application to be deployed with an automated system, you need a d
 
 ## Plans
 
-Plan Name | Description | 
---------- | ----------- | -----
-`space-deployer` | A service account for continuous deployment, initially limited to a single space | 
-`space-auditor` | A service account for auditing configuration and monitoring events, initially limited to a single space | 
+Plan Name | Description | Cloud Foundry Role
+--------- | ----------- | -------------------|
+`space-deployer` | A service account for continuous deployment, initially limited to a single space | SpaceDeveloper | 
+`space-auditor` | A service account for auditing configuration and monitoring events, initially limited to a single space | SpaceAuditor |
+
+For details on the capabilities of the SpaceDeveloper and SpaceAuditor roles, please see the Cloud Foundry documentation: https://docs.cloudfoundry.org/concepts/roles.html.
 
 > Note: Service accounts will initially be assigned a single role (SpaceDeveloper or SpaceAuditor) in a single space. However, you can add/remove roles for this account in any org and/or space using the `cf` CLI. Please be sure to read the documentation and understand the ramifications of role modifications before proceeding: https://docs.cloudfoundry.org/concepts/roles.html.
 

--- a/_docs/services/cloud-gov-service-account.md
+++ b/_docs/services/cloud-gov-service-account.md
@@ -19,7 +19,7 @@ Plan Name | Description | Cloud Foundry Role
 `space-deployer` | A service account for continuous deployment, initially limited to a single space | SpaceDeveloper | 
 `space-auditor` | A service account for auditing configuration and monitoring events, initially limited to a single space | SpaceAuditor |
 
-For details on the capabilities of the SpaceDeveloper and SpaceAuditor roles, please see the Cloud Foundry documentation: https://docs.cloudfoundry.org/concepts/roles.html.
+The `space-deployer` service account is assigned the `SpaceDeveloper` role in the space (pushing apps, provisioning services, etc). The `space-auditor` service account is assigned the `SpaceAuditor` role in the space (read-only access). For details on the capabilities associated with the SpaceDeveloper and SpaceAuditor roles, please see the Cloud Foundry documentation: https://docs.cloudfoundry.org/concepts/roles.html. 
 
 > Note: Service accounts will initially be assigned a single role (SpaceDeveloper or SpaceAuditor) in a single space. However, you can add/remove roles for this account in any org and/or space using the `cf` CLI. Please be sure to read the documentation and understand the ramifications of role modifications before proceeding: https://docs.cloudfoundry.org/concepts/roles.html.
 

--- a/_docs/services/cloud-gov-service-account.md
+++ b/_docs/services/cloud-gov-service-account.md
@@ -16,8 +16,10 @@ To set up your application to be deployed with an automated system, you need a d
 
 Plan Name | Description | 
 --------- | ----------- | -----
-`space-deployer` | A service account for continuous deployment, limited to a single space | 
+`space-deployer` | A service account for continuous deployment, initially limited to a single space | 
 `space-auditor` | A service account for auditing configuration and monitoring events limited to a single space | 
+
+> Note: Service accounts will initially be assigned a role (SpaceDeveloper or SpaceAuditor) in a single space. However, you can add/remove roles for this account in any org and/or space using the `cf` CLI. Please be sure to read the documentation and understand the ramifications of role modifications before proceeding: https://docs.cloudfoundry.org/concepts/roles.html.
 
 *These instances are available in [sandbox spaces]({{ site.baseurl }}{% link _docs/pricing/free-limited-sandbox.md %}#sandbox-limitations).*
 

--- a/_docs/services/cloud-gov-service-account.md
+++ b/_docs/services/cloud-gov-service-account.md
@@ -17,9 +17,9 @@ To set up your application to be deployed with an automated system, you need a d
 Plan Name | Description | 
 --------- | ----------- | -----
 `space-deployer` | A service account for continuous deployment, initially limited to a single space | 
-`space-auditor` | A service account for auditing configuration and monitoring events limited to a single space | 
+`space-auditor` | A service account for auditing configuration and monitoring events, initially limited to a single space | 
 
-> Note: Service accounts will initially be assigned a role (SpaceDeveloper or SpaceAuditor) in a single space. However, you can add/remove roles for this account in any org and/or space using the `cf` CLI. Please be sure to read the documentation and understand the ramifications of role modifications before proceeding: https://docs.cloudfoundry.org/concepts/roles.html.
+> Note: Service accounts will initially be assigned a single role (SpaceDeveloper or SpaceAuditor) in a single space. However, you can add/remove roles for this account in any org and/or space using the `cf` CLI. Please be sure to read the documentation and understand the ramifications of role modifications before proceeding: https://docs.cloudfoundry.org/concepts/roles.html.
 
 *These instances are available in [sandbox spaces]({{ site.baseurl }}{% link _docs/pricing/free-limited-sandbox.md %}#sandbox-limitations).*
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Clarifies roles assigned to service accounts can be manipulated if necessary.

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)


## Security Considerations

This makes clear that roles can be assigned to service accounts (this is a feature of the platform and therefore it should be documented). On the surface, this may appear risky (for example assigning an OrgManager role), but given that a service account could be created for every space I do not believe there is any more risk calling out this capability. 
