### PR TITLE
Update services menu and clarify pricing

### DIFF
--- a/_docs/services/aws-elasticache.md
+++ b/_docs/services/aws-elasticache.md
@@ -20,9 +20,9 @@ Service Name | Plan Name | Description | Number of nodes |
 `aws-elasticache-redis` | `redis-3node-large` | 3 node EC, persistent storage, 1.3GB memory limit | 3 |
 `aws-elasticache-redis` | `redis-5node-large` | 5 node EC, persistent storage, 1.3GB memory limit | 5 |
 
+## Pricing
 
-
-
+$200/month per 10 nodes block. First 10 nodes included at no cost. More information on the [pricing page]({{ site.baseurl }}{% link _pages/pricing.md %}).
 
 #### How to create an instance
 

--- a/_docs/services/aws-elasticsearch.md
+++ b/_docs/services/aws-elasticsearch.md
@@ -27,6 +27,9 @@ Service Name | Plan Name | Description | Number of nodes |
 `aws-elasticsearch` | `es-medium-ha` | 3 Primary and 4 Data node cluster | 7 |
 
 
+## Pricing
+
+$200/month per node. Six nodes included for customers using the FISMA Moderate plan. More information on the [pricing page]({{ site.baseurl }}{% link _pages/pricing.md %}).
 
 ## How to create an instance
 

--- a/_docs/services/elasticsearch56.md
+++ b/_docs/services/elasticsearch56.md
@@ -2,8 +2,8 @@
 parent: services
 layout: docs
 sidenav: true
-title: "Elasticsearch"
-name: "elasticsearch56"
+title: Elasticsearch (deprecated)
+name: elasticsearch56
 description: "Elasticsearch version 5.6: a distributed, RESTful search and analytics engine"
 ---
 

--- a/_docs/services/redis.md
+++ b/_docs/services/redis.md
@@ -2,7 +2,7 @@
 parent: services
 layout: docs
 sidenav: true
-title: Redis
+title: Redis (deprecated)
 description: "Redis: an in-memory data structure store"
 redirect_from:
 - /docs/services/redis28

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -2,7 +2,7 @@
 parent: services
 layout: docs
 sidenav: true
-title: Relational databases (RDS)
+title: RDS - Relational databases
 description: "Persistent, relational databases using Amazon RDS"
 redirect_from:
   - /docs/apps/databases


### PR DESCRIPTION
## Changes proposed in this pull request:
- Change the left hand expandable services menu to clarify which services are being deprecated
- Add pricing information and a link to the pricing page for new AWS Elasticsearch and Elasticache services.

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/update-services-pricing)

## Security Considerations
None
