### PR TITLE
Add large types to table of offerings

### DIFF
--- a/_docs/services/aws-elasticache.md
+++ b/_docs/services/aws-elasticache.md
@@ -17,6 +17,9 @@ Service Name | Plan Name | Description | Number of nodes |
 `aws-elasticache-redis` | `redis-dev` | Single EC node for non-prod use only | 1 |
 `aws-elasticache-redis` | `redis-3node` | 3 node EC, persistent storage, 512Mb memory limit | 3 |
 `aws-elasticache-redis` | `redis-5node` | 5 node EC, persistent storage, 512Mb memory limit | 5 |
+`aws-elasticache-redis` | `redis-3node-large` | 3 node EC, persistent storage, 1.3GB memory limit | 3 |
+`aws-elasticache-redis` | `redis-5node-large` | 5 node EC, persistent storage, 1.3GB memory limit | 5 |
+
 
 
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add the addition 3 and 5 node large offering for AWS Elasticache Redis

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/apb/add-aws-redis-lg/docs/services/aws-elasticache/)

## Security Considerations
None
