### PR TITLE
Update partner listing on home page

### DIFF
--- a/_assets/images/logos/NIH-logo.svg
+++ b/_assets/images/logos/NIH-logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 1224 792" style="enable-background:new 0 0 1224 792;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#5E5F5F;}
+</style>
+<path class="st0" d="M1041.9,395.4L840.2,758.9H101c-36.9,0-66.9-29.9-66.9-66.9V99.2c0-36.9,29.9-66.9,66.9-66.9h740L1041.9,395.4
+	L1041.9,395.4z M410.1,558.9V234.1H356v239.2h-1L206.8,234.1l0,0h-60l0,0v324.8l0,0H201V320h1.4l147.9,238.9H410.1L410.1,558.9
+	L410.1,558.9z M523,558.9V234.1h-56.8v324.8H523L523,558.9L523,558.9z M841.5,234.1h-56.8l0,0v129.2H636.8V234.1h-56.8v324.8h56.8
+	V412.5h147.9v146.5l0,0h56.8V234.1L841.5,234.1z"/>
+<path class="st0" d="M890.7,759.1L1092,395.4L891.4,32.3h50.3c27.5,0,61,19.7,74.3,43.8l176.5,319.2l-177.2,319.9
+	c-13.3,24-46.8,43.7-74.3,43.7L890.7,759.1L890.7,759.1z"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -206,10 +206,10 @@ redirect_from:
     </div>
     <div class="tablet:grid-col partner-card">
       <h5>
-        <a href="https://www.everykidinapark.gov/" class="usa-link usa-link--external">Every Kid in a Park</a>
+        <a href="https://dsld.od.nih.gov/" class="usa-link usa-link--external">Dietary Supplement Label Database</a>
       </h5>
-      {% asset DOI-logo.svg %}
-      Department of the Interior
+      {% asset NIH-logo.svg %}
+      National Institutes of Health
     </div>
     <div class="tablet:grid-col partner-card">
       <h5>


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update sample partner sites at bottom of home page.
- Switches out "Every Kid in a Park" (DOI) for "Dietary Supplement Label Database" (HHS/NIH)
- Fixes #1906 

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/mheadd-patch-20)

## Security Considerations
None
