### PR TITLE
Correct region/partition wording

### DIFF
--- a/_docs/technology/iaas.md
+++ b/_docs/technology/iaas.md
@@ -12,7 +12,7 @@ redirect_from:
 
 ## The infrastructure underlying cloud.gov
 
-cloud.gov runs on top of Infrastructure as a Service provided by Amazon Web Services (AWS) in the [AWS GovCloud region](https://aws.amazon.com/govcloud-us/), which has a [FedRAMP JAB P-ATO at the High impact level](https://marketplace.fedramp.gov/index.html#/product/aws-govcloud-high). GovCloud also offers support for other formal compliance needs such as [ITAR compliance](https://en.wikipedia.org/wiki/International_Traffic_in_Arms_Regulations).
+cloud.gov runs on top of Infrastructure as a Service provided by Amazon Web Services (AWS) in the [AWS GovCloud partition](https://aws.amazon.com/govcloud-us/), which has a [FedRAMP JAB P-ATO at the High impact level](https://marketplace.fedramp.gov/index.html#/product/aws-govcloud-high). GovCloud also offers support for other formal compliance needs such as [ITAR compliance](https://en.wikipedia.org/wiki/International_Traffic_in_Arms_Regulations).
 
 ## Services in our marketplace
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Wording change in opening infrastructure paragraph
- GovCloud is a separate partition, not a region. Within the govcloud partition, there are two regions (east/west). It's likely more meaningful here to just refer to the entire partition instead of a single gov-cloud region.

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)


## Security Considerations
[Note the any security considerations here, or make note of why there are none]
