### PR TITLE
Create knowledge base

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,8 +54,6 @@ primary_navigation:
         url: /docs/technology/responsibilities/
       - name: Our team
         url: /docs/overview/cloudgov-team/
-  - name: Get started
-    url: /sign-up/
   - name: Pricing
     key: pricing
     children:
@@ -70,6 +68,8 @@ primary_navigation:
   - name: Documentation
     key: docs
     children:
+    - name: Get started
+      url: /sign-up/
     - name: Deploying apps
       url: /docs/deployment/deployment/
     - name: Managing apps
@@ -80,6 +80,8 @@ primary_navigation:
       url: /docs/ops/repos/
   - name: News
     url: /news/
+  - name: Knowledge base
+    url: /knowledge-base/
   - name: Contact us
     url: /contact/
 
@@ -176,6 +178,9 @@ collections:
   docs:
     output: true
     permalink: /:collection/:path/
+  kbarticles:
+    output: true
+    permalink: /knowledge-base/:path/
 
 
 permalink: pretty

--- a/_config.yml
+++ b/_config.yml
@@ -54,6 +54,8 @@ primary_navigation:
         url: /docs/technology/responsibilities/
       - name: Our team
         url: /docs/overview/cloudgov-team/
+  - name: Get started
+    url: /sign-up/
   - name: Pricing
     key: pricing
     children:
@@ -68,8 +70,6 @@ primary_navigation:
   - name: Documentation
     key: docs
     children:
-    - name: Get started
-      url: /sign-up/
     - name: Deploying apps
       url: /docs/deployment/deployment/
     - name: Managing apps

--- a/_docs/deployment/deployment.md
+++ b/_docs/deployment/deployment.md
@@ -57,4 +57,4 @@ By default, `cf push` will deploy the working state of all the files you have in
 
 ## Troubleshooting buildpack issues
 
-If you experience issues with your app that you believe might be buildpack related, please refer to [this knowledge base article](/knowledge-base/2021-05-20-managing-buildpack-changes/) for more information.
+If you experience issues with your app that you believe might be buildpack related, please refer to [this knowledge base article]({{ site.baseurl }}/knowledge-base/2021-05-20-managing-buildpack-changes/) for more information.

--- a/_docs/deployment/deployment.md
+++ b/_docs/deployment/deployment.md
@@ -54,3 +54,7 @@ By default, `cf push` will deploy the working state of all the files you have in
 1. cloud.gov works best with applications that follow the [Twelve-Factor App](http://12factor.net/) guidelines. This is more of a comprehensive philosophy than a set of requirements, and it helps explain how cloud.gov expects applications to behave.
 1. The Cloud Foundry [Considerations for Designing and Running an Application in the Cloud](https://docs.cloudfoundry.org/devguide/deploy-apps/prepare-to-deploy.html) apply to cloud.gov as well, including more details about the core principles above.
 1. The cloud.gov [production-ready guide]({{ site.baseurl }}{% link _docs/deployment/production-ready.md %}) explains how to prepare your application for success in production on cloud.gov.
+
+## Troubleshooting buildpack issues
+
+If you experience issues with your app that you believe might be buildpack related, please refer to [this knowledge base article](/knowledge-base/2021-05-20-managing-buildpack-changes/) for more information.

--- a/_docs/getting-started/accounts.md
+++ b/_docs/getting-started/accounts.md
@@ -113,3 +113,7 @@ If you use a cloud.gov account (instead of using an agency single sign-on accoun
 Access to systems and networks owned by cloud.gov is governed by, and subject to, all federal laws, including, but not limited to, the Privacy Act, 5 U.S.C. 552a, if the applicable cloud.gov system maintains individual Privacy Act information. Access to cloud.gov systems constitutes consent to the retrieval and disclosure of the information within the scope of your authorized access, subject to the Privacy Act, and applicable state and federal laws.
 
 Please contact [cloud.gov support]({{ site.baseurl }}/docs/help/) if you have questions about these rules or don't understand them.
+
+## Trouble logging in
+
+If you are a GSA employee encountering issues logging into cloud.gov, please refer to [this knowledge base article](/knowledge-base/2021-05-24-secureauth-issues/) for more information.

--- a/_docs/getting-started/accounts.md
+++ b/_docs/getting-started/accounts.md
@@ -116,4 +116,4 @@ Please contact [cloud.gov support]({{ site.baseurl }}/docs/help/) if you have qu
 
 ## Trouble logging in
 
-If you are a GSA employee encountering issues logging into cloud.gov, please refer to [this knowledge base article](/knowledge-base/2021-05-24-secureauth-issues/) for more information.
+If you are a GSA employee encountering issues logging into cloud.gov, please refer to [this knowledge base article]({{ site.baseurl }}/knowledge-base/2021-05-24-secureauth-issues/) for more information.

--- a/_docs/management/using-ssh.md
+++ b/_docs/management/using-ssh.md
@@ -14,7 +14,7 @@ ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-comma
 command, which lets you securely log in to an application instance where you can
 perform debugging, environment inspection, and other tasks.
 
-### Debugging tips
+### Application debugging tips
 
 **Configure your shell**: If you're trying to debug your app, you'll need to [configure your session to match your application's environment](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-env) by running `/tmp/lifecycle/shell`.
 
@@ -26,20 +26,6 @@ perform debugging, environment inspection, and other tasks.
 
 This overrides the port health check with the `process` check, and sets the start command to just `sleep`. That will give you 10 minutes to `cf ssh` and inspect your container.
 
-**Error opening SSH connection**: In prior versions of the CF API (CAPI) app instances used a single process. In version 3 of the CAPI, there can be more than 1 process that makes up an app. This may occasionally cause issues when trying to SSH to your app. If a modification or update was made to an app using a v3 command or process - even if that change was made by someone else (e.g., another member of a development team) - the app's schema in the Cloud Controller might have changed to version 3, and a standard `cf ssh` may no longer work. If this occurs, you can try using `cf v3-ssh {app-name}`. By default a `cf v3-ssh` will select the `web` process.  You can also select a different process with v3-ssh using the `--process` flag
-
-### Error messages
-
-* `cf ssh` uses port 2222. If your network blocks port 2222, you may receive an error message such as `Error opening SSH connection` or `psql: could not connect to server: Connection refused`.
-
-It is possible your internet service provider or network provider will block traffic on port 2222. You can work around this by using a VPN (like the GSA VPN) or using a native ssh client and following the instructions below.
-
-1. Retrieve the APP_GUID for your app: `cf app APP_NAME --guid`.
-2. Retrive a one-time ssh passcode using `cf ssh-code`. You will be prompted for this code below.
-3. Use `ssh` (not `cf ssh`) to connect to your app container. Substitute the value for your APP_GUID: `ssh -p 22 cf:APP_GUID/0@ssh.fr.cloud.gov`. You will be prompted to enter a password. Use the one-time ssh passcode you generated in step 2.
-
-This will open an ssh connection using port 22 to your app instance with index of 0. If you need to connect to a different instance, replace the `0` in the command above.
-
 ## How to disable SSH access
 
 SSH access is enabled by default. Space Developers can disable SSH access to individual applications, and Space Managers can disable SSH access to all apps running within a space. See [Enabling and Disabling SSH Access](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#enable-disable-ssh) for the commands.
@@ -50,3 +36,6 @@ You should [disable SSH access for production applications]({{ site.baseurl }}{%
 
 Application containers use the SSH-2.0 protocol. The SSH service uses the [Cloud Foundry SSH implementation](https://github.com/cloudfoundry/diego-ssh). For more on how Cloud Foundry implements SSH, refer to Cloud Foundry's documentation on [Understanding Application SSH](https://docs.cloudfoundry.org/concepts/diego/ssh-conceptual.html).
 
+## Troubleshooting SSH issues
+
+If you are having trouble connecting to your application via SSH, [please refer to this knowledge base article](/knowledge-base/2021-05-17-troubleshooting-ssh-connections/).

--- a/_docs/management/using-ssh.md
+++ b/_docs/management/using-ssh.md
@@ -38,4 +38,4 @@ Application containers use the SSH-2.0 protocol. The SSH service uses the [Cloud
 
 ## Troubleshooting SSH issues
 
-If you are having trouble connecting to your application via SSH, [please refer to this knowledge base article](/knowledge-base/2021-05-17-troubleshooting-ssh-connections/).
+If you are having trouble connecting to your application via SSH, [please refer to this knowledge base article]({{ site.baseurl }}/knowledge-base/2021-05-17-troubleshooting-ssh-connections/).

--- a/_docs/ops/customer-support.md
+++ b/_docs/ops/customer-support.md
@@ -30,7 +30,7 @@ The support team is not required to "pair" in the traditional sense unless the t
 
 As the support team has free cycles, they can pick up tasks from the backlog designated with the `support-team` label. These tasks aim to improve our ability to support the platform by paying down technical debt, adding automation, improving monitoring and alerting, or adding to system documentation such as run-books. Because support team members inevitably face interruptions that cause context switching, the `support-team` backlog is groomed by the team with this in mind. These stories are not mission-critical, easy to pick up, and easy to hand off to another team member.
 
-The support team should also monitor requests for support in Zendesk (and other channels) to identify commonly asked questions or frequently requested issues. These topics should be added to [new or existing knowledge base articles](/knowledge-base) to make answering these requests more efficient going forward.
+The support team should also monitor requests for support in Zendesk (and other channels) to identify commonly asked questions or frequently requested issues. These topics should be added to [new or existing knowledge base articles]({{ site.baseurl }}/knowledge-base) to make answering these requests more efficient going forward.
 
 ## Zendesk Support Process
 
@@ -52,7 +52,7 @@ The support team should also monitor requests for support in Zendesk (and other 
 1. Everyone should join #cg-supportstream to get notifications on Slack. This
    can be useful to alert and coordinate with other team members.
 1. Commonly asked questions or frequently requested items should be considered for 
-   adding to the [cloud.gov knowledge base](/knowledge-base).
+   adding to the [cloud.gov knowledge base]({{ site.baseurl }}/knowledge-base).
 
 ## Support Status
 

--- a/_docs/ops/customer-support.md
+++ b/_docs/ops/customer-support.md
@@ -30,6 +30,7 @@ The support team is not required to "pair" in the traditional sense unless the t
 
 As the support team has free cycles, they can pick up tasks from the backlog designated with the `support-team` label. These tasks aim to improve our ability to support the platform by paying down technical debt, adding automation, improving monitoring and alerting, or adding to system documentation such as run-books. Because support team members inevitably face interruptions that cause context switching, the `support-team` backlog is groomed by the team with this in mind. These stories are not mission-critical, easy to pick up, and easy to hand off to another team member.
 
+The support team should also monitor requests for support in Zendesk (and other channels) to identify commonly asked questions or frequently requested issues. These topics should be added to [new or existing knowledge base articles](/knowledge-base) to make answering these requests more efficient going forward.
 
 ## Zendesk Support Process
 
@@ -50,6 +51,8 @@ As the support team has free cycles, they can pick up tasks from the backlog des
    acknowledged and set to Open or Pending.
 1. Everyone should join #cg-supportstream to get notifications on Slack. This
    can be useful to alert and coordinate with other team members.
+1. Commonly asked questions or frequently requested items should be considered for 
+   adding to the [cloud.gov knowledge base](/knowledge-base).
 
 ## Support Status
 

--- a/_docs/services/aws-elasticsearch.md
+++ b/_docs/services/aws-elasticsearch.md
@@ -45,9 +45,9 @@ Note: AWS Elasticsearch creation times will vary and is outside of Cloud.gov's c
 
 When using the `medium` and `medium-ha` plans, please read [Scalability and resilience: clusters, nodes, and shards](https://www.elastic.co/guide/en/elasticsearch/reference/current/scalability.html) for the elasticsearch basics on clusters as well as the AWS specific [Developer Guide](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/what-is-amazon-elasticsearch-service.html).  The `medium` plan is mainly focused for customers that need a single index and have coverage with 2 data nodes.  For customers wanting more coverage and more indexes, then the `medium-ha` plan scales the cluster to 4 data nodes to offer high availability (HA).
 
-### AWS Signing requests requirement
+### Connecting to your service instance
 
-In order to use the Elasticsearch service hosted on AWS you will need to use [AWS signed HTTP headers](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html)
+If you need to directly access your service instance from your local environment, please read [this knowledge base article](/knowledge-base/2021-05-20-connecting-to-brokered-service-instances/) for more information.
 
 ## Managing backups
 

--- a/_docs/services/aws-elasticsearch.md
+++ b/_docs/services/aws-elasticsearch.md
@@ -47,7 +47,7 @@ When using the `medium` and `medium-ha` plans, please read [Scalability and resi
 
 ### Connecting to your service instance
 
-If you need to directly access your service instance from your local environment, please read [this knowledge base article](/knowledge-base/2021-05-20-connecting-to-brokered-service-instances/) for more information.
+If you need to directly access your service instance from your local environment, please read [this knowledge base article]({{ site.baseurl }}/knowledge-base/2021-05-20-connecting-to-brokered-service-instances/) for more information.
 
 ## Managing backups
 

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -53,7 +53,7 @@ Or, the following command (using cf cli version 7):
 cf marketplace -e aws-rds
 ```
 
-The dedicated plans listed above (marked "AWS RDS Latest") deploy the default version as advertised by AWS. If you need to determine the exact version of the RDS service deployed, see [this knowledge base article](/knowledge-base/2021-05-20-getting-rds-version-information/).
+The dedicated plans listed above (marked "AWS RDS Latest") deploy the default version as advertised by AWS. If you need to determine the exact version of the RDS service deployed, see [this knowledge base article]({{ site.baseurl }}/knowledge-base/2021-05-20-getting-rds-version-information/).
 
 *Additional Cost:* All databases have a limit of 1TB in storage. After 1TB, each additional terabyte will cost $300 per month.
 

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -53,9 +53,7 @@ Or, the following command (using cf cli version 7):
 cf marketplace -e aws-rds
 ```
 
-The dedicated plans listed above (marked "AWS RDS Latest") deploy the default version as advertised by AWS. There is currently no way to verify ahead of time the version of an RDS service that will be deployed by the cloud.gov broker, but you can check the version once an instance has been created by connecting to that instance using the [cf-service-connect](https://github.com/cloud-gov/cf-service-connect#usage) plugin, and running `SELECT version();` (or equivalent command) at the prompt.
-
-Note that you can also look at the AWS RDS User Guides for [PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.DBVersions), [MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html), and [Oracle](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Oracle.html) for version information, but these documents sometimes lists versions that are not yet available on AWS GovCloud.
+The dedicated plans listed above (marked "AWS RDS Latest") deploy the default version as advertised by AWS. If you need to determine the exact version of the RDS service deployed, see [this knowledge base article](/knowledge-base/2021-05-20-getting-rds-version-information/).
 
 *Additional Cost:* All databases have a limit of 1TB in storage. After 1TB, each additional terabyte will cost $300 per month.
 

--- a/_includes/pagination-links.html
+++ b/_includes/pagination-links.html
@@ -1,0 +1,35 @@
+<div class="grid-row padding-top-2">
+  <div
+    class="tablet:grid-col-4 text-center tablet:order-2 font-body-xs text-base"
+  >
+    Page {{ paginator.page }} of {{ paginator.total_pages }}
+  </div>
+  <div class="tablet:grid-col-4 text-right tablet:order-3">
+    {% if paginator.next_page %}
+    <a
+      href="{{ paginator.next_page_path | prepend: site.baseurl }}"
+      class="paginate-link usa-link font-family-ui text-no-underline text-bold tablet:margin-top-0"
+      >Next {{ paginator.per_page }} Posts &rsaquo;</a
+    >
+    <a
+      href="{{ paginator.next_page_path | prepend: site.baseurl }}"
+      class="paginate-button usa-button margin-top-3 font-family-ui"
+      >Next {{ paginator.per_page }} Posts &rsaquo;</a
+    >
+    {% endif %}
+  </div>
+  <div class="tablet:grid-col-4 text-left tablet:order-1">
+    {% if paginator.previous_page %}
+    <a
+      href="{{ paginator.previous_page_path | prepend: site.baseurl }}"
+      class="paginate-link usa-link font-family-ui text-no-underline tablet:margin-top-0"
+      >&lsaquo; Previous {{ paginator.per_page }} Posts</a
+    >
+    <a
+      href="{{ paginator.previous_page_path | prepend: site.baseurl }}"
+      class="paginate-button font-family-ui usa-button margin-top-2"
+      >&lsaquo; Previous {{ paginator.per_page }} Posts</a
+    >
+    {% endif %}
+  </div>
+</div>

--- a/_kbarticles/2021-05-17-troubleshooting-ssh-connections.md
+++ b/_kbarticles/2021-05-17-troubleshooting-ssh-connections.md
@@ -1,0 +1,33 @@
+---
+layout: post
+title: "Troubleshooting SSH Connections"
+date: May 17, 2021
+excerpt: Some tips and tricks for logging into app instances using SSH
+---
+
+This post will help you troubleshoot issues when [connecting to your app using SSH](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html).
+
+Some things to check:
+
+* Make sure you have SSH access enabled. You can check to see of SSH is enabled by running `cf ssh-enabled APP_NAME`. Enable it by running `cf enable-ssh APP_NAME`.
+* Make sure you are not in an environment that blocks outgoing traffic on port 2222 (the default port for `cf ssh` traffic). Some offices or corporate locations may block traffic on this port.
+
+### Working around port blocking
+
+`cf ssh` uses port 2222. If your network blocks port 2222, you may receive an error message such as `Error opening SSH connection` or `psql: could not connect to server: Connection refused`.
+
+It is possible your internet service provider or network provider will block traffic on port 2222. You can work around this by using a VPN (like the GSA VPN) or using a native ssh client and following the instructions below.
+
+1. Retrieve the APP_GUID for your app: `cf app APP_NAME --guid`.
+2. Retrive a one-time ssh passcode using `cf ssh-code`. You will be prompted for this code below.
+3. Use `ssh` (not `cf ssh`) to connect to your app container. Substitute the value for your APP_GUID: `ssh -p 22 cf:APP_GUID/0@ssh.fr.cloud.gov`. You will be prompted to enter a password. Use the one-time ssh passcode you generated in step 2.
+
+This will open an ssh connection using port 22 to your app instance with index of 0. If you need to connect to a different instance, replace the `0` in the command above.
+
+### Changes to your app in the CAPI
+
+If you are still experiencing trouble connecting to your app using SSH, it may be the result of some changes in a newer version of the Cloud Foundry API (CAPI). In prior versions of the CAPI, app instances used a single process. In version 3 of the CAPI, there can be more than 1 process that makes up an app. This may occasionally cause issues when trying to SSH to your app. 
+
+If a modification or update was made to an app using a v3 command or process - even if that change was made by someone else (e.g., another member of a development team) - the app’s schema in the Cloud Controller might have changed to version 3, and a standard cf ssh may no longer work. 
+
+If this occurs, you can try using `cf v3-ssh {app-name}`. By default a cf v3-ssh will select the `web` process. You can also select a different process if needed with v3-ssh using the `--process` flag.

--- a/_kbarticles/2021-05-20-connecting-to-brokered-service-instances.md
+++ b/_kbarticles/2021-05-20-connecting-to-brokered-service-instances.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title: "Connecting to brokered Elasticsearch service instances"
+date: May 20, 2021
+excerpt: Some suggestions for connecting to brokered Elasticsearch instances
+---
+
+For compliance purposes, brokered Elasticsearch service instances may only be accessed from within the cloud.gov environment. Additionally in order to connect to these instances, AWS requires the use of [signed HTTP headers](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html). If you plan to connect to your Elasticsearch instance from your local environment frequently, this can present challenges.
+
+Some things to consider:
+
+* The brokered Elasticsearch instances are not well suited for running your own logging stack (if that's what you are trying to do), and are designed to be used for data storage in conjunction with an application running on cloud.gov.
+* If you need to capture or analyze log data from your application, some better options include using the [cloud.gov logging dashboard](https://cloud.gov/docs/deployment/logs/#web-based-logs-with-historic-log-data), or setting up a [log drain to offload platform logs](https://cloud.gov/docs/deployment/logs/#how-to-automatically-copy-your-logs-elsewhere) to an external logging tool or platform.
+
+If you do need to directly interact with your cloud.gov Elasticsearch instance you can configure and deploy a basic proxy application similar to the example that can found here: https://github.com/cloud-gov/aws-elasticsearch-auth-proxy (please note the documented security considerations).
+
+

--- a/_kbarticles/2021-05-20-getting-rds-version-information.md
+++ b/_kbarticles/2021-05-20-getting-rds-version-information.md
@@ -7,6 +7,10 @@ excerpt: Find out what version of AWS RDS version your app is using
 
 The dedicated plans listed in the [RDS Services page](https://cloud.gov/docs/services/relational-database/) (marked “AWS RDS Latest”) deploy the default version as advertised by AWS. 
 
-There is currently no way to verify ahead of time the version of an RDS service that will be deployed by the cloud.gov broker, but you can check the version once an instance has been created by connecting to that instance using the cf-service-connect plugin, and running SELECT version(); (or equivalent command) at the prompt.
+There is currently no way to verify ahead of time the version of an RDS service that will be deployed by the cloud.gov broker, but you can check the version once an instance has been created by connecting to that instance using the cf-service-connect plugin.  Once the database prompt appears, run the command that matches the database you're using:
+
+- PostgreSQL:  `SELECT version();`
+- MySQL:  `SELECT VERSION();`
+- Oracle:  `SELECT * FROM v$version;`
 
 Note that you can also look at the AWS RDS User Guides for [PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.DBVersions), [MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html), and [Oracle](Oracle) for version information, but these documents sometimes lists versions that are not yet available on AWS GovCloud.

--- a/_kbarticles/2021-05-20-getting-rds-version-information.md
+++ b/_kbarticles/2021-05-20-getting-rds-version-information.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: "Getting RDS version information"
+date: May 20, 2021
+excerpt: Find out what version of AWS RDS version your app is using
+---
+
+The dedicated plans listed in the [RDS Services page](https://cloud.gov/docs/services/relational-database/) (marked “AWS RDS Latest”) deploy the default version as advertised by AWS. 
+
+There is currently no way to verify ahead of time the version of an RDS service that will be deployed by the cloud.gov broker, but you can check the version once an instance has been created by connecting to that instance using the cf-service-connect plugin, and running SELECT version(); (or equivalent command) at the prompt.
+
+Note that you can also look at the AWS RDS User Guides for [PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.DBVersions), [MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html), and [Oracle](Oracle) for version information, but these documents sometimes lists versions that are not yet available on AWS GovCloud.

--- a/_kbarticles/2021-05-20-managing-buildpack-changes.md
+++ b/_kbarticles/2021-05-20-managing-buildpack-changes.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "Managing buildpack changes"
+date: May 20, 2021
+excerpt: If your application's behavior changes unexpectedly without code changes, it might be related to a new buildpack release
+---
+
+If you notice strange behavior in your application, or if builds / deployments are not working properly and no coding changes were made, one possible cause could be changes to the [buildpack](https://cloud.gov/docs/getting-started/concepts/#buildpacks) used by your application.
+
+Some things to check:
+
+* You can check which buildpack and version your app is using by running `cf app APP_NAME`
+* You can check the latest version of cloud.gov system buildpacks by running: `cf buildpacks`
+* You can check the latest buildpack release version by checking the releases page in the appropriate buildpack GitHub repository: `https://github.com/cloudfoundry/{BUILDPACK-TYPE}-buildpack/releases`
+
+New buildpack versions are released often to update components and address security vulnerabilities. When a new buildpack is available (either via a reference to a buildpack URL or a system buildpack), it will be picked up and used by your application when you do a `cf restage`.
+
+Buildpack changes can sometimes cause unexpected behavior because of changes in a runtime, component, or dependency. You should carefully read the release notes for new buildpack releases to ensure that changes don't adversely impact your application. If you suspect that a buildpack update may be causing issues with your application, you can validate it by using an earlier version of a buildpack to see if a new release includes a breaking change.
+
+To use a specific version of a buildpack, you can do a `cf push` with the `--buildpack` or `-b` option and reference a specific release. For example: `cf push APP_NAME -b https://github.com/cloudfoundry/java-buildpack.git#v3.3.0`. 
+
+It may help to experiment by doing `cf push` with a prior release to see if this resolves the issue. If it does, you can modify your application to ensure it works properly with the latest buildpack release.

--- a/_kbarticles/2021-05-24-secureauth-issues.md
+++ b/_kbarticles/2021-05-24-secureauth-issues.md
@@ -19,4 +19,4 @@ Things you can check:
 
 * You can try clearing all cache and cookies, restart your browser, and retry logging in.
 
-If these steps don't work, [GSA also has a tool that can clear these items](https://secureauth.gsa.gov/secureauth2/cleancert.aspx). Note - if you are a Mac user, this site will only works in Safari.
+If these steps don't work, [GSA also has a tool that can clear these items](https://secureauth.gsa.gov/secureauth2/cleancert.aspx). Note - if you are a Mac user, this site will only work in Safari.

--- a/_kbarticles/2021-05-24-secureauth-issues.md
+++ b/_kbarticles/2021-05-24-secureauth-issues.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "Trouble Logging in to cloud.gov"
+date: May 20, 2021
+excerpt: If you see an error while logging into cloud.gov, these tips can help you troubleshoot
+---
+
+When logging in to cloud.gov, and using GSA's single sign on integration (SecureAuth), you may encounter an error message that includes reference to `InResponseToField`. For example, something like:
+
+```
+InResponseToField of the Response doesn’t correspond to sent message {code}
+```
+
+This is typically caused by SecureAuth having an old certificate or session cookie in your browser, and is not related to the cloud.gov platform. 
+
+Things you can check:
+
+* You can verify this issue is affecting your login by opening a private or incognito session in your browser and retry logging in. 
+
+* You can try clearing all cache and cookies, restart your browser, and retry logging in.
+
+If these steps don't work, [GSA also has a tool that can clear these items](https://secureauth.gsa.gov/secureauth2/cleancert.aspx). Note - if you are a Mac user, this site will only works in Safari.

--- a/knowledge-base/index.html
+++ b/knowledge-base/index.html
@@ -3,6 +3,7 @@ layout: wide
 permalink: /knowledge-base/
 pagination:
   enabled: true
+  collection: kbarticles
 ---
 
 <div id="blog" class="usa-graphic-list usa-section usa-section--dark sign-up-intro">
@@ -14,7 +15,7 @@ pagination:
   <div class="grid-row">
     <div class="desktop:grid-col-8 usa-prose padding-right-4">
       <!-- This loops through the paginated posts -->
-      {% for kb in site.kbarticles %}
+      {% for kb in paginator.posts %}
       <div
         class="padding-bottom-5 margin-top-4 usa-prose border-bottom-05 border-base-lightest usa-content"
       >
@@ -38,6 +39,9 @@ pagination:
         </div>
       </div>
       {% endfor %}
+
+      <!-- Pagination links -->
+      {%- include pagination-links.html -%}
     </div>
 
   </div>

--- a/knowledge-base/index.html
+++ b/knowledge-base/index.html
@@ -1,0 +1,44 @@
+---
+layout: wide
+permalink: /knowledge-base/
+pagination:
+  enabled: true
+---
+
+<div id="blog" class="usa-graphic-list usa-section usa-section--dark sign-up-intro">
+  <div class="grid-container maxw-desktop">
+    <h1 class="margin-0">cloud.gov knowledge base</h1>
+  </div>
+</div>
+<div class="grid-container padding-bottom-2 maxw-desktop">
+  <div class="grid-row">
+    <div class="desktop:grid-col-8 usa-prose padding-right-4">
+      <!-- This loops through the paginated posts -->
+      {% for kb in site.kbarticles %}
+      <div
+        class="padding-bottom-5 margin-top-4 usa-prose border-bottom-05 border-base-lightest usa-content"
+      >
+        <h3 class="title">
+          <a
+            class="usa-link text-no-underline"
+            href="{{ site.baseurl }}{{ kb.url }}"
+            >{{kb.title}}</a
+          >
+        </h3>
+        <div class="margin-bottom-2">
+          <div class="margin-top-neg-105 font-family-ui">
+            {{ kb.date | date: '%B %d, %Y' }}
+          </div>
+        </div>
+        <div >
+          {% if kb.image %} {% asset "{{ kb.image }}"
+          class="tablet:float-left tablet:width-1/3 padding-right-3
+          padding-top-1" alt="{{ kb.image_alt_text }}" %} {% endif %} {{
+          kb.excerpt | markdownify }}
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+
+  </div>
+</div>

--- a/news/index.html
+++ b/news/index.html
@@ -40,42 +40,9 @@ pagination:
         </div>
       </div>
       {% endfor %}
+
       <!-- Pagination links -->
-      <div class="grid-row padding-top-2">
-        <div
-          class="tablet:grid-col-4 text-center tablet:order-2 font-body-xs text-base"
-        >
-          Page {{ paginator.page }} of {{ paginator.total_pages }}
-        </div>
-        <div class="tablet:grid-col-4 text-right tablet:order-3">
-          {% if paginator.next_page %}
-          <a
-            href="{{ paginator.next_page_path | prepend: site.baseurl }}"
-            class="paginate-link usa-link font-family-ui text-no-underline text-bold tablet:margin-top-0"
-            >Next {{ paginator.per_page }} Posts &rsaquo;</a
-          >
-          <a
-            href="{{ paginator.next_page_path | prepend: site.baseurl }}"
-            class="paginate-button usa-button margin-top-3 font-family-ui"
-            >Next {{ paginator.per_page }} Posts &rsaquo;</a
-          >
-          {% endif %}
-        </div>
-        <div class="tablet:grid-col-4 text-left tablet:order-1">
-          {% if paginator.previous_page %}
-          <a
-            href="{{ paginator.previous_page_path | prepend: site.baseurl }}"
-            class="paginate-link usa-link font-family-ui text-no-underline tablet:margin-top-0"
-            >&lsaquo; Previous {{ paginator.per_page }} Posts</a
-          >
-          <a
-            href="{{ paginator.previous_page_path | prepend: site.baseurl }}"
-            class="paginate-button font-family-ui usa-button margin-top-2"
-            >&lsaquo; Previous {{ paginator.per_page }} Posts</a
-          >
-          {% endif %}
-        </div>
-      </div>
+      {%- include pagination-links.html -%}
     </div>
 
   </div>


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds a new collection to hold knowledge base articles
- Modifies top navigation to add new link for knowledge base
- Moves `Get started` to be a child under `Documentation` 
- Modified existing doc pages (where appropriate) to refer to new knowledge base articles

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/create-knowedge-base)

## Security Considerations
None. Content changes only
