### PR TITLE
Link to team roster for contact phone numbers

### DIFF
--- a/_docs/ops/security-ir.md
+++ b/_docs/ops/security-ir.md
@@ -149,7 +149,7 @@ At this point, we're trying to fix the issue! Remediation will be very situation
 
     - For High-severity incidents, the team should take action immediately, even if this causes disruption. A notification about the disruption should be sent out as soon as possible, but the team needs no permission to take action at this level.
 
-    - For Medium-severity incidents, the team should notify the cloud.gov leads of the planned action, and help them assess the relative risk of disruption vs. security. If the leads are unavailable via Slack, they should be contacted using the phone numbers in their Slack profiles. The team should reach a collaborative decision on action, with a bias towards disruption. If they can't be reached within 1 hour, the team may take action without them.
+    - For Medium-severity incidents, the team should notify the cloud.gov leads of the planned action, and help them assess the relative risk of disruption vs. security. If the leads are unavailable via Slack, they should be contacted using the phone numbers, found either in their Slack profiles or on the [cloud.gov Team Roster](https://docs.google.com/spreadsheets/d/187663k5MYJBNlKExLu_nhuovcZQfIbqYCu2n4noNY1o/edit#gid=0). The team should reach a collaborative decision on action, with a bias towards disruption. If they can't be reached within 1 hour, the team may take action without them.
 
     - For Low-severity issues, the team should notify as above, and not take action until a mutually-agreed-on course of action has been determined.
 


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Link to team roster for contact phone numbers
-

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/peterb/phones-in-roster)


## Security Considerations

Link to roster is behind auth wall
