### PR TITLE
fix 18f org repo refs to point to cloud-gov

### DIFF
--- a/_docs/getting-started/code-samples.md
+++ b/_docs/getting-started/code-samples.md
@@ -25,11 +25,11 @@ Test your install with following command:
 
 Now that you have your account and the CLI installed, let’s deploy a Java web application by downloading the application code, connecting to cloud.gov, and “pushing” the application.
 
-##### Download the application code from 18F's GitHub repository
+##### Download the application code from cloud.gov's GitHub repository
 
 If you have Git installed:
 
-`git clone https://github.com/18F/cf-sample-app-spring`
+`git clone https://github.com/cloud-gov/cf-sample-app-spring`
 
 `cd cf-sample-app-spring`
 
@@ -102,12 +102,12 @@ Test your install with following command:
 
 Now that you have your account and the CLI installed, let’s download the "Hello World" samples, choose one, connect to cloud.gov and "push" the application code.
 
-##### Download the Hello World code examples from 18F's GitHub repository
+##### Download the Hello World code examples from cloud.gov's GitHub repository
 
 If you have Git installed:
 
 ```
-git clone https://github.com/18F/cf-hello-worlds
+git clone https://github.com/cloud-gov/cf-hello-worlds
 cd cf-hello-worlds
 ```
 
@@ -173,7 +173,7 @@ If you’re done, you can delete your app by running `cf delete <APPNAME>` (it�
 
 If you've run into any issues with these tutorials, please [Contact support at cloud.gov](mailto:support@cloud.gov). We're happy to help.
 
-Did we miss a tip or useful resource that you think we should add? [Submit a suggestion on GitHub](https://github.com/18F/cg-site/issues/new) or [send us an email](mailto:inquiries@cloud.gov?subject=%5BSuggestion%5D%20&body=%0A%0A%0A%0ARefcode:%20quickstart).
+Did we miss a tip or useful resource that you think we should add? [Submit a suggestion on GitHub](https://github.com/cloud-gov/cg-site/issues/new) or [send us an email](mailto:inquiries@cloud.gov?subject=%5BSuggestion%5D%20&body=%0A%0A%0A%0ARefcode:%20quickstart).
 
 #### Additional sample applications
 

--- a/_docs/getting-started/your-first-deploy.md
+++ b/_docs/getting-started/your-first-deploy.md
@@ -43,8 +43,8 @@ cf target -o sandbox-gsa -s harry.truman
 
 ## Deploy a test application
 
-1. Get code for "hello world" applications ([repository](https://github.com/18F/cf-hello-worlds)):
-   * **Using git:** `git clone https://github.com/18F/cf-hello-worlds.git`
+1. Get code for "hello world" applications ([repository](https://github.com/cloud-gov/cf-hello-worlds)):
+   * **Using git:** `git clone https://github.com/cloud-gov/cf-hello-worlds.git`
    * **Download:** [`https://github.com/cloud-gov/cf-hello-worlds/archive/main.zip`](https://github.com/cloud-gov/cf-hello-worlds/archive/main.zip)
 1. Move into that directory, for example: `cd cf-hello-worlds`
 1. Look at the collection of tiny apps, and `cd` into the directory for the language/framework you feel most comfortable with. For example: `cd python-flask`


### PR DESCRIPTION
## Changes proposed in this pull request:
- nit couple of repo urls point to 18f, now should be cloud-gov
- gh redirects already, so this is just for 'looks'
-

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/rbogle-ghorg-updates/docs/getting-started/code-samples/)
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/rbogle-ghorg-updates/docs/getting-started/your-first-deploy/)

## Security Considerations
no security concerns, just url fixes. 
