### PR TITLE
Update rexml from 3.2.4 to 3.2.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rouge (3.21.0)
     safe_yaml (1.0.5)
     sass (3.7.4)


### PR DESCRIPTION
This changeset is a mirror of https://github.com/cloud-gov/cg-site/pull/1913/ due to the failing status checks.

## Changes proposed in this pull request:
- Updates `rexml` from 3.2.4 to 3.2.5

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/update-rexml)

## Security Considerations
- Helps us stay up-to-date with our dependencies