### PR TITLE
Add a specific note to look for resource limits

### DIFF
--- a/_docs/ops/maintenance-list.md
+++ b/_docs/ops/maintenance-list.md
@@ -191,6 +191,9 @@ ensure the updated release is deployed to all required VMs.
 ## Review potential improvements in CloudCheckr
 Review the [Best Practices report in CloudCheckr](https://app.cloudcheckr.com/#Report/BestPracticesConsolidated) and try to fix something near the top.
 
+Pay extra attention to any notices that indicate we are approaching a limit on resources so that we can reach out to AWS
+to ask for a quota increase before the limit is hit.  This will help prevent future sudden outages.
+
 ---
 
 ### Page information


### PR DESCRIPTION
This changeset adds a specific note to pay close attention to resource limits in Cloudcheckr.  This has been helpful in the past in giving us time to proactively reach out to AWS for quota increases before the limit is hit, helping prevent sudden system outages.

## Changes proposed in this pull request:
- Add a specific note about looking for AWS resource limit notices

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/updaate-cloudcheckr-info/docs/ops/maintenance-list/#review-potential-improvements-in-cloudcheckr)

## Security Considerations
- None