### PR TITLE
Update addressable gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,3 +36,5 @@ gem "html-proofer", "~> 3.10"
 gem "kramdown-parser-gfm"
 
 gem "nokogiri", ">= 1.11.0.rc4"
+
+gem "addressable", ">= 2.8.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.7)
@@ -99,7 +99,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     posix-spawn (0.3.15)
-    public_suffix (4.0.5)
+    public_suffix (4.0.6)
     racc (1.5.2)
     rack (2.2.3)
     rainbow (3.0.0)
@@ -128,6 +128,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable (>= 2.8.0)
   html-proofer (~> 3.10)
   jekyll (~> 3.8)
   jekyll-assets (~> 3.0)


### PR DESCRIPTION
## Changes proposed in this pull request:
- Upgrade gem to address vulnerability 
- Supersedes #1958 

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/fix-addressable)

## Security Considerations
Addresses [vulnerability](https://github.com/cloud-gov/cg-site/security/dependabot/Gemfile.lock/addressable/open)
