### PR TITLE
Upgrade transitive dependency on outdated version of trim module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,35 +21,34 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
     },
     "@babel/highlight": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.14.0",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/runtime": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
-      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/types": {
-      "version": "7.13.14",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
-      "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.2.tgz",
+      "integrity": "sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "@babel/helper-validator-identifier": "^7.14.0",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -229,35 +228,26 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@nodelib/fs.scandir": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
       "requires": {
-        "@nodelib/fs.stat": "2.0.3",
+        "@nodelib/fs.stat": "2.0.4",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
       "requires": {
-        "@nodelib/fs.scandir": "2.1.3",
+        "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
-      }
-    },
-    "@types/glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
-      "requires": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
       }
     },
     "@types/hoist-non-react-statics": {
@@ -268,11 +258,6 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
       }
-    },
-    "@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
       "version": "14.14.12",
@@ -290,9 +275,9 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.3.tgz",
-      "integrity": "sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==",
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.5.tgz",
+      "integrity": "sha512-bj4biDB9ZJmGAYTWSKJly6bMr4BLUiBrx9ujiJEoP9XIDY9CTaPGxE5QWN/1WjpPLzYF7/jRNnV2nNxNe970sw==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -300,9 +285,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
-          "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+          "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
         }
       }
     },
@@ -406,9 +391,9 @@
       }
     },
     "anchor-js": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/anchor-js/-/anchor-js-4.3.0.tgz",
-      "integrity": "sha512-ROYrnfZIA0zLJbWCFO7IJH9VPetyN0gXb9iSWNXUGh4wLHX7Mw+foIizbbxAhOgfNFJfQDrAWbuU49ChF8bQ0A=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/anchor-js/-/anchor-js-4.3.1.tgz",
+      "integrity": "sha512-TziERoibspey7KSm95oIdzTxiogXonJl7inQI07Y3cI25DKQaLkUftB7RhCuSb1GcwunHL6/PcIKM4dDUb9xYQ=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -691,9 +676,9 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "codemirror": {
-      "version": "5.60.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.60.0.tgz",
-      "integrity": "sha512-AEL7LhFOlxPlCL8IdTcJDblJm8yrAGib7I+DErJPdZd4l6imx8IMgKK3RblVgBQqz3TZJR4oknQ03bz+uNjBYA=="
+      "version": "5.61.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.0.tgz",
+      "integrity": "sha512-D3wYH90tYY1BsKlUe0oNj2JAhQ9TepkD51auk3N7q+4uz7A/cgJ5JsWHreT0PqieW1QhOuqxQ2reCXV1YXzecg=="
     },
     "collapse-white-space": {
       "version": "1.0.6",
@@ -817,23 +802,15 @@
         "warning": "^4.0.3"
       }
     },
-    "crypto-random-string": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-3.3.0.tgz",
-      "integrity": "sha512-teWAwfMb1d6brahYyKqcBEb5Yp8PJPvPOdOonXDnvaKOTmKDFNVE8E3Y2XQuzjNV/3XMwHbrX9fHWvrhRKt4Gg==",
-      "requires": {
-        "type-fest": "^0.8.1"
-      }
-    },
     "css-b64-images": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/css-b64-images/-/css-b64-images-0.2.5.tgz",
       "integrity": "sha1-QgBdgyBLK0pdk7axpWRBM7WSegI="
     },
     "csstype": {
-      "version": "2.6.16",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.16.tgz",
-      "integrity": "sha512-61FBWoDHp/gRtsoDkq/B1nWrCUG/ok1E3tUrcNbZjsE9Cxd9yzUirjS3+nAATB8U4cTtaQmAHbNndoFz5L6C9Q=="
+      "version": "2.6.17",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
+      "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
     },
     "d3": {
       "version": "5.16.0",
@@ -1141,17 +1118,17 @@
       }
     },
     "del": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
-      "integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+      "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
       "requires": {
-        "globby": "^10.0.1",
-        "graceful-fs": "^4.2.2",
+        "globby": "^11.0.1",
+        "graceful-fs": "^4.2.4",
         "is-glob": "^4.0.1",
         "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.1",
-        "p-map": "^3.0.0",
-        "rimraf": "^3.0.0",
+        "is-path-inside": "^3.0.2",
+        "p-map": "^4.0.0",
+        "rimraf": "^3.0.2",
         "slash": "^3.0.0"
       }
     },
@@ -1205,9 +1182,9 @@
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "dompurify": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.7.tgz",
-      "integrity": "sha512-jdtDffdGNY+C76jvodNTu9jt5yYj59vuTUyx+wXdzcSwAGTYZDAQkQ7Iwx9zcGrA4ixC1syU4H3RZROqRxokxg=="
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.8.tgz",
+      "integrity": "sha512-9H0UL59EkDLgY3dUFjLV6IEUaHm5qp3mxSqWw7Yyx4Zhk2Jn2cmLe+CNPP3xy13zl8Bqg+0NehQzkdMoVhGRww=="
     },
     "domready": {
       "version": "1.0.8",
@@ -1279,6 +1256,14 @@
         }
       }
     },
+    "entity-decode": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/entity-decode/-/entity-decode-2.0.2.tgz",
+      "integrity": "sha512-5CCY/3ci4MC1m2jlumNjWd7VBFt4VfFnmSqSNmVcXq4gxM3Vmarxtt+SvmBnzwLS669MWdVuXboNVj1qN2esVg==",
+      "requires": {
+        "he": "^1.1.1"
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1330,11 +1315,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
-    "escaper": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/escaper/-/escaper-2.5.3.tgz",
-      "integrity": "sha512-QGb9sFxBVpbzMggrKTX0ry1oiI4CSDAl9vIL702hzl1jGW8VZs7qfqTRX7WDOjoNDoEVGcEtu1ZOQgReSfT2kQ=="
-    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -1369,9 +1349,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -1392,9 +1372,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastq": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
-      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -1477,9 +1457,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -1494,17 +1474,15 @@
       }
     },
     "globby": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
-      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+      "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
       "requires": {
-        "@types/glob": "^7.1.1",
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.0.3",
-        "glob": "^7.1.3",
-        "ignore": "^5.1.1",
-        "merge2": "^1.2.3",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
         "slash": "^3.0.0"
       }
     },
@@ -1517,9 +1495,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "graphlib": {
       "version": "2.1.8",
@@ -1535,16 +1513,26 @@
       "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA=="
     },
     "graphql-tag": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
-      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
+      "version": "2.12.4",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.4.tgz",
+      "integrity": "sha512-VV1U4O+9x99EkNpNmCUV5RZwq6MnK4+pGbRYWG+lA/m3uo7TSqJF81OkcOP148gFP6fzdl7JWYBrwWVTS9jXww==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
     },
     "gray-matter": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.2.tgz",
-      "integrity": "sha512-7hB/+LxrOjq/dd8APlK0r24uL/67w7SkYnfwhNFwg/VDIGWGmduTDYf3WNstLW2fbbmRwrDGCVSJ2isuf2+4Hw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
       "requires": {
-        "js-yaml": "^3.11.0",
+        "js-yaml": "^3.13.1",
         "kind-of": "^6.0.2",
         "section-matter": "^1.0.0",
         "strip-bom-string": "^1.0.0"
@@ -1614,9 +1602,9 @@
       "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ=="
     },
     "hast-util-to-html": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-7.1.2.tgz",
-      "integrity": "sha512-pu73bvORzdF6XZgwl9eID/0RjBb/jtRfoGRRSykpR1+o9rCdiAHpgkSukZsQBRlIqMg6ylAcd7F0F7myJUb09Q==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-7.1.3.tgz",
+      "integrity": "sha512-yk2+1p3EJTEE9ZEUkgHsUSVhIpCsL/bvT8E5GzmWc+N1Po5gBw+0F8bo7dpxXR0nu0bQVxVZGX2lBGF21CmeDw==",
       "requires": {
         "ccount": "^1.0.0",
         "comma-separated-tokens": "^1.0.0",
@@ -1777,9 +1765,9 @@
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "immer": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.1.tgz",
-      "integrity": "sha512-7CCw1DSgr8kKYXTYOI1qMM/f5qxT5vIVMeGLDCDX8CSxsggr1Sjdoha4OhsP0AZ1UvWbyZlILHvLjaynuu02Mg=="
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.2.tgz",
+      "integrity": "sha512-mkcmzLtIfSp40vAqteRr1MbWNSoI7JE+/PB36FNPoSfJ9RQRmNKuTYCjKkyXyuq3Dgn07HuJBrwJd4ZSk2yUbw=="
     },
     "immutable": {
       "version": "3.8.2",
@@ -1852,16 +1840,16 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-bigint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+      "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA=="
     },
     "is-boolean-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+      "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
       "requires": {
-        "call-bind": "^1.0.0"
+        "call-bind": "^1.0.2"
       }
     },
     "is-buffer": {
@@ -1875,17 +1863,17 @@
       "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
     },
     "is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
       "requires": {
         "has": "^1.0.3"
       }
     },
     "is-date-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+      "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A=="
     },
     "is-decimal": {
       "version": "1.0.4",
@@ -1936,9 +1924,9 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-number-object": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+      "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw=="
     },
     "is-path-cwd": {
       "version": "2.2.0",
@@ -1946,9 +1934,9 @@
       "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ=="
     },
     "is-path-inside": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-      "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -1964,30 +1952,25 @@
       }
     },
     "is-regex": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
       "requires": {
         "call-bind": "^1.0.2",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.2"
       }
     },
-    "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
-    },
     "is-string": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+      "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w=="
     },
     "is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
       "requires": {
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.2"
       }
     },
     "is-whitespace-character": {
@@ -2077,6 +2060,11 @@
       "resolved": "https://registry.npmjs.org/keyboardevent-key-polyfill/-/keyboardevent-key-polyfill-1.1.0.tgz",
       "integrity": "sha1-ijGdjkWhMXL8pWKGNy+QwdTHAUw="
     },
+    "khroma": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-1.4.1.tgz",
+      "integrity": "sha512-+GmxKvmiRuCcUYDgR7g5Ngo0JEDeOsGdNONdU2zsiBQaK4z19Y2NvXqfEDE0ZiIrg45GTZyAnPLVsLZZACYm3Q=="
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -2122,11 +2110,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "longest-streak": {
       "version": "2.0.4",
@@ -2213,6 +2196,13 @@
         "unist-util-position": "^3.0.0",
         "unist-util-visit": "^1.1.0",
         "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "trim": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/trim/-/trim-1.0.1.tgz",
+          "integrity": "sha512-3JVP2YVqITUisXblCDq/Bi4P9457G/sdEamInkyvCsjbTcXLXIiG7XCb4kGMFWh6JGXesS3TKxOPtrncN/xe8w=="
+        }
       }
     },
     "mdast-util-to-string": {
@@ -2226,9 +2216,9 @@
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "memoize-one": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "merge2": {
       "version": "1.4.1",
@@ -2236,21 +2226,21 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
     "mermaid": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.4.6.tgz",
-      "integrity": "sha512-6YQBkXfvhfjKIzRhtqbCics3pJurGrJAYEeqgyRcDZeTHQ/WCB2Bh/4wdAOho1Uffe0jXB+HjmHT5kEUOxudJw==",
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.10.1.tgz",
+      "integrity": "sha512-KxwKEJDKy303TQdz5TQMFb/4u+gUL21CefUMGOfuigDh9powcYaNmuJ5BkHmO0jB3Y1z2zlsuKvHZ2CusWH5+A==",
       "requires": {
         "@braintree/sanitize-url": "^3.1.0",
-        "crypto-random-string": "^3.0.1",
         "d3": "^5.7.0",
         "dagre": "^0.8.4",
         "dagre-d3": "^0.6.4",
+        "entity-decode": "^2.0.2",
         "graphlib": "^2.1.7",
         "he": "^1.2.0",
-        "lodash": "^4.17.11",
+        "khroma": "^1.1.0",
         "minify": "^4.1.1",
         "moment-mini": "^2.22.1",
-        "scope-css": "^1.2.1"
+        "stylis": "^3.5.2"
       }
     },
     "micro-api-client": {
@@ -2259,12 +2249,12 @@
       "integrity": "sha512-y0y6CUB9RLVsy3kfgayU28746QrNMpSm9O/AYGNsBgOkJr/X/Jk0VLGoO8Ude7Bpa8adywzF+MzXNZRFRsNPhg=="
     },
     "micromatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
       "requires": {
         "braces": "^3.0.1",
-        "picomatch": "^2.0.5"
+        "picomatch": "^2.2.3"
       }
     },
     "min-document": {
@@ -2335,12 +2325,12 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "netlify-cms": {
-      "version": "2.10.113",
-      "resolved": "https://registry.npmjs.org/netlify-cms/-/netlify-cms-2.10.113.tgz",
-      "integrity": "sha512-l8T+FFfM3fA0v7AE7yvE++ULqcOgJkyQeB2sjgdstEn2pfmv4xclRvXXrXhC7kJ+WpbVLdhtKhsuJ2TI/RFVtA==",
+      "version": "2.10.126",
+      "resolved": "https://registry.npmjs.org/netlify-cms/-/netlify-cms-2.10.126.tgz",
+      "integrity": "sha512-HPt/P179oO7mGGftrdceW/5YnzBTjYpQ2dV0IDDje7JaJKUSMrTCS26i5vshVDx6T0wpDukEiM/PSNcb3amqeg==",
       "requires": {
         "codemirror": "^5.46.0",
-        "netlify-cms-app": "^2.14.42",
+        "netlify-cms-app": "^2.15.6",
         "netlify-cms-media-library-cloudinary": "^1.3.10",
         "netlify-cms-media-library-uploadcare": "^0.5.10",
         "react": "^16.8.4",
@@ -2348,63 +2338,64 @@
       }
     },
     "netlify-cms-app": {
-      "version": "2.14.42",
-      "resolved": "https://registry.npmjs.org/netlify-cms-app/-/netlify-cms-app-2.14.42.tgz",
-      "integrity": "sha512-sh4hcBwlO/rllnsC5UetNLWKLi9ZCQb963l/L9ayUiSdfj10qHM1klCehyp8r1FYgMrevwfEaveHDT2RRk0nFw==",
+      "version": "2.15.6",
+      "resolved": "https://registry.npmjs.org/netlify-cms-app/-/netlify-cms-app-2.15.6.tgz",
+      "integrity": "sha512-8kYiA6fnJybsxc/JFqdwR8bBDuxdFLGHuu1mOIHfgxIXJemP51JZMl6SBXW+56b2I4Y9Pbjf7TPb4lo2KD2B8w==",
       "requires": {
         "@emotion/core": "^10.0.35",
         "@emotion/styled": "^10.0.27",
+        "codemirror": "^5.46.0",
         "immutable": "^3.7.6",
         "lodash": "^4.17.11",
         "moment": "^2.24.0",
-        "netlify-cms-backend-azure": "^1.1.2",
-        "netlify-cms-backend-bitbucket": "^2.12.8",
-        "netlify-cms-backend-git-gateway": "^2.11.11",
-        "netlify-cms-backend-github": "^2.12.0",
-        "netlify-cms-backend-gitlab": "^2.9.9",
-        "netlify-cms-backend-proxy": "^1.1.7",
-        "netlify-cms-backend-test": "^2.10.7",
-        "netlify-cms-core": "^2.39.5",
-        "netlify-cms-editor-component-image": "^2.6.7",
-        "netlify-cms-lib-auth": "^2.3.0",
+        "netlify-cms-backend-azure": "^1.2.0",
+        "netlify-cms-backend-bitbucket": "^2.13.0",
+        "netlify-cms-backend-git-gateway": "^2.12.0",
+        "netlify-cms-backend-github": "^2.13.0",
+        "netlify-cms-backend-gitlab": "^2.11.1",
+        "netlify-cms-backend-proxy": "^1.2.0",
+        "netlify-cms-backend-test": "^2.11.0",
+        "netlify-cms-core": "^2.40.3",
+        "netlify-cms-editor-component-image": "^2.7.0",
+        "netlify-cms-lib-auth": "^2.4.0",
         "netlify-cms-lib-util": "^2.13.0",
         "netlify-cms-lib-widgets": "^1.6.1",
-        "netlify-cms-locales": "^1.30.0",
-        "netlify-cms-ui-default": "^2.12.2",
-        "netlify-cms-widget-boolean": "^2.3.6",
-        "netlify-cms-widget-code": "^1.2.8",
-        "netlify-cms-widget-colorstring": "^1.0.3",
-        "netlify-cms-widget-date": "^2.5.7",
-        "netlify-cms-widget-datetime": "^2.6.8",
-        "netlify-cms-widget-file": "^2.9.2",
-        "netlify-cms-widget-image": "^2.7.7",
-        "netlify-cms-widget-list": "^2.8.5",
-        "netlify-cms-widget-map": "^1.4.6",
-        "netlify-cms-widget-markdown": "^2.12.12",
-        "netlify-cms-widget-number": "^2.4.7",
-        "netlify-cms-widget-object": "^2.6.2",
-        "netlify-cms-widget-relation": "^2.9.0",
-        "netlify-cms-widget-select": "^2.7.4",
-        "netlify-cms-widget-string": "^2.2.10",
-        "netlify-cms-widget-text": "^2.3.6",
+        "netlify-cms-locales": "^1.30.1",
+        "netlify-cms-ui-default": "^2.13.1",
+        "netlify-cms-widget-boolean": "^2.4.0",
+        "netlify-cms-widget-code": "^1.3.0",
+        "netlify-cms-widget-colorstring": "^1.1.0",
+        "netlify-cms-widget-date": "^2.6.0",
+        "netlify-cms-widget-datetime": "^2.7.0",
+        "netlify-cms-widget-file": "^2.10.1",
+        "netlify-cms-widget-image": "^2.8.0",
+        "netlify-cms-widget-list": "^2.9.1",
+        "netlify-cms-widget-map": "^1.5.0",
+        "netlify-cms-widget-markdown": "^2.13.0",
+        "netlify-cms-widget-number": "^2.5.0",
+        "netlify-cms-widget-object": "^2.7.0",
+        "netlify-cms-widget-relation": "^2.10.0",
+        "netlify-cms-widget-select": "^2.8.0",
+        "netlify-cms-widget-string": "^2.3.0",
+        "netlify-cms-widget-text": "^2.4.0",
         "prop-types": "^15.7.2",
         "react-immutable-proptypes": "^2.1.0",
         "uuid": "^3.3.2"
       }
     },
     "netlify-cms-backend-azure": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-azure/-/netlify-cms-backend-azure-1.1.2.tgz",
-      "integrity": "sha512-UlQC06I6kPFEyMsWS52Q1Ff2o+4551v0orH7OH8zSlsxYH29Dy0pt5Cbqf1OiPRiXpTsMwk0nYzUyU7msqXYPQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-backend-azure/-/netlify-cms-backend-azure-1.2.0.tgz",
+      "integrity": "sha512-XsvGWE7FtbpGCkzR244G7gAH2B+qoTvA0w/rXxkFbvdKG7Yot6nuxhrhfgg/TRTCsjnIPF9fEPEpOpXqm5V/8Q==",
       "requires": {
         "js-base64": "^3.0.0",
         "semaphore": "^1.1.0"
       }
     },
     "netlify-cms-backend-bitbucket": {
-      "version": "2.12.8",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-bitbucket/-/netlify-cms-backend-bitbucket-2.12.8.tgz",
-      "integrity": "sha512-cjrS5nA6dcBPeyyOefgGfATxoSyZNN4rdfOcQyLGFZj4U3+cfDvu9NRLNNqaKl9/G08rvzbFG4C27l2Mmfte2w==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-backend-bitbucket/-/netlify-cms-backend-bitbucket-2.13.0.tgz",
+      "integrity": "sha512-ljgZSgNJLnjjGGpj05gjkIpDeZ+unfR2O5UEwcNEwUjNsY+lJF+vrJ3s5hTgBJHrhi2K9e8SNVPi7At0BZQbyQ==",
       "requires": {
         "common-tags": "^1.8.0",
         "js-base64": "^3.0.0",
@@ -2413,9 +2404,9 @@
       }
     },
     "netlify-cms-backend-git-gateway": {
-      "version": "2.11.11",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-git-gateway/-/netlify-cms-backend-git-gateway-2.11.11.tgz",
-      "integrity": "sha512-ESjte6NK09AN2jVnZHYq0Z7VVM0WOXe7qyZ5qkWZN5mYiIalweo5Sqope6tIf6og9OIw4xivnOPvHX5kVE7YPQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-backend-git-gateway/-/netlify-cms-backend-git-gateway-2.12.0.tgz",
+      "integrity": "sha512-w582O8fEJjq4Wvyvbw1s4GGBMOQCaeKkage81CbDU7OvaHZbVh8H8O7CyyLOboTkHsvQEPw95bZZEIxiwwWQbg==",
       "requires": {
         "gotrue-js": "^0.9.24",
         "ini": "^2.0.0",
@@ -2424,9 +2415,9 @@
       }
     },
     "netlify-cms-backend-github": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-github/-/netlify-cms-backend-github-2.12.0.tgz",
-      "integrity": "sha512-PVBwIdBvECUPSRzEsIVxxVqh56bJaXsOpU6qLUK4jy1Nb8coPE14ZutPyNAUp7jQAcyAlm3/pHW2cA9ujhn13w==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-backend-github/-/netlify-cms-backend-github-2.13.0.tgz",
+      "integrity": "sha512-tlds1ZhuY2EIHHrpHB6JSwgEf7wXGNMXC0PQ5z5aRBJGwNA4lzYWl0Dooj/4wvj0JGUn1klEbOpbru7yaP/CjA==",
       "requires": {
         "apollo-cache-inmemory": "^1.6.2",
         "apollo-client": "^2.6.3",
@@ -2440,31 +2431,31 @@
       }
     },
     "netlify-cms-backend-gitlab": {
-      "version": "2.9.9",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-gitlab/-/netlify-cms-backend-gitlab-2.9.9.tgz",
-      "integrity": "sha512-UIRA6cA+y3dShIuId3CebYypAjm8R+pKwEgnwGI5sMoTYxBEncaCwN5GINBbYddioVsU5OdyN3FngPx/eHKCcg==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/netlify-cms-backend-gitlab/-/netlify-cms-backend-gitlab-2.11.1.tgz",
+      "integrity": "sha512-a9PDwCCKUu6tZ25nkZYIR4ccGFdWiaJpwf1PszzNsyseLvr80LGO0ZtRvv9U4j8GIU926dcCRjjXhJFrZ9WyAw==",
       "requires": {
         "js-base64": "^3.0.0",
         "semaphore": "^1.1.0"
       }
     },
     "netlify-cms-backend-proxy": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-proxy/-/netlify-cms-backend-proxy-1.1.7.tgz",
-      "integrity": "sha512-PMDAgilIab9jIzNc602BMOOfaVzJomzirnHNydmROlgrXnmiP48mkrTy4HTpNl9W4U8Pzn3x+kYfyAaZNvM84g=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-backend-proxy/-/netlify-cms-backend-proxy-1.2.0.tgz",
+      "integrity": "sha512-hPeDl8mUuby83X3BTSYOOrb8utzTAwrO7PIdlxC50oh+V4+hHESlUGnEJVAwikOfTJeVTaOkAivk/ORMJMCHbw=="
     },
     "netlify-cms-backend-test": {
-      "version": "2.10.7",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-test/-/netlify-cms-backend-test-2.10.7.tgz",
-      "integrity": "sha512-AoCLHVUocXLSzfXJwn4CeqqKph1lIeyzQcsjJN6Je5r2UU66fiayG+skhu3RjudeKiIfmA4Cf/p0Ay9ooRkxOg=="
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-backend-test/-/netlify-cms-backend-test-2.11.0.tgz",
+      "integrity": "sha512-6GLpg94YUH6ttPg2JaC7x8ZD/cpXGR0P9n7PaJUbwXpmYj/ZMyT6+iKs8aAbfyX3OzaAQEv8gkFl6ths5+cUFg=="
     },
     "netlify-cms-core": {
-      "version": "2.39.5",
-      "resolved": "https://registry.npmjs.org/netlify-cms-core/-/netlify-cms-core-2.39.5.tgz",
-      "integrity": "sha512-cqANjxFJn3WHgftkyWvZI9rArPBmXayDtBmapJvaE9ubrVhrCLmde8rjwWcmhgAVvQUHgNrkX6k6mJ4WfuNDwA==",
+      "version": "2.40.3",
+      "resolved": "https://registry.npmjs.org/netlify-cms-core/-/netlify-cms-core-2.40.3.tgz",
+      "integrity": "sha512-SfU5fuK310Cl1GoMbcyV5Z1n2M4HmU95I8Frr+f8Vl0Pk5OUexLA07lZ7bMT0VnAXY8sUJcl5c6G92PhaRWyHQ==",
       "requires": {
         "@iarna/toml": "2.2.5",
-        "ajv": "^8.0.0",
+        "ajv": "8.1.0",
         "ajv-errors": "^3.0.0",
         "ajv-keywords": "^5.0.0",
         "copy-text-to-clipboard": "^3.0.0",
@@ -2483,7 +2474,7 @@
         "react-dnd": "^7.3.2",
         "react-dnd-html5-backend": "^7.2.0",
         "react-dom": "^16.8.4",
-        "react-frame-component": "^4.1.0",
+        "react-frame-component": "^5.0.0",
         "react-hot-loader": "^4.8.0",
         "react-immutable-proptypes": "^2.1.0",
         "react-is": "16.13.1",
@@ -2491,12 +2482,12 @@
         "react-polyglot": "^0.7.0",
         "react-redux": "^7.2.0",
         "react-router-dom": "^5.2.0",
-        "react-scroll-sync": "^0.8.0",
-        "react-sortable-hoc": "^1.0.0",
+        "react-scroll-sync": "^0.9.0",
+        "react-sortable-hoc": "^2.0.0",
         "react-split-pane": "^0.1.85",
         "react-topbar-progress-indicator": "^4.0.0",
         "react-virtualized-auto-sizer": "^1.0.2",
-        "react-waypoint": "^9.0.3",
+        "react-waypoint": "^10.0.0",
         "react-window": "^1.8.5",
         "redux": "^4.0.5",
         "redux-devtools-extension": "^2.13.8",
@@ -2506,19 +2497,20 @@
         "semaphore": "^1.0.5",
         "tomlify-j0.4": "^3.0.0-alpha.0",
         "url": "^0.11.0",
+        "url-join": "^4.0.1",
         "what-input": "^5.1.4",
         "yaml": "^1.8.3"
       }
     },
     "netlify-cms-editor-component-image": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/netlify-cms-editor-component-image/-/netlify-cms-editor-component-image-2.6.7.tgz",
-      "integrity": "sha512-aUkueCG+rLXcvY5Lfc77pllREpA0oY2V9v8Q+AXu08CvW61kigVTa/AKFTd1oGN8CDpoIr0uO8580tYskzjIRw=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-editor-component-image/-/netlify-cms-editor-component-image-2.7.0.tgz",
+      "integrity": "sha512-pQ7vcviNSHz0tAkW+lpw1zAh2BNplb5R8w58ZeA6svVte+v9Db8n54mZeVwk6y+e7quZoEl4isV1LMVcox5HLQ=="
     },
     "netlify-cms-lib-auth": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/netlify-cms-lib-auth/-/netlify-cms-lib-auth-2.3.0.tgz",
-      "integrity": "sha512-+428eI/EkRSchRslhtWagjgtbgN+CZhhHMUXTDmpjqPiRVCYeIfKDubDI2yUa2PVIATGFr0Z/v7tJQSdKDop5w=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-lib-auth/-/netlify-cms-lib-auth-2.4.0.tgz",
+      "integrity": "sha512-mAIv74VUhXX5V9+LgMZxzSm0adyjYTlBRkZZ08gm7SqrgPSyewph495P0t5/tzL1K41fBlbzj1ROwJJPJ0Iqdw=="
     },
     "netlify-cms-lib-util": {
       "version": "2.13.0",
@@ -2536,9 +2528,9 @@
       "integrity": "sha512-UGBnoixI31VhKLeMtlz0y36LZtnn1DngxjYKAP2z53w4CiTzvkf7FL6Eu/2KzVfLhxIdel1KgWcfDOQtnmgxnQ=="
     },
     "netlify-cms-locales": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/netlify-cms-locales/-/netlify-cms-locales-1.30.0.tgz",
-      "integrity": "sha512-tr/AicVjNjJB4arrVb2cJZXXIHRhYV/I7ZZVTmykJ9r6Cdsdqc9tsqPd34j127TyEBHUuo0g5EaXpFyCZYxQKQ=="
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/netlify-cms-locales/-/netlify-cms-locales-1.30.1.tgz",
+      "integrity": "sha512-AUFrTIj+5zPApVJD8FZFYpKkDsaqM3w1q5GMriU3on4I7U0e8UxYv16bunJrzMXNtTfoIm+GgVZtrQwM5/lCAw=="
     },
     "netlify-cms-media-library-cloudinary": {
       "version": "1.3.10",
@@ -2555,9 +2547,9 @@
       }
     },
     "netlify-cms-ui-default": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/netlify-cms-ui-default/-/netlify-cms-ui-default-2.12.2.tgz",
-      "integrity": "sha512-N88nLQi10wHCwXyPe4FnHMYsWSHut6MLcu27IIY96sI1SL4a/SiMKAUNtEIwKHO36CUG0zlNtXQtaSOi6FFvmQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/netlify-cms-ui-default/-/netlify-cms-ui-default-2.13.1.tgz",
+      "integrity": "sha512-yM2f7hUvx5KqhMiRd6rYbX2iu3284OmzrDPxgwVQ8JZ9OUrvEP0NNqfkoTgrkFICfvY50ALmts3K/LIPCPfkRg==",
       "requires": {
         "react-aria-menubutton": "^6.0.0",
         "react-toggled": "^1.1.2",
@@ -2578,76 +2570,76 @@
       }
     },
     "netlify-cms-widget-boolean": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-boolean/-/netlify-cms-widget-boolean-2.3.6.tgz",
-      "integrity": "sha512-d2Bs7L/irffvvZlvRvEPraOc3L6dbQmowDZW6Mb2QbxXjYs/mDgVcANFZcB/3p0kCa65DuknJkGLl6fZMV/QsQ=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-boolean/-/netlify-cms-widget-boolean-2.4.0.tgz",
+      "integrity": "sha512-toPiI8tka+4WI15ctxTYqn8l+m0UobK0Az8sYgJKPeQqZd8I2r36E+dQjNXbXQyW2Vd57XL5OPV6MWV59U3+jw=="
     },
     "netlify-cms-widget-code": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-code/-/netlify-cms-widget-code-1.2.8.tgz",
-      "integrity": "sha512-l603N2nL+Tv1qVQ9PVA8R+uXLxxFNBy0JSiw6O6gSweba2G+HJCML2GZnzLo3lKB8bRlj1FxSeX1qAuObFxhBQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-code/-/netlify-cms-widget-code-1.3.0.tgz",
+      "integrity": "sha512-qLIvYXu/oH7OJAYTUm+zRwXhrKMw3u+AtKSlPXlQO/xs63ut21qNS1m4ezW/0DjU+iLHW5bx4WXKpFUq3iIZzA==",
       "requires": {
         "react-codemirror2": "^7.0.0",
         "react-select": "^2.4.3"
       }
     },
     "netlify-cms-widget-colorstring": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-colorstring/-/netlify-cms-widget-colorstring-1.0.3.tgz",
-      "integrity": "sha512-O2clcdug+31AhozeeLPE9HPl4i4GrP0VrG9ljpz9Al2QdDMnAqloh2wTi93KxUb03WNbfCMOHUyX1mN3Lc5jyA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-colorstring/-/netlify-cms-widget-colorstring-1.1.0.tgz",
+      "integrity": "sha512-ZjGNhHjKgR3VcRFTtx50JHvbcg6suVMjQNdaXf3srjvVCjs+YxYekJqntt19Joj/m3Nd3GOExrc/X2sYF08FCQ==",
       "requires": {
         "react-color": "^2.18.1",
         "validate-color": "^2.1.0"
       }
     },
     "netlify-cms-widget-date": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-date/-/netlify-cms-widget-date-2.5.7.tgz",
-      "integrity": "sha512-GZNzj793qEeoK2tVLDbhVWLIwhSq+KhcNV8jKIFGMho38kOV7mb/GRCsDwsI4ADtklqfjYkXs8PPtA2ZDl/4/w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-date/-/netlify-cms-widget-date-2.6.0.tgz",
+      "integrity": "sha512-8ZjuxElT4xZkU/IQyUaI59C3CgQxwraF3X+sGfPsIz5lc5WWlON9097qi3ZiFQR8v9ZEInZFC0/gzTYYsxKBKA==",
       "requires": {
         "react-datetime": "^2.16.3"
       }
     },
     "netlify-cms-widget-datetime": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-datetime/-/netlify-cms-widget-datetime-2.6.8.tgz",
-      "integrity": "sha512-fo09cdnxDXJyrLghF5PGmyTsgGZB/Ori2AGY2nWTtuFY7+o1CvLDGeOEPHwod6wMamLUhR4HOvKfQZCmweD2tg=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-datetime/-/netlify-cms-widget-datetime-2.7.0.tgz",
+      "integrity": "sha512-2gTnyWi/dONFSZteTBZ3AIwuPCw18DqILkke22CDf3/VKOpO/jqJfTgFIcCXb9XF4z5UbW+p52Zf8U4Iq0uJPQ=="
     },
     "netlify-cms-widget-file": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-file/-/netlify-cms-widget-file-2.9.2.tgz",
-      "integrity": "sha512-3ByQ6iAPGqNCdE2Mb2HCAlhA3siPRAo7oDnqBum9b4NKod7BB9olew1IEPG3GCji5t0/2VZKdi7xql9vM4ieYg==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-file/-/netlify-cms-widget-file-2.10.1.tgz",
+      "integrity": "sha512-TkvT+byLziN6UyYnVX3jbyVH/vcRPH0p+kC9gpIcAdRC12DdAhnxKymJ5zvDgpPX4xvYKpqEpA2//xiV39UDmQ==",
       "requires": {
         "array-move": "3.0.1",
         "common-tags": "^1.8.0",
-        "react-sortable-hoc": "^1.0.0"
+        "react-sortable-hoc": "^2.0.0"
       }
     },
     "netlify-cms-widget-image": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-image/-/netlify-cms-widget-image-2.7.7.tgz",
-      "integrity": "sha512-wG8o9riClhmst+fpLkod38Ee0sk4vUR7NoqpQ3TAvpdoVjsPf5qYQnK/EUpFLRzHT3gYgaLTIG/NpezZoMuAJA=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-image/-/netlify-cms-widget-image-2.8.0.tgz",
+      "integrity": "sha512-tPT2Lz40PNmLpvwcbtA3ZNrkMHojb9aWx0p71okkXm3udoErZQLWed5f/zDQsT1FDDPmdLhoeLF2CjtZUu80Qg=="
     },
     "netlify-cms-widget-list": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-list/-/netlify-cms-widget-list-2.8.5.tgz",
-      "integrity": "sha512-/yfH5KDtxoG4eEVewf1ytoq3Jhp1jyib8udSdI7x1DHmUf9qt71C52bkeGrgbc1J/a9AOgmGqe1J8v0vKvxmQQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-list/-/netlify-cms-widget-list-2.9.1.tgz",
+      "integrity": "sha512-oDUM7aNJGxOHg51VCeK0tzLBHSyY3IpFiK28Pdwzcg/kfoGk0LuJhAE0lJ0uvN8ZJD/d9xsJB3n3frQEgrebOQ==",
       "requires": {
-        "react-sortable-hoc": "^1.0.0"
+        "react-sortable-hoc": "^2.0.0"
       }
     },
     "netlify-cms-widget-map": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-map/-/netlify-cms-widget-map-1.4.6.tgz",
-      "integrity": "sha512-ip1YAsRRHxu7GuSFdJTyQMtFLZ2IOCMSaiQvF/T4M4YtszSqxUf/ByK2nJxK6pvFQOUrM3uiMZqE5oXT7zsX9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-map/-/netlify-cms-widget-map-1.5.0.tgz",
+      "integrity": "sha512-+6xkVWi3RDacOadAsKTMUmDw10okCKHrJ6x4a1FUZpmnSiDeEvuMVJMLz0gGIwJJuDnPqnB2qUpshUhOwDy4kA==",
       "requires": {
         "ol": "^5.3.1"
       }
     },
     "netlify-cms-widget-markdown": {
-      "version": "2.12.12",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-markdown/-/netlify-cms-widget-markdown-2.12.12.tgz",
-      "integrity": "sha512-2RuWCCpUmczitymAhEkNuUPYxTnhh4A09MDiJmvy2gJA4Ak8wt4xzKsXBOs3/UyQhmxkpbrVTrwHKq4N4CNDeg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-markdown/-/netlify-cms-widget-markdown-2.13.0.tgz",
+      "integrity": "sha512-bQ9kaEV6mwoNj5+xellA6DyAPS/SayA8dmsDwOaNTGVTfLNJxVX4+JgVcgSwwpQI9s+UhkBHXABMpBMX+sPaRw==",
       "requires": {
         "dompurify": "^2.2.6",
         "is-hotkey": "^0.2.0",
@@ -2671,41 +2663,41 @@
       }
     },
     "netlify-cms-widget-number": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-number/-/netlify-cms-widget-number-2.4.7.tgz",
-      "integrity": "sha512-gT9lEa4CYxSeBZtoaYEDsE8mYifYUYLqPaTcxw1yq2ziV+u5ylBMSy540934FEIk+lmalvUw6tJmjvn5d7Rowg=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-number/-/netlify-cms-widget-number-2.5.0.tgz",
+      "integrity": "sha512-4F7c+xkLba4UQTxhqfO8HTKfzCgQLeyDfdvJJOm/RXJjvcK+tp4MnTPqMI3OHBKi56Ay/oV1Q8OHIQ6grT9bpQ=="
     },
     "netlify-cms-widget-object": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-object/-/netlify-cms-widget-object-2.6.2.tgz",
-      "integrity": "sha512-wSF3c3sMqlifBKmUFgoe6b5H2e//OI3AT9wSMNQmB5YJlnr3FUxS+nyUWMF6w9SzwFvEpGcHlEL/hKE0ZDZ9oQ=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-object/-/netlify-cms-widget-object-2.7.0.tgz",
+      "integrity": "sha512-5i3T88JOLtOjXCRwCe684t2YrUrGbeZsuJXsZ+n6Lx1MK4hBeImaLMKKTNN5IvUFMr/JmJdJSgQtHxNF4gRvGw=="
     },
     "netlify-cms-widget-relation": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-relation/-/netlify-cms-widget-relation-2.9.0.tgz",
-      "integrity": "sha512-3vUkUYFpKd9TjEajgn04w70BC6cJS7U5uvwwD9596tZ4wKt93ZVv/xg8rx59doto1p2IS/UqRxflf+9bpRR/6A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-relation/-/netlify-cms-widget-relation-2.10.0.tgz",
+      "integrity": "sha512-EF7fc81M5AX5pmr0H4LSTeOL/dll3Srlz0O9RzWz0MRtZO0DoXDICEgl6pAtaDgd3yCZVSd/BEOMirjMPlqkCw==",
       "requires": {
         "react-select": "^2.4.2",
         "react-window": "^1.8.5"
       }
     },
     "netlify-cms-widget-select": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-select/-/netlify-cms-widget-select-2.7.4.tgz",
-      "integrity": "sha512-ITmaSCj7fC4XmQMLHaKxqudFeh3W2O9awhHO5ZEuAI5nWCoWXwxt4f2Ck6yBulPxIjVt5gpgKKin5ynPwXs4fw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-select/-/netlify-cms-widget-select-2.8.0.tgz",
+      "integrity": "sha512-zYDY9cCM1IFS68Dc2pEokX4nCA1i7pR57cT1CKIVTUGGqXz9/c+Jv2g1w92quMPocaeLf4whqOM9D4n6bwxm+Q==",
       "requires": {
         "react-select": "^2.4.2"
       }
     },
     "netlify-cms-widget-string": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-string/-/netlify-cms-widget-string-2.2.10.tgz",
-      "integrity": "sha512-7GiJt9Yzvd7jP+c7kDTsjubpmOenhrYu63m1VeyJW9354A1gmgucXDNOfcKt0PV1MpS4asshtMIbwhGj7yEkfg=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-string/-/netlify-cms-widget-string-2.3.0.tgz",
+      "integrity": "sha512-3TeDNob5wj8jyoqsuy7hPTtXNMwSx8yXzUrBPWVSMedvFYccqylQS3TamwMMM63S83zNC0SrqatYMSUiEG5dhw=="
     },
     "netlify-cms-widget-text": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-text/-/netlify-cms-widget-text-2.3.6.tgz",
-      "integrity": "sha512-/Q+eVxqrIicAym7C82kAleitmbaJp0YxU3uC5nJwkGHcxJ+m9rdK0NfFaf85RiykuTHMzLo9s/6FIZ0Tqy/EEw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/netlify-cms-widget-text/-/netlify-cms-widget-text-2.4.0.tgz",
+      "integrity": "sha512-FmDWNwLHB6d9rA30hs0/tS3arkpOeSmSYgjy8Q3dhdZwnwo8dk8RJ3G8cybcl4JRapKemHcXdLDKom5Ug+hPSQ==",
       "requires": {
         "react-textarea-autosize": "^8.0.0"
       }
@@ -2743,9 +2735,9 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -2790,9 +2782,9 @@
       }
     },
     "p-map": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
       "requires": {
         "aggregate-error": "^3.0.0"
       }
@@ -2880,9 +2872,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg=="
     },
     "pixelworks": {
       "version": "1.1.0",
@@ -2926,6 +2918,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "quickselect": {
       "version": "1.1.1",
@@ -3044,9 +3041,9 @@
       }
     },
     "react-frame-component": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/react-frame-component/-/react-frame-component-4.1.3.tgz",
-      "integrity": "sha512-4PurhctiqnmC1F5prPZ+LdsalH7pZ3SFA5xoc0HBe8mSHctdLLt4Cr2WXfXOoajHBYq/yiipp9zOgx+vy8GiEA=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-frame-component/-/react-frame-component-5.0.0.tgz",
+      "integrity": "sha512-JyoPSU6H96sd4l76EUvzB/cNkvhW74OK43A1m7kmgc14QztodV39l9g7DwVgkVeKpSqnpMYhrKcvehHZzfXBGA=="
     },
     "react-hot-loader": {
       "version": "4.13.0",
@@ -3097,9 +3094,9 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-modal": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.12.1.tgz",
-      "integrity": "sha512-WGuXn7Fq31PbFJwtWmOk+jFtGC7E9tJVbFX0lts8ZoS5EPi9+WWylUJWLKKVm3H4GlQ7ZxY7R6tLlbSIBQ5oZA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.13.1.tgz",
+      "integrity": "sha512-m6yXK7I4YKssQnsjHK7xITSXy2O81BSOHOsg0/uWAsdKtuT9HF2tdoYhRuxNNQg2V+LgepsoHUPJKS8m6no+eg==",
       "requires": {
         "exenv": "^1.2.0",
         "prop-types": "^15.5.10",
@@ -3122,9 +3119,9 @@
       }
     },
     "react-redux": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.3.tgz",
-      "integrity": "sha512-ZhAmQ1lrK+Pyi0ZXNMUZuYxYAZd59wFuVDGUt536kSGdD0ya9Q7BfsE95E3TsFLE3kOSFp5m6G5qbatE+Ic1+w==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz",
+      "integrity": "sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==",
       "requires": {
         "@babel/runtime": "^7.12.1",
         "@types/react-redux": "^7.1.16",
@@ -3166,9 +3163,12 @@
       }
     },
     "react-scroll-sync": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/react-scroll-sync/-/react-scroll-sync-0.8.0.tgz",
-      "integrity": "sha512-Ms9srm41UM+lWexuqdocXjqaqqt6ZRSFxcudgB0sYhC7Or+m12WemTwY8BaQCRf7hA8zHDk55FHvMkqsH7gF+w=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/react-scroll-sync/-/react-scroll-sync-0.9.0.tgz",
+      "integrity": "sha512-IaMUSTbarj9mhjVtBl9I45Er8gQqV8rdb9A0eK77JJ8MvnLcFIlnoiXVx1NS9ACy9QELq7xCTxdIVEdhDV9R0Q==",
+      "requires": {
+        "prop-types": "^15.5.7"
+      }
     },
     "react-select": {
       "version": "2.4.4",
@@ -3198,9 +3198,9 @@
       }
     },
     "react-sortable-hoc": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
-      "integrity": "sha512-v1CDCvdfoR3zLGNp6qsBa4J1BWMEVH25+UKxF/RvQRh+mrB+emqtVHMgZ+WreUiKJoEaiwYoScaueIKhMVBHUg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-2.0.0.tgz",
+      "integrity": "sha512-JZUw7hBsAHXK7PTyErJyI7SopSBFRcFHDjWW5SWjcugY0i6iH7f+eJkY8cJmGMlZ1C9xz1J3Vjz0plFpavVeRg==",
       "requires": {
         "@babel/runtime": "^7.2.0",
         "invariant": "^2.2.4",
@@ -3276,13 +3276,21 @@
       "integrity": "sha512-kivjYVWX15TX2IUrm8F1jaCEX8EXrpy3DD+u41WGqJ1ZqbljWpiwscV+VxOM1l7sSIM1jwi2LADjhhAJkJ9dxA=="
     },
     "react-waypoint": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/react-waypoint/-/react-waypoint-9.0.3.tgz",
-      "integrity": "sha512-NRmyjW8CUBNNl4WpvBqLDgBs18rFUsixeHVHrRrFlWTdOlWP7eiDjptqlR/cJAPLD6RwP5XFCm3bi9OiofN3nA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-waypoint/-/react-waypoint-10.1.0.tgz",
+      "integrity": "sha512-wiVF0lTslVm27xHbnvUUADUrcDjrQxAp9lEYGExvcoEBScYbXu3Kt++pLrfj6CqOeeRAL4HcX8aANVLSn6bK0Q==",
       "requires": {
+        "@babel/runtime": "^7.12.5",
         "consolidated-events": "^1.1.0 || ^2.0.0",
         "prop-types": "^15.0.0",
-        "react-is": "^16.6.3"
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        }
       }
     },
     "react-window": {
@@ -3314,12 +3322,11 @@
       }
     },
     "redux": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
-      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.0.tgz",
+      "integrity": "sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==",
       "requires": {
-        "loose-envify": "^1.4.0",
-        "symbol-observable": "^1.2.0"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "redux-devtools-extension": {
@@ -3433,6 +3440,13 @@
         "unist-util-remove-position": "^1.0.0",
         "vfile-location": "^2.0.0",
         "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "trim": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/trim/-/trim-1.0.1.tgz",
+          "integrity": "sha512-3JVP2YVqITUisXblCDq/Bi4P9457G/sdEamInkyvCsjbTcXLXIiG7XCb4kGMFWh6JGXesS3TKxOPtrncN/xe8w=="
+        }
       }
     },
     "remark-rehype": {
@@ -3538,9 +3552,12 @@
       }
     },
     "run-parallel": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
-      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "rw": {
       "version": "1.3.3",
@@ -3572,16 +3589,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
-      }
-    },
-    "scope-css": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/scope-css/-/scope-css-1.2.1.tgz",
-      "integrity": "sha512-UjLRmyEYaDNiOS673xlVkZFlVCtckJR/dKgr434VMm7Lb+AOOqXKdAcY7PpGlJYErjXXJzKN7HWo4uRPiZZG0Q==",
-      "requires": {
-        "escaper": "^2.5.3",
-        "slugify": "^1.3.1",
-        "strip-css-comments": "^3.0.0"
       }
     },
     "section-matter": {
@@ -3738,11 +3745,6 @@
       "resolved": "https://registry.npmjs.org/slate-soft-break/-/slate-soft-break-0.9.0.tgz",
       "integrity": "sha512-iTy2bl/G+tphN10YQBOPDRxDqgM46ZH1UUz0ublmL6PLtwJ3jJK1n08w37YxnY/ge4aW31UN386KV6qvFx6Hsw=="
     },
-    "slugify": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.6.tgz",
-      "integrity": "sha512-ZdJIgv9gdrYwhXqxsH9pv7nXxjUEyQ6nqhngRxoAAOlmMGA28FDq5O4/5US4G2/Nod7d1ovNcgURQJ7kHq50KQ=="
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3814,14 +3816,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
-    },
-    "strip-css-comments": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-css-comments/-/strip-css-comments-3.0.0.tgz",
-      "integrity": "sha1-elYl7/iisibPiUehElTaluE9rok=",
-      "requires": {
-        "is-regexp": "^1.0.0"
-      }
     },
     "stylis": {
       "version": "3.5.4",
@@ -3907,11 +3901,6 @@
         "nopt": "~1.0.10"
       }
     },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-    },
     "trim-lines": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.3.tgz",
@@ -3963,20 +3952,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
-    },
     "type-of": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-of/-/type-of-2.0.1.tgz",
       "integrity": "sha1-5yoXQYllaOn2KDeNgW1pEvfyOXI="
     },
     "uglify-js": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.1.tgz",
-      "integrity": "sha512-o8lHP20KjIiQe5b/67Rh68xEGRrc2SRsCuuoYclXXoC74AfSRGblU1HKzJWH3HxPZ+Ort85fWHpSX7KwBUC9CQ=="
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.6.tgz",
+      "integrity": "sha512-rRprLwl8RVaS+Qvx3Wh5hPfPBn9++G6xkGlUupya0s5aDmNjI7z3lnRLB3u7sN4OmbB0pWgzhM9BEJyiWAwtAA=="
     },
     "unbox-primitive": {
       "version": "1.0.1",
@@ -4060,11 +4044,11 @@
       }
     },
     "unist-util-stringify-position": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.0.tgz",
+      "integrity": "sha512-SdfAl8fsDclywZpfMDTVDxA2V7LjtRDTOFd44wUJamgl6OlVngsqWjxvermMYf60elWHbxhuRCZml7AnuXCaSA==",
       "requires": {
-        "@types/unist": "^2.0.2"
+        "@types/unist": "^2.0.0"
       }
     },
     "unist-util-visit": {
@@ -4126,6 +4110,11 @@
         }
       }
     },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+    },
     "use-composed-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.1.0.tgz",
@@ -4148,15 +4137,14 @@
       }
     },
     "uswds": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.9.0.tgz",
-      "integrity": "sha512-5IMVgMCUUlgWVFrB7Wf1qTvv5L3oDDlSsAgvJ02+/sV2uh4JzO9YPm3493RTaMuHTc+feRCuYyEIloXsEQY0Pg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/uswds/-/uswds-2.11.2.tgz",
+      "integrity": "sha512-JISTXCjPIlrufbObIifjrMDn5jF9bbLu7UYhGWmEs9iqB6Z2KDCXHVoBUyzMmIrIjW/UWWYHZzPqOOHO6/IMCQ==",
       "requires": {
         "classlist-polyfill": "^1.0.3",
-        "del": "^5.1.0",
+        "del": "^6.0.0",
         "domready": "^1.0.8",
         "elem-dataset": "^2.0.0",
-        "lodash.debounce": "^4.0.7",
         "object-assign": "^4.1.1",
         "receptor": "^1.0.0",
         "resolve-id-refs": "^0.1.0"
@@ -4214,12 +4202,12 @@
       "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
     },
     "vfile-message": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.0.1.tgz",
+      "integrity": "sha512-gYmSHcZZUEtYpTmaWaFJwsuUD70/rTY4v09COp8TGtOkix6gGxb/a8iTQByIY9ciTk9GwAwIXd/J9OPfM4Bvaw==",
       "requires": {
         "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
+        "unist-util-stringify-position": "^3.0.0"
       }
     },
     "warning": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
     "build": "bundle exec jekyll build",
     "clean": "bundle exec jekyll clean",
     "reset": "npx rimraf Gemfile.lock package-lock.json LICENSE.md CONTRIBUTING.md degit.json .git",
-    "start": "bundle exec jekyll serve",
-    "preinstall": "npx npm-force-resolutions"
+    "start": "bundle exec jekyll serve"
   },
   "dependencies": {
     "anchor-js": "^4.3.1",
@@ -16,8 +15,5 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2"
-  },
-  "resolutions": {
-    "trim": ">=0.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,15 +5,19 @@
     "build": "bundle exec jekyll build",
     "clean": "bundle exec jekyll clean",
     "reset": "npx rimraf Gemfile.lock package-lock.json LICENSE.md CONTRIBUTING.md degit.json .git",
-    "start": "bundle exec jekyll serve"
+    "start": "bundle exec jekyll serve",
+    "preinstall": "npx npm-force-resolutions"
   },
   "dependencies": {
-    "anchor-js": "^4.3.0",
-    "mermaid": "^8.4.6",
-    "netlify-cms": "^2.10.112",
-    "uswds": "^2.9.0"
+    "anchor-js": "^4.3.1",
+    "mermaid": "^8.10.1",
+    "netlify-cms": "^2.10.126",
+    "uswds": "^2.11.2"
   },
   "devDependencies": {
     "rimraf": "^3.0.2"
+  },
+  "resolutions": {
+    "trim": ">=0.0.3"
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fixed outdated packages. Bumped Netlify to `v2.10.126`
- Fix transitive dependency on trim module, which has a known vulnerability.
- Modified package.json on to add resolution key
- Use `npm-force-resolutions` 

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/fix-trim)

## Security Considerations
Fix outdated dependency
