### PR TITLE
Update nokogiri version to address vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,5 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
 gem "html-proofer", "~> 3.10"
 gem "kramdown-parser-gfm"
+
+gem "nokogiri", ">= 1.11.0.rc4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,10 +88,11 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.1)
-    nokogiri (1.10.8)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.0.rc4)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     nokogumbo (2.0.2)
       nokogiri (~> 1.8, >= 1.8.4)
     parallel (1.19.1)
@@ -99,6 +100,7 @@ GEM
       forwardable-extended (~> 2.6)
     posix-spawn (0.3.15)
     public_suffix (4.0.5)
+    racc (1.5.2)
     rack (2.2.3)
     rainbow (3.0.0)
     rb-fsevent (0.10.4)
@@ -136,6 +138,7 @@ DEPENDENCIES
   jekyll-seo-tag
   jekyll-sitemap
   kramdown-parser-gfm
+  nokogiri (>= 1.11.0.rc4)
   sprockets (~> 3.7)
   tzinfo-data
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Bump the version of the `nokogiri` gem used to 1.11.0.rc4 to address vulnerability.

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/update-nokogiri)

## Security Considerations
Updates dependency that has known vulnerability
