### PR TITLE
remove smoke-tests note

### DIFF
--- a/_docs/ops/maintenance-list.md
+++ b/_docs/ops/maintenance-list.md
@@ -18,8 +18,7 @@ If you see a way to make this checklist better, just submit a PR to the
 
 ### Review and respond to alerts
 
-- Review all alerts on [Prometheus](https://prometheus.fr.cloud.gov/alerts) (requires the VPN).
-- Review all production smoke tests to ensure they are passing.
+Review all alerts on [Prometheus](https://prometheus.fr.cloud.gov/alerts) (requires the VPN).
 
 #### Investigate open alerts
 - Use our guides for reviewing cloud.gov alerts ([prometheus](https://github.com/cloud-gov/cg-deploy-prometheus/tree/master/bosh) for alert descriptions, links to the relevant rules, and starting points for reviewing each type of alert.


### PR DESCRIPTION
## Changes proposed in this pull request:
- remove smoke-tests note. This was added in when slack webhooks were broken and we had to go looking for smoke test failures


:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)


## Security Considerations
None