### PR TITLE
update links from 18F to TTS

### DIFF
--- a/_docs/ops/security-ir.md
+++ b/_docs/ops/security-ir.md
@@ -19,9 +19,9 @@ At a high level, incident response follows this process:
 
 [Initiate](#initiate):
 
-- An 18F staff member inside or outside the cloud.gov team (the *reporter*) notices and reports a cloud.gov-related incident, using the [18F incident response process](https://handbook.18f.gov/security-incidents/) and then notifying the cloud.gov team in [`#cloud-gov`](https://gsa-tts.slack.com/messages/cloud-gov/) using `@cg-team`.
+- A TTS staff member inside or outside the cloud.gov team (the *reporter*) notices and reports a cloud.gov-related incident, using the [TTS incident response process](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/security-incidents/) and then notifying the cloud.gov team in [`#cloud-gov`](https://gsa-tts.slack.com/messages/cloud-gov/) using `@cg-team`.
 - The first responder on the cloud.gov team (which could be the reporter if the reporter is on the team) becomes the initial *Incident Commander* (IC).
-- The IC follows the [18F incident response process](https://handbook.18f.gov/security-incidents/) (or supports the reporter if the reporter already started it).
+- The IC follows the [TTS incident response process](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/security-incidents/) (or supports the reporter if the reporter already started it).
 
 [Assess](#assess):
 
@@ -53,19 +53,19 @@ For full details, read on.
 
 An incident begins when someone becomes aware of a potential incident. We define "incident" broadly, following [NIST SP 800-61](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf), as "a violation or imminent threat of violation of computer security policies, acceptable use policies, or standard security practices" (6). This is a deliberately broad definition, designed to encompass any scenario that might threaten the security of cloud.gov.
 
-When a person outside the cloud.gov team (the *reporter*) notices a cloud.gov-related incident, they should begin reporting it by using the [18F incident response process](https://handbook.18f.gov/security-incidents/), and then post about it in [`#cloud-gov`](https://gsa-tts.slack.com/messages/cloud-gov/) using `@cg-team`. If they don't get acknowledgment from the cloud.gov team right away, they should escalate by contacting the cloud.gov leads directly until they receive acknowledgment of their report.
+When a person outside the cloud.gov team (the *reporter*) notices a cloud.gov-related incident, they should begin reporting it by using the [TTS incident response process](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/security-incidents/), and then post about it in [`#cloud-gov`](https://gsa-tts.slack.com/messages/cloud-gov/) using `@cg-team`. If they don't get acknowledgment from the cloud.gov team right away, they should escalate by contacting the cloud.gov leads directly until they receive acknowledgment of their report.
 
-When a cloud.gov team member is the first person to notice an incident, they should also begin reporting it by using the [18F incident response process](https://handbook.18f.gov/security-incidents/) and posting about it in [`#cloud-gov`](https://gsa-tts.slack.com/messages/cloud-gov/) using `@cg-team` (including notifying the cloud.gov leads).
+When a cloud.gov team member is the first person to notice an incident, they should also begin reporting it by using the [TTS incident response process](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/security-incidents/) and posting about it in [`#cloud-gov`](https://gsa-tts.slack.com/messages/cloud-gov/) using `@cg-team` (including notifying the cloud.gov leads).
 
 In either case, the first participant on the cloud.gov team becomes the initial *Incident Commander* (IC) and carries out the next steps in the response. The IC's responsibility is coordination, not necessarily investigation. The IC's primary role is to guide the process. The first responder may remain IC throughout the process, or they may hand off IC duties later in the process.
 
-The IC makes sure that the [18F incident response process](https://handbook.18f.gov/security-incidents/) is followed, including supporting the reporter if the reporter already started it, or starting it if nobody has started it yet.
+The IC makes sure that the [TTS incident response process](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/security-incidents/) is followed, including supporting the reporter if the reporter already started it, or starting it if nobody has started it yet.
 
 #### Comms at the Initiate phase
 
 Note that at this point the issue's status is "investigating" — we haven't confirmed that it's really an issue yet. So, we should actually refer to this as just an "event" at this point; it doesn't become an "incident" until we've confirmed it.
 
-At this phase, communications should follow the steps in the [18F incident response process](https://handbook.18f.gov/security-incidents/) including creating an issue in the [`security-incidents`](https://github.com/18f/security-incidents) GitHub repository. Copy the following template to create the issue:
+At this phase, communications should follow the steps in the [TTS incident response process](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/security-incidents/) including creating an issue in the [`security-incidents`](https://github.com/18f/security-incidents) GitHub repository. Copy the following template to create the issue:
 
 ```
 Short description of what's going on
@@ -201,7 +201,7 @@ High-sev incidents successfully compromise the confidentiality/integrity of Pers
 
 - Confirmed breach of PII
 - Successful root-level compromise of production systems
-- Financial malware (ie. CryptoLocker) targeting 18F staff
+- Financial malware (ie. CryptoLocker) targeting TTS staff
 - Denial of Service attacks resulting in severe outages
 - Unauthorized access or traffic across network interconnect
 
@@ -217,7 +217,7 @@ Medium-sev incidents represent attempts (possibly un- or not-yet-successful) at 
 
 - Suspected PII breach
 - Targeted (but as-of-yet) attempts to compromise production systems
-- Spam/phishing attacks targeting 18F staff
+- Spam/phishing attacks targeting TTS staff
 - DoS attacks resulting in limited service degradation
 
 Guidelines for addressing Medium-sev issues:


### PR DESCRIPTION
There is a handbook redirect, but adding the url to the updated url we are trying to reference. Updating a few 18F referenced to TTS where it makes sense. 

I am asking if https://github.com/18f/security-incidents is being maintained, it is archived at the moment. I can confirm what we are supposed to do when @pburkholder is back.

## Changes proposed in this pull request:
- update handbook link
- update TTS instead of 18F

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)


## Security Considerations
We will want to confirm the security procedures are up to date. 
