### PR TITLE
Adjust overflow scrolling of code blocks

### DIFF
--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -363,7 +363,7 @@ code {
   @include u-display("block");
   border-radius: radius('sm');
   word-wrap: break-word;
-  white-space: pre-wrap;
+  overflow: auto;
   line-height: line-height("mono", 1);
 }
 


### PR DESCRIPTION
This changeset updates our code blocks to allow for scrolling for content that expands beyond a visible line.  However, there are a couple of caveats:

- Modern browsers and OSes never display the scrollbars, even if you can scroll and set the `overflow` property to `scroll`
- It is not visibly clear that you can scroll

I am not sure if this is a better solution, but it is confusing when we have lines of code that get truncated and pushed to the next line, making it look like separate lines of code when they are not.  We may have to reformat some of our code blocks to account for this instead.

If folks aren't happy with this solution then we shouldn't merge it; however, I'd like to make sure this is addressed in any redesign or more significant layout changes.

## Changes proposed in this pull request:
- Change CCS `word-wrap` property to `overflow` for code blocks

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/adjust-code-block-overflow/docs/ops/runbook/troubleshooting-logsearch/#reindexing-data-from-s3-partial-day)

## Security Considerations
- None; site formatting changes