### PR TITLE
Update secrets.md

### DIFF
--- a/_docs/ops/secrets.md
+++ b/_docs/ops/secrets.md
@@ -55,7 +55,7 @@ To work with AWS credentials on a day-to-day basis, we rely on [`aws-vault`](htt
 Install `aws-vault` with this [Homebrew](https://brew.sh/) command:
 
 ```sh
-brew cask install aws-vault
+brew install aws-vault
 ```
 
 Now create a profile, e.g., for the AWS GovCloud account:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Changed instruction for installing aws-vault via brew. Cask is no longer needed to install aws-vault, and previous command in docs fails. 

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/rbogle-patch-1/docs/ops/secrets/)


## Security Considerations
no security concerns, simple update to tooling install instructions to make current with tooling version. 
