### PR TITLE
Add post on PHP and Java bp updates for log4j

### DIFF
--- a/_posts/2021-12-14-log4j-buildpack-updates.md
+++ b/_posts/2021-12-14-log4j-buildpack-updates.md
@@ -5,14 +5,19 @@ title: "Buildpack Updates to Mitigate log4shell exploit"
 excerpt: Critical new updates have been released for the Java and PHP buildpacks and customers should restage their apps immediately.
 ---
 
-In response to the [recently announced exploit targeting vulnerable versions of the log4j logging utility](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q), the Cloud Foundry community today released patched versions of both the Java and PHP buildpacks. Customers are advised to immediately restage their applications to pick up these changes, which mitigate this new exploit. The new buildpack versions are:
+In response to the [recently announced exploit targeting vulnerable versions of the log4j logging utility](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q), referred to as "log4shell", the Cloud Foundry community today released patched versions of both the Java and PHP buildpacks. Customers are advised to immediately restage their applications to pick up these changes, which mitigate this new exploit. The new buildpack versions are:
 
 * Java buildpack - [version 4.44](https://github.com/cloudfoundry/java-buildpack/releases/tag/v4.44)
 * PHP buildpack - [version 4.4.52](https://github.com/cloudfoundry/php-buildpack/releases/tag/v4.4.52)
 
- The cloud.gov team immediately worked to make these new buildpack releases available to customers. Application owners can restage their applications [following the directions contained in the Cloud Foundry documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/start-restart-restage.html#restage). After restaging, you can verify the version of buildpack being used by your application by inspecting the app details using `cf app {application-name}`.
+ The cloud.gov team worked to make these new buildpacks available to customers immediately upon their release. Application owners can restage their applications [following the directions contained in the Cloud Foundry documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/start-restart-restage.html#restage). After restaging, you can verify the version of buildpack being used by your application by inspecting the app details using `cf app {application-name}`.
+
+CISA has released official guidance on this exploit, which [you can review here](https://www.cisa.gov/uscert/apache-log4j-vulnerability-guidance). 
+
+In addition, customers can [review the cloud.gov statuspage announcement](https://cloudgov.statuspage.io/incidents/hc60k5316r34) which contains some additional details on steps we are taking to mitigate this exploit for users of our platform.
 
 Customers with additional questions or experiencing issues can reach out to support at [support@cloud.gov](mailto:support@cloud.gov).
+
 
 
 

--- a/_posts/2021-12-14-log4j-buildpack-updates.md
+++ b/_posts/2021-12-14-log4j-buildpack-updates.md
@@ -1,0 +1,18 @@
+---
+layout: post
+date: December 14, 2021
+title: "Buildpack Updates to Mitigate log4shell exploit" 
+excerpt: Critical new updates have been released for the Java and PHP buildpacks and customers should restage their apps immediately.
+---
+
+In response to the [recently announced exploit targeting vulnerable versions of the log4j logging utility](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q), the Cloud Foundry community today released patched versions of both the Java and PHP buildpacks. Customers are advised to immediately restage their applications to pick up these changes, which mitigate this new exploit. The new buildpack versions are:
+
+* Java buildpack - [version 4.44](https://github.com/cloudfoundry/java-buildpack/releases/tag/v4.44)
+* PHP buildpack - [version 4.4.52](https://github.com/cloudfoundry/php-buildpack/releases/tag/v4.4.52)
+
+ The cloud.gov team immediately worked to make these new buildpack releases available to customers. Application owners can restage their applications [following the directions contained in the Cloud Foundry documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/start-restart-restage.html#restage). After restaging, you can verify the version of buildpack being used by your application by inspecting the app details using `cf app {application-name}`.
+
+Customers with additional questions or experiencing issues can reach out to support at [support@cloud.gov](mailto:support@cloud.gov).
+
+
+

--- a/_posts/2021-12-14-log4j-buildpack-updates.md
+++ b/_posts/2021-12-14-log4j-buildpack-updates.md
@@ -1,20 +1,24 @@
 ---
 layout: post
 date: December 14, 2021
-title: "Buildpack Updates to Mitigate log4shell exploit" 
+title: "log4j Customer responsibility: Restage Java and PHP applications to Mitigate log4shell exploit" 
 excerpt: Critical new updates have been released for the Java and PHP buildpacks and customers should restage their apps immediately.
 ---
 
-In response to the [recently announced exploit targeting vulnerable versions of the log4j logging utility](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q), referred to as "log4shell", the Cloud Foundry community today released patched versions of both the Java and PHP buildpacks. Customers are advised to immediately restage their applications to pick up these changes, which mitigate this new exploit. The new buildpack versions are:
+Late last week, a serious new vulnerability referred to as "log4shell" was disclosed [targeting vulnerable versions of the popular log4j logging utility](https://nvd.nist.gov/vuln/detail/CVE-2021-44228). 
+
+In response, the cloud.gov team has -- since last Friday -- applied a series of mitigations and updates to the platform, as described in our [most recent statuspage updates](https://cloudgov.statuspage.io/incidents/hc60k5316r34). These actions have secured our platform and afforded some protection to our customers without any need for customer intervention.
+
+Today the Cloud Foundry community released patched versions of both the Java and PHP buildpacks, which are vulnerable to this new exploit. Upon their release, the cloud.gov team worked to make these new buildpacks available to customers immediately. 
+
+Customers now need to take additional steps to further mitigate this vulnerability, and are advised to immediately restage their applications to pick up these new buildpack changes. The new buildpack versions are:
 
 * Java buildpack - [version 4.44](https://github.com/cloudfoundry/java-buildpack/releases/tag/v4.44)
 * PHP buildpack - [version 4.4.52](https://github.com/cloudfoundry/php-buildpack/releases/tag/v4.4.52)
 
- The cloud.gov team worked to make these new buildpacks available to customers immediately upon their release. Application owners can restage their applications [following the directions contained in the Cloud Foundry documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/start-restart-restage.html#restage). After restaging, you can verify the version of buildpack being used by your application by inspecting the app details using `cf app {application-name}`.
+Application owners can restage their applications [following the directions contained in the Cloud Foundry documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/start-restart-restage.html#restage). After restaging, you can verify the version of buildpack being used by your application by inspecting the app details using `cf app {application-name}`.
 
-CISA has released official guidance on this exploit, which [you can review here](https://www.cisa.gov/uscert/apache-log4j-vulnerability-guidance). 
-
-In addition, customers can [review the cloud.gov statuspage announcement](https://cloudgov.statuspage.io/incidents/hc60k5316r34) which contains some additional details on steps we are taking to mitigate this exploit for users of our platform.
+In addition, CISA has released official guidance on this exploit, which [you can review here](https://www.cisa.gov/uscert/apache-log4j-vulnerability-guidance). 
 
 Customers with additional questions or experiencing issues can reach out to support at [support@cloud.gov](mailto:support@cloud.gov).
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add a new post advising customers using the Java and PHP buildpacks to immediately restage to pick up changes to mitigate log4j exploit.

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/mheadd-patch-22/2021/12/14/log4j-buildpack-updates/)

## Security Considerations
Provide guidance to customers on how to mitigate a known exploit.
