### PR TITLE
Fix S3 service-key script

### DIFF
--- a/_docs/services/s3.md
+++ b/_docs/services/s3.md
@@ -100,17 +100,24 @@ For example, you might want to use the [AWS Command Line Interface](https://aws.
 ```sh
 #!/bin/bash
 
+Run this script with a . in order to set environment variables in your shell
+For example:
+  . ./getcreds.sh
+
+set -e 
+
 SERVICE_INSTANCE_NAME=your-s3-service-instance-name-here
 KEY_NAME=your-service-key-name-here
 
 cf create-service-key "${SERVICE_INSTANCE_NAME}" "${KEY_NAME}"
 S3_CREDENTIALS=`cf service-key "${SERVICE_INSTANCE_NAME}" "${KEY_NAME}" | tail -n +2`
 
-export AWS_ACCESS_KEY_ID=`echo "${S3_CREDENTIALS}" | jq -r .access_key_id`
-export AWS_SECRET_ACCESS_KEY=`echo "${S3_CREDENTIALS}" | jq -r .secret_access_key`
-export BUCKET_NAME=`echo "${S3_CREDENTIALS}" | jq -r .bucket`
-export AWS_DEFAULT_REGION=`echo "${S3_CREDENTIALS}" | jq -r '.region'`
+export AWS_ACCESS_KEY_ID=`echo "${S3_CREDENTIALS}" | jq -r .credentials.access_key_id`
+export AWS_SECRET_ACCESS_KEY=`echo "${S3_CREDENTIALS}" | jq -r .credentials.secret_access_key`
+export BUCKET_NAME=`echo "${S3_CREDENTIALS}" | jq -r .credentials.bucket`
+export AWS_DEFAULT_REGION=`echo "${S3_CREDENTIALS}" | jq -r '.credentials.region'`
 ```
+
 
 If you are running Windows on your local machine, you can find [instructions on how to set environmental variables using the Windows Command Prompt or PowerShell here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-set).
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fix the example script so that it actually works.
- Note that the script must be "sourced" (run with a '. ' in front of it for maximum cross-shell compatibility).

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)


## Security Considerations

No impact to the system. Corrects a non-functional script in documentation which customers might copy-and-paste.