### PR TITLE
Update using-ssh.md

### DIFF
--- a/_docs/management/using-ssh.md
+++ b/_docs/management/using-ssh.md
@@ -26,6 +26,8 @@ perform debugging, environment inspection, and other tasks.
 
 This overrides the port health check with the `process` check, and sets the start command to just `sleep`. That will give you 10 minutes to `cf ssh` and inspect your container.
 
+**Error opening SSH connection**: In prior versions of the CF API (CAPI) app instances used a single process. In version 3 of the CAPI, there can be more then 1 process that makes up and app. This may occasionally cause issues when trying to SSH to your app. If a modification or update was made to an app using a v3 command or process - even if that change was made by someone else (e.g., another member of a development team) - the app's schema in the Cloud Controller might have changed to version 3, and a standard `cf ssh` may no longer work. If this occurs, you can try using `cf v3-ssh {app-name}`. By default a `cf v3-ssh` will select the `web` process.  You can also select a different process with v3-ssh using the `--process` flag
+
 ### Error messages
 
 * `cf ssh` uses port 2222. If your network blocks port 2222, you may receive an error message such as `Error opening SSH connection` or `psql: could not connect to server: Connection refused`.

--- a/_docs/management/using-ssh.md
+++ b/_docs/management/using-ssh.md
@@ -26,7 +26,7 @@ perform debugging, environment inspection, and other tasks.
 
 This overrides the port health check with the `process` check, and sets the start command to just `sleep`. That will give you 10 minutes to `cf ssh` and inspect your container.
 
-**Error opening SSH connection**: In prior versions of the CF API (CAPI) app instances used a single process. In version 3 of the CAPI, there can be more then 1 process that makes up and app. This may occasionally cause issues when trying to SSH to your app. If a modification or update was made to an app using a v3 command or process - even if that change was made by someone else (e.g., another member of a development team) - the app's schema in the Cloud Controller might have changed to version 3, and a standard `cf ssh` may no longer work. If this occurs, you can try using `cf v3-ssh {app-name}`. By default a `cf v3-ssh` will select the `web` process.  You can also select a different process with v3-ssh using the `--process` flag
+**Error opening SSH connection**: In prior versions of the CF API (CAPI) app instances used a single process. In version 3 of the CAPI, there can be more than 1 process that makes up an app. This may occasionally cause issues when trying to SSH to your app. If a modification or update was made to an app using a v3 command or process - even if that change was made by someone else (e.g., another member of a development team) - the app's schema in the Cloud Controller might have changed to version 3, and a standard `cf ssh` may no longer work. If this occurs, you can try using `cf v3-ssh {app-name}`. By default a `cf v3-ssh` will select the `web` process.  You can also select a different process with v3-ssh using the `--process` flag
 
 ### Error messages
 
@@ -49,5 +49,4 @@ You should [disable SSH access for production applications]({{ site.baseurl }}{%
 ## SSH version information 
 
 Application containers use the SSH-2.0 protocol. The SSH service uses the [Cloud Foundry SSH implementation](https://github.com/cloudfoundry/diego-ssh). For more on how Cloud Foundry implements SSH, refer to Cloud Foundry's documentation on [Understanding Application SSH](https://docs.cloudfoundry.org/concepts/diego/ssh-conceptual.html).
-
 


### PR DESCRIPTION
Add debugging tip for failed SSH connections

## Changes proposed in this pull request:
- Add tip to try `cf v3-ssh` when encountering failed SSH connection.

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/add-ssh-debug-tip)

## Security Considerations
None