### PR TITLE
fix service creation time notes on rds

### DIFF
--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -143,26 +143,21 @@ cf create-service aws-rds \
 ### Instance creation time
 
 Dedicated RDS instance provisioning can take anywhere between 5 minutes and 60
-minutes. During instance provisioning, the results of `cf services` or `cf service SERVICE_NAME` will show status as `created`, as in the following example:
+minutes. During instance provisioning, the results of `cf services` or `cf service SERVICE_NAME` will show status as `create in progress`, as in the following example:
+
+```
+> cf services
+name                 service   plan                bound apps   last operation
+test-oracle          aws-rds   medium-oracle-se2                create in progress
+```
+
+Once the instance is ready for use, it will show `create succeeded` as below:
 
 ```
 > cf services
 name                 service   plan                bound apps   last operation
 test-oracle          aws-rds   medium-oracle-se2                create succeeded
 ```
-
-**The `last operation` value of `create succeeed` may lead you to think the database is ready to use. This is misleading.** Instead, the _last operation_ indicates the API call to create the database has succeeded, not that provisioning has completed. To determine if a database is ready to use, test if you can create a `service key`. For example, `test-oracle` is not yet ready in this case:
-
-```
-cf create-service-key test-oracle test-oracle-ok
-Creating service key test-oracle-oke for service instance test-oracle as peter.burkholder@gsa.gov...
-FAILED
-Server error, status code: 502, error code: 10001, message: Service broker error: There was an error binding the database instance to the application. Error: Instance not available yet. Please wait and try again..
-```
-
-If the response is `OK` instead of `FAILED` then your database is ready to use.
-
-The cloud.gov team aims to provide clearer status indicators in a future release of our service broker.
 
 ## Update an instance
 


### PR DESCRIPTION

## Changes proposed in this pull request:
- fix service creation time notes on rds. fixes #1911

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/rds-docs)


## Security Considerations
None