### PR TITLE
drop pricing references to services that no longer exist

### DIFF
--- a/_pages/pricing.md
+++ b/_pages/pricing.md
@@ -159,12 +159,6 @@ redirect_from:
             Postgres, MySQL, Oracle database - 1TB included<br><i>$300/month per additional additional terabyte</i>
           </li>
           <li>
-            Legacy Elasticsearch RESTful search and analytics - 10 GB included<br><i>$100/month per additional gigabyte</i>
-          </li>
-          <li>
-            Legacy Redis in-memory data store - 10GB included<br><i>$100/month per additional gigabyte</i>
-          </li>
-          <li>
             Elasticsearch RESTful search and analytics<br><i>$200/month per node for medium, $400/month per node for large, 6 nodes included for FISMA Moderate</i>
           </li>
           <li>


### PR DESCRIPTION
## Changes proposed in this pull request:
- drop pricing references to services that no longer exist


:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/drop-old-services/pricing/)


## Security Considerations
None