### PR TITLE
remove deprecated shared RDS service from docs

### DIFF
--- a/_docs/deployment/docker.md
+++ b/_docs/deployment/docker.md
@@ -39,7 +39,7 @@ There is [a Cloud Foundry API for tasks creation](http://v3-apidocs.cloudfoundry
 
 ### Using non-standard ports in Docker containers
 
-When you assign a route to an app running on cloud.gov using the `*.app.cloud.gov` domain, external ports 80 and 443 are mapped to a dynamically assigned internal port on the container(s) running your app. You can't change the internal port assigned to your app if it's been assigned an `*.app.cloud.gov` domain, but you can use alternate ports if your app is assigned [an internal route](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#internal-routes) on cloud.gov. 
+When you assign a route to an app running on cloud.gov using the `*.app.cloud.gov` domain, external ports 80 and 443 are mapped to a dynamically assigned internal port on the container(s) running your app. You can't change the internal port assigned to your app if it's been assigned an `*.app.cloud.gov` domain, but you can use alternate ports if your app is assigned [an internal route](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#internal-routes) on cloud.gov.
 
 When you deploy a Docker image that has a non-standard port exposed (e.g., port 5000) and assign an internal route to this app, this overrides the dynamic assignment of a default port by cloud.gov and exposes that non-standard port to container-to-container traffic. Your app can't be accessed by external traffic coming from outside the cloud.gov platform, but can be reached by traffic from another application running in your cloud.gov org.
 
@@ -62,7 +62,7 @@ cf push my-spring --docker-image pburkholder/my-springmusic -m 1016M
 
 Then create a database service, bind it, and restage the app to use the database:
 ```
-cf create-service aws-rds shared-psql my-spring-db
+cf create-service aws-rds micro-psql my-spring-db
 cf bind-service my-spring my-spring-db
 cf restage my-spring
 ```

--- a/_docs/management/database-backup-restore.md
+++ b/_docs/management/database-backup-restore.md
@@ -2,7 +2,7 @@
 parent: management
 layout: docs
 sidenav: true
-redirect_from: 
+redirect_from:
     - /docs/apps/database-backup-restore/
 title: Perform a database backup or restore
 ---
@@ -78,7 +78,6 @@ cf ds <service name>
 
 # Recreate the database service
 # To see all available service plans, run cf marketplace
-# Note: Only production should have something other than shared-psql
 cf cs aws-rds <service plan> <service name>
 
 # rebind the service to the app

--- a/_docs/ops/runbook/restoring-rds.md
+++ b/_docs/ops/runbook/restoring-rds.md
@@ -13,8 +13,7 @@ cloud.gov structured data is stored using Amazon's Relational Database Service (
 
 Coordinate with the tenant to determine the point in time to restore the database from, and when the operation will take place:
 
-1. Shared database plans do not include backups and restores.
-1. Dedicated RDS plans include backups as described in the [user documentation]({{ site.baseurl }}{% link _docs/services/relational-database.md %}#backups).
+1. RDS plans include backups as described in the [user documentation]({{ site.baseurl }}{% link _docs/services/relational-database.md %}#backups).
 1. The restore will result in the database being restored to a point in time.
 1. Data written after the restore point in time will be lost.
 

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -15,7 +15,6 @@ If your application uses relational databases for storage, you can use the AWS R
 
 Plan Name                   | Description                                                                  | Software Version       |
 ---                         | ---                                                                          | ---                    |
-`shared-psql`               | Shared PostgreSQL database for prototyping (no sensitive or production data) | 9.5.23                 |
 `micro-psql`                | Dedicated micro RDS PostgreSQL DB instance                                   | AWS RDS Latest Default |
 `micro-psql-redundant`      | Dedicated redundant micro RDS PostgreSQL DB instance                         | AWS RDS Latest Default |
 `small-psql`                | Dedicated small RDS PostgreSQL DB instance                                   | AWS RDS Latest Default |
@@ -28,7 +27,6 @@ Plan Name                   | Description                                       
 `large-gp-psql-redundant`   | Dedicated higher workload redundant large RDS PostgreSQL DB instance         | AWS RDS Latest Default |
 `xlarge-gp-psql`            | Dedicated higher workload x-large RDS PostgreSQL DB instance                 | AWS RDS Latest Default |
 `xlarge-gp-psql-redundant`  | Dedicated higher workload redundant xlarge RDS PostgreSQL DB instance        | AWS RDS Latest Default |
-`shared-mysql`              | Shared MySQL database for prototyping (no sensitive or production data)      | 5.6.41                 |
 `small-mysql`               | Dedicated small RDS MySQL DB instance                                        | AWS RDS Latest Default |
 `small-mysql-redundant`     | Dedicated redundant small RDS MySQL DB instance                              | AWS RDS Latest Default |
 `medium-mysql`              | Dedicated medium RDS MySQL DB instance                                       | AWS RDS Latest Default |
@@ -41,7 +39,7 @@ Plan Name                   | Description                                       
 `xlarge-gp-mysql-redundant` | Dedicated higher workload redundant x-large RDS MySQL DB instance            | AWS RDS Latest Default |
 `medium-oracle-se2`         | Dedicated medium RDS Oracle SE2 DB                                           | AWS RDS Latest Default |
 
-*Only the `shared-psql`, `shared-mysql`, `micro-psql`, and `small-mysql` plans are available in [sandbox spaces]({{ site.baseurl }}{% link _docs/pricing/free-limited-sandbox.md %}#sandbox-limitations).*
+*Only the `micro-psql` and `small-mysql` plans are available in [sandbox spaces]({{ site.baseurl }}{% link _docs/pricing/free-limited-sandbox.md %}#sandbox-limitations).*
 
 You can always view an up-to-date version of this list directly in your command line as well with the following command (using cf cli version 6):
 
@@ -169,9 +167,8 @@ cf update-service ${SERVICE_NAME} -p ${NEW_SERVICE_PLAN_NAME}
 
 `${NEW_SERVICE_PLAN_NAME}` can be any of the *dedicated* service plans that are listed above.
 
-There are several caveats regarding this command with the `-p` flag:
+There are a couple of caveats regarding this command with the `-p` flag:
 
-- You can only update dedicated RDS instances; updates to shared instances are not supported.
 - You can only update using plans with the same database engine as your existing service instance. This means that if your original service instance was using a PostgreSQL plan (e.g., `micro-psql`), you can only update to one of the other `psql`-based plans.
 - You can **only** switch service plans with this command; you cannot do things like upgrade your database version.
 
@@ -213,9 +210,7 @@ The contents of the `DATABASE_URL` environment variable contain the credentials 
 
 *Please note that these instructions will change in the future as we expand our service offerings and provide more options for customers.*
 
-For shared plans (`shared-psql` and `shared-mysql`), cloud.gov and RDS does not back up your data. These are only intended for limited use development and testing instances, not for production.
-
-For dedicated plans, RDS automatically retains daily backups for 14 days. These backups are AWS RDS storage volume snapshots, backing up the entire DB instance and not just individual databases. If you need to have a database restored using one of these backups, you can [email support](mailto:support@cloud.gov).  For non-emergency situations, please provide at least 48 hours advance notice.
+RDS automatically retains daily backups for 14 days. These backups are AWS RDS storage volume snapshots, backing up the entire DB instance and not just individual databases. If you need to have a database restored using one of these backups, you can [email support](mailto:support@cloud.gov).  For non-emergency situations, please provide at least 48 hours advance notice.
 
 If you have an emergency situation, such as data loss or a compromised system, please [email support](mailto:support@cloud.gov) immediately and inform us of the situation.
 
@@ -305,11 +300,11 @@ Since Oracle is not open-source there are fewer resources available online to ge
 
 ### Demo with Spring Music and Oracle
 
-To demonstrate the core Cloud Foundry / OracleDB functionality, we'll start by deploying the 
-[Spring Music app](https://github.com/cloudfoundry-samples/spring-music). 
+To demonstrate the core Cloud Foundry / OracleDB functionality, we'll start by deploying the
+[Spring Music app](https://github.com/cloudfoundry-samples/spring-music).
 
 First, though, one needs the proprietary Oracle database drivers.
-Visit the Oracle drivers' site at http://www.oracle.com/technetwork/database/application-development/jdbc/downloads/index.html and download the `ojdbc8.jar` from the latest available release. You will need to have a valid Oracle profile account for the download. 
+Visit the Oracle drivers' site at http://www.oracle.com/technetwork/database/application-development/jdbc/downloads/index.html and download the `ojdbc8.jar` from the latest available release. You will need to have a valid Oracle profile account for the download.
 
 Then, clone the repository and make a `libs/` directory:
 
@@ -319,7 +314,7 @@ cd spring-music
 mkdir libs/
 ```
 
-Copy the downloaded `ojdbc8.jar` to the `libs/` directory of `spring-music`. 
+Copy the downloaded `ojdbc8.jar` to the `libs/` directory of `spring-music`.
 
 Edit `build.gradle`, look for the following near line 60:
 
@@ -347,7 +342,7 @@ When the restart completes, you can visit the app and view in the upper-right-ha
 
 Install Oracle's `instantclient-basiclite` and `instantclient-sqlplus` for your operating system.
 
-To get the database connection information, we'll use 
+To get the database connection information, we'll use
 [Cloud Foundry service keys](https://docs.cloudfoundry.org/devguide/services/service-keys.html) as follows, for the
 case of an Oracle database called `spring-oracle`:
 
@@ -421,7 +416,7 @@ psql postgres://$creds@localhost:5432/$dbname
 
 The software versions listed in the table above are for new instances of those plans.
 
-New instances of dedicated RDS plans use the latest default database version available from AWS RDS GovCloud (US) at the time. New instances of shared plans may use older database versions.
+New instances of dedicated RDS plans use the latest default database version available from AWS RDS GovCloud (US) at the time.
 
 The PostgreSQL and MySQL plans are configured to automatically upgrade currently-running dedicated instances to the most recent compatible [minor version](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Upgrading.html) available via AWS RDS GovCloud (US).
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Per https://github.com/cloud-gov/product/issues/1547, remove shared RDS instances from the docs

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/remove-rds-shared-plans)


## Security Considerations
No security impact on the website. Part of the larger effort to only provide dedicated RDS instances, which will improve platform security.
