### PR TITLE
adding # of nodes col to help customers understand pricing better

### DIFF
--- a/_docs/services/aws-elasticache.md
+++ b/_docs/services/aws-elasticache.md
@@ -12,8 +12,8 @@ cloud.gov offers [aws-elasticache-redis](https://aws.amazon.com/elasticache/) Re
 
 ## Plans
 
-Service Name | Plan Name | Description | Num of nodes |
------------- | --------- | ----------- | ------------ | -----
+Service Name | Plan Name | Description | Number of nodes |
+------------ | --------- | ----------- | --------------- | -----
 `aws-elasticache-redis` | `redis-dev` | Single EC node for non-prod use only | 1 |
 `aws-elasticache-redis` | `redis-3node` | 3 node EC, persistent storage, 512Mb memory limit | 3 |
 `aws-elasticache-redis` | `redis-5node` | 5 node EC, persistent storage, 512Mb memory limit | 5 |

--- a/_docs/services/aws-elasticache.md
+++ b/_docs/services/aws-elasticache.md
@@ -12,11 +12,11 @@ cloud.gov offers [aws-elasticache-redis](https://aws.amazon.com/elasticache/) Re
 
 ## Plans
 
-Service Name | Plan Name | Description |
------------- | --------- | ----------- | -----
-`aws-elasticache-redis` | `redis-dev` | Single EC node for non-prod use only |
-`aws-elasticache-redis` | `redis-3node` | 3 node EC, persistent storage, 512Mb memory limit |
-`aws-elasticache-redis` | `redis-5node` | 5 node EC, persistent storage, 512Mb memory limit |
+Service Name | Plan Name | Description | Num of nodes |
+------------ | --------- | ----------- | ------------ | -----
+`aws-elasticache-redis` | `redis-dev` | Single EC node for non-prod use only | 1 |
+`aws-elasticache-redis` | `redis-3node` | 3 node EC, persistent storage, 512Mb memory limit | 3 |
+`aws-elasticache-redis` | `redis-5node` | 5 node EC, persistent storage, 512Mb memory limit | 5 |
 
 
 

--- a/_docs/services/aws-elasticsearch.md
+++ b/_docs/services/aws-elasticsearch.md
@@ -20,8 +20,8 @@ This service is currently running Elasticsearch 7.4.  Our prior Elasticsearch se
 
 ## Plans
 
-Service Name | Plan Name | Description | Num of nodes |
------------- | --------- | ----------- | ------------ | -----
+Service Name | Plan Name | Description | Number of nodes |
+------------ | --------- | ----------- | --------------- | -----
 `aws-elasticsearch` | `es-dev` | Single data node for non-prod use only | 1 |
 `aws-elasticsearch` | `es-medium` | 3 Master and 2 Data node cluster | 5 |
 `aws-elasticsearch` | `es-medium-ha` | 3 Master and 4 Data node cluster | 7 |

--- a/_docs/services/aws-elasticsearch.md
+++ b/_docs/services/aws-elasticsearch.md
@@ -20,11 +20,11 @@ This service is currently running Elasticsearch 7.4.  Our prior Elasticsearch se
 
 ## Plans
 
-Service Name | Plan Name | Description |
------------- | --------- | ----------- | -----
-`aws-elasticsearch` | `es-dev` | Single data node for non-prod use only |
-`aws-elasticsearch` | `es-medium` | 3 Master and 2 Data node cluster |
-`aws-elasticsearch` | `es-medium-ha` | 3 Master and 4 Data node cluster |
+Service Name | Plan Name | Description | Num of nodes |
+------------ | --------- | ----------- | ------------ | -----
+`aws-elasticsearch` | `es-dev` | Single data node for non-prod use only | 1 |
+`aws-elasticsearch` | `es-medium` | 3 Master and 2 Data node cluster | 5 |
+`aws-elasticsearch` | `es-medium-ha` | 3 Master and 4 Data node cluster | 7 |
 
 
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- To the new AWS services pages, added an additional column to show the number of nodes with each service plan to make it easier for customers to figure out how many nodes they are using

- EC: https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/node-col/docs/services/aws-elasticache/

- ES: https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/node-col/docs/services/aws-elasticsearch/

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/node-col)


## Security Considerations
n/a
