### PR TITLE
Update partial reindexing logsearch docs

### DIFF
--- a/_docs/ops/runbook/troubleshooting-logsearch.md
+++ b/_docs/ops/runbook/troubleshooting-logsearch.md
@@ -108,6 +108,8 @@ prefix => "1968/11/15/08"
 
 You're able to go down to the minute; check the S3 bucket to verify the path(s) that you would like to reindex.
 
+Lastly, if you want to run multiple days, hours or minutes, you can declare multiple S3 blocks with the unique prefix paths (e.g., `2021/01/00`, `2021/01/01`, `2021/01/02/00`) to run multiple batches of data without needing to rerun and update the S3 block settings. Each block just needs a unique prefix and unique `.sincedb` file.
+
 #### Configure logstash to index log entries by the date in the file and not the current time.
 
 _follow these steps to index a small portion of a day. This is fairly quick, but a bit fidly at the start and end times. Alternately, reindex the whole day._
@@ -174,7 +176,6 @@ Run logstash passing in your edited configuration file:
 
 ```sh
 export JAVA_HOME=/var/vcap/packages/openjdk-11/jre
-rm /var/vcap/data/ingestor_syslog/tmp/s3_import.sincedb
 /var/vcap/packages/logstash/bin/logstash --path.config /var/vcap/data/ingestor_syslog/tmp/logstash-restore.config
 ```
 
@@ -210,20 +211,11 @@ To restore the ingestor to known good configuration after the restore, recreate 
 bosh -d logsearch recreate ingestor/0
 ```
 
-This will also remove the IAM role policy you added to the VM.  Finally, restore the IAM role policy itself.  Adjust the Allow Actions block to its former state:
+This will also remove the IAM role policy you added to the VM.  Finally, restore the IAM role policy itself.  Refer to the current policy definition in the [logsearch IAM role policy](https://github.com/cloud-gov/cg-provision/blob/master/terraform/modules/iam_role_policy/logsearch_ingestor/policy.json) to revert the changes properly and save the changes.
 
-```
-"s3:PutObject",
-"s3:DeleteObject"
-```
+### If you need to rerun the reindexing
 
-And adjust the Allow Resources block to its former state:
-
-```
-"arn:${aws_partition}:s3:::logsearch-*/*"
-```
-
-Now save the policy, and you're done!
+When running the reindexing, if there is an issue at any point and you need to restart, make whatever adjustments you need to and be sure to remove any of the new `.sincedb` files created before starting again.
 
 ## Reindexing whole days from S3
 

--- a/_docs/ops/runbook/troubleshooting-logsearch.md
+++ b/_docs/ops/runbook/troubleshooting-logsearch.md
@@ -56,9 +56,12 @@ A copy of all data received by the logsearch ingestors is archived in S3.  This 
 
 These instructions are for indexing arbitrary lengths of time into the existing daily indices. It's often easier to reindex a whole day's data, replacing the existing index for that day. Instructions for doing so follow these instructions.
 
+Also note that you may want to pause some Concourse pipelines before starting this work so that redeployments don't disrupt your progress, particularly those that would impact logsearch.
+
 ### Create a custom logstash.conf for the restore operation
 
 Log into any `ingestor` node and make a copy of its current logstash configuration.
+
 ```sh
 bosh -d logsearch ssh ingestor/0
 
@@ -67,7 +70,8 @@ cp /var/vcap/jobs/ingestor_syslog/config/logstash.conf /var/vcap/data/ingestor_s
 
 Edit the `/tmp/logstash-restore.conf` and make the following changes:
 
-#### Update the "input" block to only contain s3
+#### Update the "input" block to only contain S3 information
+
 ```
 input {
   s3 {
@@ -83,28 +87,31 @@ input {
 ```
 
 The values for `:bucket:` and `:region:` can be found in [cg-provision](https://github.com/18F/cg-provision/blob/master/terraform/modules/cloudfoundry/buckets.tf#L25-L30) or retrieved from the bosh manifest:
+
 ```sh
-spruce merge --cherry-pick properties.logstash_ingestor.outputs <(bosh -d logsearch manifest)`
+bosh -d logsearch manifest
 ```
 
-When run with default configuration the S3 input plugin will reindex ALL data in the bucket. To reindex a specific subset of data pass [additional options to the s3 input plugin](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-s3.html).
+When run with default configuration the S3 input plugin will reindex ALL data in the bucket. To reindex a specific subset of data pass [additional options to the S3 input plugin](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-s3.html).
 
-For example, to reindex only data from November 15th, 1968 use a `prefix` to limit to files that match that date: `prefix => "1968/11/15"`.
+For example, to reindex only data from November 15th, 1968 use a `prefix` to limit to files that match that date:
 
-#### Disable the timecop filter
-
-The default Logsearch-for-CloudFoundry configuration will drop any messages older than 24 hours. When reindexing older data this sanity check needs to be disabled.
-
-To disable the timecop filter set the environment variable `TIMECOP_REJECT_LESS_THAN_HOURS` to match the desired rentention policy:
-```sh
-export TIMECOP_REJECT_LESS_THAN_HOURS=$((180 * 24))
 ```
+prefix => "1968/11/15"
+```
+
+To reindex data from a specific hour of that day, include that in the `prefix`:
+
+```
+prefix => "1968/11/15/08"
+```
+
+You're able to go down to the minute; check the S3 bucket to verify the path(s) that you would like to reindex.
 
 #### Configure logstash to index log entries by the date in the file and not the current time.
 
 _follow these steps to index a small portion of a day. This is fairly quick, but a bit fidly at the start and end times. Alternately, reindex the whole day._
 Using the default configuration logstash will reindex documents into an index for the current day. To avoid this configure logstash to generate indexes based on the timestamps in the data being imported from S3.
-
 
 Add this stanza to the end of the `filters` section in `/var/vcap/data/ingestor_syslog/tmp/logstash-restore.conf`
 
@@ -123,34 +130,100 @@ mutate {
 ```
 
 Edit the `output` section in `/var/vcap/data/ingestor_syslog/tmp/logstash-restore.conf` and change `index` to:
+
 ```
 index => "logs-%{@index_type}-%{[@metadata][index-date]}"
 ```
+
+### Disable the timecop filter
+
+The default Logsearch-for-CloudFoundry configuration will drop any messages older than 24 hours. When reindexing older data this sanity check needs to be disabled.
+
+To disable the timecop filter set the environment variable `TIMECOP_REJECT_LESS_THAN_HOURS` to match the desired rentention policy:
+
+```sh
+export TIMECOP_REJECT_LESS_THAN_HOURS=$((180 * 24))
+```
+
+### Adjust the IAM role policy to allow the reindexing to read from the S3 bucket
+
+You must go in to the AWS console and adjust the IAM role policy for the environment ingestor you are restoring in, then
+attach the role policy to the ingestor VM you are working in.  When you find the IAM role policy, make sure the Allow Actions match this block:
+
+```
+"s3:PutObject",
+"s3:DeleteObject",
+"s3:GetObject",
+"s3:ListObjects",
+"s3:ListObjectsV2",
+"s3:ListObjectVersions",
+"s3:ListBucket"
+```
+
+Then make sure that Allow Resources matches this block:
+
+```
+"arn:${aws_partition}:s3:::logsearch-*/*",
+"arn:${aws_partition}:s3:::logsearch-*"
+```
+
+Save the role policy adjustments, then attach the role policy to the ingestor VM you are working in.
 
 ### Start the reindexing
 Run logstash passing in your edited configuration file:
 
 ```sh
 export JAVA_HOME=/var/vcap/packages/openjdk-11/jre
-rm /tmp/s3_import.sincedb
+rm /var/vcap/data/ingestor_syslog/tmp/s3_import.sincedb
 /var/vcap/packages/logstash/bin/logstash --path.config /var/vcap/data/ingestor_syslog/tmp/logstash-restore.config
 ```
 
-### Monitor progress
+### Monitor reindexing progress
 
-Logstash will run forever once started. Monitor the progress of the reindex, and stop logstash once the data has been reindexed. Progress can be monitored by tailing the sincedb file which logstash will update after each file it processes.
+Logstash will run forever once started. Monitor the progress of the reindex, and stop logstash once the data has been reindexed. Progress can be monitored by first setting turning the logstash reindexing to a background process and then by tailing the sincedb file which logstash will update after each file it processes:
 
 ```sh
+# While logstash process is running in your foreground:
+<Ctrl>+Z
+bg
+disown
+
+# Once the process is in the background and you're back at the terminal:
 watch cat /var/vcap/data/ingestor_syslog/tmp/s3_import.sincedb
 ```
 
-### Recreate ingestor
+When the proocess has finishing ingesting up to the point at which you are done, kill the background process:
+
+```sh
+# Find the pid (process ID) of the logstash process you put in the background:
+ps aux | grep <process name>
+
+# Terminate the process:
+kill <pid>
+```
+
+### Recreate ingestor and restore IAM role policy
 
 To restore the ingestor to known good configuration after the restore, recreate the VM:
 
 ```sh
 bosh -d logsearch recreate ingestor/0
 ```
+
+This will also remove the IAM role policy you added to the VM.  Finally, restore the IAM role policy itself.  Adjust the Allow Actions block to its former state:
+
+```
+"s3:PutObject",
+"s3:DeleteObject"
+```
+
+And adjust the Allow Resources block to its former state:
+
+```
+"arn:${aws_partition}:s3:::logsearch-*/*"
+```
+
+Now save the policy, and you're done!
 
 ## Reindexing whole days from S3
 


### PR DESCRIPTION
This changeset updates our instructions for a partial day reindex with logsearch based on our most recent quarterly backup exercise.

## Changes proposed in this pull request:
- A note about pausing pipelines in Concourse before starting
- Reorganizing of steps to make it easier to follow
- Expanded information on providing specific timeframes
- Added instructions for modifying an IAM role policy
- Correction for the rm statement to cleanup previous reindexing attempts
- Improved documentation for monitoring the progress of reindexing

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/update-partial-log-restore-docs/docs/ops/runbook/troubleshooting-logsearch/#reindexing-data-from-s3-partial-day)

## Security considerations
- Some mention of IAM role policy adjustments, however these instructions are pulled from previous work done publicly in a [cg-provision PR](https://github.com/cloud-gov/cg-provision/pull/798)