### PR TITLE
If no statuspage, use Twitter and cloud.gov/news

### DIFF
--- a/_docs/ops/contingency-plan.md
+++ b/_docs/ops/contingency-plan.md
@@ -160,6 +160,9 @@ needs to be recovered separately, a [cloud.gov Pages contingency
 plan](https://docs.google.com/document/d/1YG6oucagNO_ZmmlsLPdQeFABCiVcY1BYuhDEEvDwe4Q/edit)
 is available internally. 
 
+## Statuspage
+
+If Statuspage is unavailable, cloud.gov will use Twitter, https://twiter.com/clouddotgov, and updates to https://cloud.gov/news.
 
 ## Continuity of Operations and Disaster Recovery Plan
 

--- a/_docs/ops/contingency-plan.md
+++ b/_docs/ops/contingency-plan.md
@@ -162,7 +162,7 @@ is available internally.
 
 ## Statuspage
 
-If Statuspage is unavailable, cloud.gov will use Twitter, https://twiter.com/clouddotgov, and updates to https://cloud.gov/news.
+If Statuspage is unavailable, cloud.gov will use Twitter, [https://twiter.com/clouddotgov](https://twiter.com/clouddotgov), and updates to [https://cloud.gov/news](https://cloud.gov/news).
 
 ## Continuity of Operations and Disaster Recovery Plan
 


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- If no statuspage, use Twitter and cloud.gov/news
- Now we can retire cloud-gov-emergency email list.

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/peterb/statuspage_cp


## Security Considerations
Nope. Only a tweak to our contingencies. 
