### PR TITLE
Enable Atom feed for posts and KB articles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -270,3 +270,11 @@ last-modified-at:
 # Custom plugin to render the diagrams as mermaid
 mermaid:
   src: 'mermaid.min.js'
+
+feed:
+  path: updates.xml
+  collections:
+    kbarticles:
+      path: "/support.xml"
+  excerpt_only: true
+  posts_limit: 20


### PR DESCRIPTION
## Changes proposed in this pull request:
- Enable Atom feed for site
- Configure feeds for blog posts and knowledge base articles
- Fixes #2012 

## Preview links
- Blog posts / new updates: [/updates.xml](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/add-rss-feed/updates.xml)
- Knowledge base articles: [/support.xml](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/add-rss-feed/support.xml)

## Security Considerations
None