### PR TITLE
Specify specific region that cloud.gov is deployed to

### DIFF
--- a/_docs/technology/iaas.md
+++ b/_docs/technology/iaas.md
@@ -12,7 +12,7 @@ redirect_from:
 
 ## The infrastructure underlying cloud.gov
 
-cloud.gov runs on top of Infrastructure as a Service provided by Amazon Web Services (AWS) in the [AWS GovCloud partition](https://aws.amazon.com/govcloud-us/), which has a [FedRAMP JAB P-ATO at the High impact level](https://marketplace.fedramp.gov/index.html#/product/aws-govcloud-high). GovCloud also offers support for other formal compliance needs such as [ITAR compliance](https://en.wikipedia.org/wiki/International_Traffic_in_Arms_Regulations).
+cloud.gov runs on top of Infrastructure as a Service provided by Amazon Web Services (AWS) in the [AWS GovCloud partition](https://aws.amazon.com/govcloud-us/) (specifically within the us-gov-west-1 region), which has a [FedRAMP JAB P-ATO at the High impact level](https://marketplace.fedramp.gov/index.html#/product/aws-govcloud-high). GovCloud also offers support for other formal compliance needs such as [ITAR compliance](https://en.wikipedia.org/wiki/International_Traffic_in_Arms_Regulations).
 
 ## Services in our marketplace
 


### PR DESCRIPTION
In order to prevent having to field the same "What region is Cloud.gov deployed to?" question multiple times, specify the region in on the website. If specifying here is undesirable (because there are plans to deploy to multiple regions, or cloud.gov may switch regions) then feel free to comment/close.

## Changes proposed in this pull request:
- Specify the region that Cloud.gov is deployed to.

## Security Considerations
None - Wording change to website only.