### PR TITLE
Remove references to master

### DIFF
--- a/_docs/deployment/deployment.md
+++ b/_docs/deployment/deployment.md
@@ -14,7 +14,7 @@ Learn [how to get your application up](#how-deployment-works) and [important app
 
 The command to create a new app and to push a new version of an existing one are the same: `cf push`. The steps:
 
-1. Set up your local directory with the code you want to deploy. For example, if you use Git, check out the code you want to deploy: `git checkout master`
+1. Set up your local directory with the code you want to deploy. For example, if you use Git, check out the code you want to deploy: `git checkout main`
 
 1. [Target]({{ site.baseurl }}{% link _docs/getting-started/concepts.md %}#target) the appropriate [organization]({{ site.baseurl }}{% link _docs/getting-started/concepts.md %}#organizations)/[space]({{ site.baseurl }}{% link _docs/getting-started/concepts.md %}#spaces): `cf target -o <ORG> -s <SPACE>`
 1. Deploy the application: `cf push <APPNAME>`

--- a/_docs/getting-started/code-samples.md
+++ b/_docs/getting-started/code-samples.md
@@ -33,9 +33,9 @@ If you have Git installed:
 
 `cd cf-sample-app-spring`
 
-If you don’t have Git installed, download [`master.zip`](https://github.com/18F/cf-sample-app-spring/archive/master.zip) from the repository, unzip `master.zip`, then:
+If you don’t have Git installed, download [`main.zip`](https://codeload.github.com/cloud-gov/cf-sample-app-spring/zip/main.zip) from the repository, unzip `main.zip`, then:
 
-`cd cf-sample-app-spring-master`
+`cd cf-sample-app-spring-main`
 
 ##### Connect to cloud.gov
 
@@ -111,9 +111,9 @@ git clone https://github.com/18F/cf-hello-worlds
 cd cf-hello-worlds
 ```
 
-If you don’t have Git installed, download [`master.zip`](https://github.com/18F/cf-hello-worlds/archive/master.zip) from the repository, unzip `master.zip`, then:
+If you don’t have Git installed, download [`main.zip`](https://github.com/18F/cf-hello-worlds/archive/main.zip) from the repository, unzip `main.zip`, then:
 
-`cd cf-hello-worlds-master`
+`cd cf-hello-worlds-main`
 
 ##### Choose a framework
 

--- a/_docs/getting-started/code-samples.md
+++ b/_docs/getting-started/code-samples.md
@@ -33,7 +33,7 @@ If you have Git installed:
 
 `cd cf-sample-app-spring`
 
-If you don’t have Git installed, download [`main.zip`](https://codeload.github.com/cloud-gov/cf-sample-app-spring/zip/main.zip) from the repository, unzip `main.zip`, then:
+If you don’t have Git installed, download [`main.zip`](https://github.com/cloud-gov/cf-sample-app-spring/archive/main.zip) from the repository, unzip `main.zip`, then:
 
 `cd cf-sample-app-spring-main`
 
@@ -111,7 +111,7 @@ git clone https://github.com/18F/cf-hello-worlds
 cd cf-hello-worlds
 ```
 
-If you don’t have Git installed, download [`main.zip`](https://github.com/18F/cf-hello-worlds/archive/main.zip) from the repository, unzip `main.zip`, then:
+If you don’t have Git installed, download [`main.zip`](https://github.com/cloud-gov/cf-hello-worlds/archive/main.zip) from the repository, unzip `main.zip`, then:
 
 `cd cf-hello-worlds-main`
 

--- a/_docs/getting-started/your-first-deploy.md
+++ b/_docs/getting-started/your-first-deploy.md
@@ -45,7 +45,7 @@ cf target -o sandbox-gsa -s harry.truman
 
 1. Get code for "hello world" applications ([repository](https://github.com/18F/cf-hello-worlds)):
    * **Using git:** `git clone https://github.com/18F/cf-hello-worlds.git`
-   * **Download:** [`https://github.com/18F/cf-hello-worlds/archive/master.zip`](https://github.com/18F/cf-hello-worlds/archive/master.zip)
+   * **Download:** [`https://github.com/cloud-gov/cf-hello-worlds/archive/main.zip`](https://github.com/cloud-gov/cf-hello-worlds/archive/main.zip)
 1. Move into that directory, for example: `cd cf-hello-worlds`
 1. Look at the collection of tiny apps, and `cd` into the directory for the language/framework you feel most comfortable with. For example: `cd python-flask`
 1. Deploy the application, where `APPNAME` should be something unique like `FRAMEWORK-YOURNAME` (e.g. `python-truman`). By default, your `APPNAME` will become part of the route to make your application publicly reachable, usually `https://APPNAME.app.cloud.gov/` or similar, and route names must be unique across the platform.

--- a/_docs/management/continuous-deployment.md
+++ b/_docs/management/continuous-deployment.md
@@ -88,7 +88,7 @@ For more information about configuring Travis, see [Customizing the Build](https
 
 #### Using Conditional Deployments with Travis
 
-A common pattern for team workflows is to use separate development and master branches, along with using a staging or QA deployment with the development branch, and a production deployment with the master branch. This can be achieved in Travis with [`on:`](https://docs.travis-ci.com/user/deployment#Conditional-Releases-with-on%3A) to specify a branch, and using unique manifests for each deployment.
+A common pattern for team workflows is to use separate development and main branches, along with using a staging or QA deployment with the development branch, and a production deployment with the main branch. This can be achieved in Travis with [`on:`](https://docs.travis-ci.com/user/deployment#Conditional-Releases-with-on%3A) to specify a branch, and using unique manifests for each deployment.
 
 ```yaml
 deploy:
@@ -99,7 +99,7 @@ deploy:
 - manifest: manifest.yml
   # ...
   on:
-    branch: master
+    branch: main
 ```
 
 Each manifest should at the very least define an unique `name`, but can also define an unique `host`. Also, it may be necessary to define unique services for each application to use. See [Cloning Applications]({{ site.baseurl }}{% link _docs/management/cloning.md %}) for more information.
@@ -140,7 +140,7 @@ test:
 
 deployment:
   production:
-    branch: master
+    branch: main
     commands:
       - cf push
 ```
@@ -161,14 +161,14 @@ After following the instructions for setting up a [cloud.gov service account](ht
 
 #### Sample workflow
 
-The following is an example of a workflow that uses this action. This example shows how to deploy a simple [.NET Core app](https://github.com/cloud-gov/cf-hello-worlds/tree/master/dotnet-core) to cloud.gov
+The following is an example of a workflow that uses this action. This example shows how to deploy a simple [.NET Core app](https://github.com/cloud-gov/cf-hello-worlds/tree/main/dotnet-core) to cloud.gov
 
 ```yml
 name: .NET Core Deploy
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -194,7 +194,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Deploy to cloud.gov
-        uses: cloud-gov/cg-cli-tools@master
+        uses: cloud-gov/cg-cli-tools@main
         with: 
           cf_api: https://api.fr.cloud.gov
           cf_username: ${{ secrets.CG_USERNAME }}
@@ -203,4 +203,4 @@ jobs:
           cf_space: your-space
 ```
 
-Note the reference to `cloud-gov/cg-cli-tools@master` in the workflow file above. You can use another workflow file as part of your deployment process if you desire, or add additional steps to your workflow by referencing other GitHub actions.
+Note the reference to `cloud-gov/cg-cli-tools@main` in the workflow file above. You can use another workflow file as part of your deployment process if you desire, or add additional steps to your workflow by referencing other GitHub actions.

--- a/_docs/ops/configuration-management.md
+++ b/_docs/ops/configuration-management.md
@@ -34,7 +34,7 @@ Security tests need to be executed in the development environment where changes 
 
 1. All configuration changes must flow through a git repository, centrally managed through GitHub, unless they contain sensitive information. In these cases, sensitive information should be stored in an S3 bucket with a proper security policy and encryption, versioned such that changes can be easily rolled back.
 1. A change is initiated and discussed, following the steps in our [Story Lifecycle](https://github.com/cloud-gov/cg-product/blob/master/StoryLifecycle.md).
-1. In the appropriate GitHub repository for the component, a pull request (PR) against the `master` branch is created that addresses the change.
+1. In the appropriate GitHub repository for the component, a pull request (PR) against the main branch is created that addresses the change (note - sometimes this branch is called `main`, other times it is not, be sure to check).
 1. If the repository contains cloud.gov-developed code, the PR must have an automated [Code Climate](https://codeclimate.com) check, which must pass before the PR can be merged.
 1. The PR is reviewed by someone other than the committer. Pairing via screen-sharing
 is encouraged and qualifies as a review. Review should include assessment of architectural design, DRY principles, security and code quality.

--- a/_docs/ops/runbook/restoring-rds.md
+++ b/_docs/ops/runbook/restoring-rds.md
@@ -40,7 +40,7 @@ cf target -s SPACE -o ORGANIZATION
 cf env APP
 ```
 
-The JSON containing the environment variables includes the `database identifier` and `password` under the key `host` within the credentials map for the database service (look for `aws-rds`).  The `database identifier` is needed to find the database instance in the AWS RDS instance listing, and the `password` is required for setting the master password in the new instance.
+The JSON containing the environment variables includes the `database identifier` and `password` under the key `host` within the credentials map for the database service (look for `aws-rds`).  The `database identifier` is needed to find the database instance in the AWS RDS instance listing, and the `password` is required for setting the primary password in the new instance.
 
 ### Performing the database restore
 
@@ -53,7 +53,7 @@ Prior to restoring, record the configuration settings of the existing instance:
 - VPC (dev, staging, etc.)
 - Subnet
 - Security Groups
-- Master password (this is the `password` you saw above in the application environment variables)
+- Primary password (this is the `password` you saw above in the application environment variables)
 
 Copy all of these values and configure them in the restore form to mirror the configuration of the existing database instance.  For the `identifier` name, provide a name like `<instance name>-<date>-restore` to make the instance easy to find.  Note that the database should never be set to publicly accessible.
 

--- a/_docs/services/aws-elasticsearch.md
+++ b/_docs/services/aws-elasticsearch.md
@@ -23,8 +23,8 @@ This service is currently running Elasticsearch 7.4.  Our prior Elasticsearch se
 Service Name | Plan Name | Description | Number of nodes |
 ------------ | --------- | ----------- | --------------- | -----
 `aws-elasticsearch` | `es-dev` | Single data node for non-prod use only | 1 |
-`aws-elasticsearch` | `es-medium` | 3 Master and 2 Data node cluster | 5 |
-`aws-elasticsearch` | `es-medium-ha` | 3 Master and 4 Data node cluster | 7 |
+`aws-elasticsearch` | `es-medium` | 3 Primary and 2 Data node cluster | 5 |
+`aws-elasticsearch` | `es-medium-ha` | 3 Primary and 4 Data node cluster | 7 |
 
 
 

--- a/_docs/services/elasticsearch56.md
+++ b/_docs/services/elasticsearch56.md
@@ -16,7 +16,7 @@ cloud.gov offers [Elasticsearch](https://www.elastic.co/) 5.6 as a service.
 
 Plan Name | Description |
 --------- | ----------- | -----
-`medium-ha` | Elasticsearch cluster with three master nodes (3584M memory limit, 1792M heap) and three data nodes (3584M memory limit, 1792M heap, 10G disk) |
+`medium-ha` | Elasticsearch cluster with three primary nodes (3584M memory limit, 1792M heap) and three data nodes (3584M memory limit, 1792M heap, 10G disk) |
 
 
 *Additional Cost:* Elasticsearch has a limit of 10GB in storage. After 10G, each additional gigabyte will cost $100 per month.

--- a/_posts/2018-10-30-release-notes.md
+++ b/_posts/2018-10-30-release-notes.md
@@ -32,7 +32,7 @@ Now, you can use **apps.internal** as a route for anything that shouldn't be pub
 
 ### Polyglot service discovery
 
-Along with internal routing, cloud.gov now also offers polyglot service discovery. You can use DNS from within your applications to refer to instances of that application. That means you can have different instances of the app act as master and follower nodes rather than just scaling naively, which enables clustered applications.
+Along with internal routing, cloud.gov now also offers polyglot service discovery. You can use DNS from within your applications to refer to instances of that application. That means you can have different instances of the app act as leader and follower nodes rather than just scaling naively, which enables clustered applications.
 
 You can also use these routes across language stacks — because it's DNS-based, it's not tied to a particular language library. See [this Cloud Foundry blog post](https://www.cloudfoundry.org/blog/polyglot-service-discovery-container-networking-cloud-foundry/) for details.
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removes references to `master` that are not needed, or that do not reference a Github repo branch that uses that word.
- Updates links to several cloud.gov repos that have renamed their primary branch to `main`
- For services with a `1 leader -> n followers` deployment model, remove the word `master` so long as it doesn't obfuscate important details of how the service works.
- Fixes #1871 

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/remove-master-refs)


## Security Considerations
None
