### PR TITLE
Add instructions for performing restorations of deleted database instances

### DIFF
--- a/_docs/ops/runbook/restoring-rds.md
+++ b/_docs/ops/runbook/restoring-rds.md
@@ -100,6 +100,25 @@ Once we receive confirmation that the restore has been completed successfully, w
 
 Work with the tenant to come to a firm agreed upon date and time that the old database instance will be removed.  Be sure to also remind them that no backups or snapshots will be saved either unless they are explicitly requested.
 
+## Recovering a deleted brokered instance
+
+If a brokered database that was deleted needs to be recovered, the automated backups will persist for up to 14 days after the deletion took place.  If a customer reaches out to us and requests help with a backup of this nature, we can restore the instance from one of the snapshots taken prior to the database deleted as long as it is within this 14 day window.
+
+To perform this restore, you need the following information:
+- The deleted database instance ID - this is used to identify which backup needs to be used
+- VPC security group
+- Subnet group
+- Instance class
+- Storage size
+- Parameter group (usually the default, but it may not be)
+- Multi AZ setting
+
+Once you have this information, go into the RDS console in AWS and select `Automated Backups` from the side menu.  In the Automated Backups dashboard that appears, there are two tabs on the top - click on the `Retained` tab to see all backups that exist for deleted instances.
+
+Find the backups that match the database instance ID and click on the name.  You'll be taken to a screen that lists all of the snapshots available.  Find the one you would like to restore from (most likely the last available) and click its name.  This will take you to the snapshot details page, and from there you can perform a point in time restore.  This will create a new database instance using the backup snapshot.
+
+The remaining restoration steps are the same as above in the [Performing the database restore](#performing-the-database-restore) section.  Note that just like the restoration steps above, this creates a new instance and it will not be tied to the broker.
+
 ## Platform Databases
 
 Databases created by Terraform store credentials in the Terraform State S3 Bucket:

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -214,7 +214,9 @@ RDS automatically retains daily backups for 14 days. These backups are AWS RDS s
 
 If you have an emergency situation, such as data loss or a compromised system, please [email support](mailto:support@cloud.gov) immediately and inform us of the situation.
 
-When you do [contact support](mailto:support@cloud.gov) with a database backup request, please include the following information:
+If you deleted your database instance and want to recover it, the recovery must be done within 14 days of the instance being deleted.  We can perform a restoration using the automated backups that are retained for that 14 day window after a database is removed.
+
+When you do [contact support](mailto:support@cloud.gov) with a database backup or restoration request, please include the following information:
 
 - Your organization name
 - The space you are working within


### PR DESCRIPTION
This changeset adds some information to the platform operator runbook for how to perform a restoration of a deleted database instance as well as a note in the customer-facing services documentation.

## Changes proposed in this pull request:
- Adds instructions to the operator runbook on how to restore deleted database instances
- Adds a specific note in the customer documentation for restoring deleted database instances

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/rds-backup-updates)

## Security considerations:
- General information about how to perform an RDS restore, which is found in publicly available documentation via AWS