### PR TITLE
Update strings for Mysql go driver to not trigger

### DIFF
--- a/_posts/2021-11-18-release-notes.md
+++ b/_posts/2021-11-18-release-notes.md
@@ -182,7 +182,7 @@ USN-5133-1 USN-5133-1: ICU vulnerability:
 
 ### Diego Release 2.53.1 up from 2.53.0
 Changes
-* Bump to Go MySQL Driver v1.6.0 @mariash (#595)
+* Bump Go driver for MySQL Driver to v1.6.0 @mariash (#595)
 * BBS: Implement max-retries when failing to connect to event streams (cloudfoundry/bbs#45)
 
 Resources

--- a/_posts/2021-11-18-release-notes.md
+++ b/_posts/2021-11-18-release-notes.md
@@ -182,7 +182,7 @@ USN-5133-1 USN-5133-1: ICU vulnerability:
 
 ### Diego Release 2.53.1 up from 2.53.0
 Changes
-* Bump Go driver for MySQL Driver to v1.6.0 @mariash (#595)
+* Bump Go driver for MySQL to v1.6.0 @mariash (#595)
 * BBS: Implement max-retries when failing to connect to event streams (cloudfoundry/bbs#45)
 
 Resources


### PR DESCRIPTION
"Mysql Driver" is a verboten phrase where OWASP ZAP is concerned.

## Changes proposed in this pull request:
-
-
-

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)


## Security Considerations
Typo level changes to not trigger a scanner with a false positive
