### PR TITLE
Add missing instruction

### DIFF
--- a/_docs/orgs-spaces/roles.md
+++ b/_docs/orgs-spaces/roles.md
@@ -36,7 +36,7 @@ Log into the [Dashboard (https://dashboard.fr.cloud.gov)](https://dashboard.fr.c
 {% asset roles-05-open-manage-users.png alt="Click on the Manage Roles by Username icon toward the top of the screen." %}
 1. Type in the username that you want to either add or remove roles for in the organization, then click on the "Next" button at the bottom right of the screen.
 {% asset roles-06-specify-username.png alt="Type in the username that you want to either add or remove roles for in the organization, then click on the Next button at the bottom right of the screen." %}
-1. Select the roles that you would like to add or remove from the user.  You may also set roles for any spaces within the organization that you would like to add or remove them from on this screen.
+1. Select the roles that you would like to add or remove from the user. **Please be sure to check the `User` box** regardless so that the user will have proper access when finished.  You may also set roles for any spaces within the organization that you would like to add or remove them from on this screen.
 {% asset roles-07-select-roles.png alt="Select the roles that you would like to add or remove from the user.  You may also set roles for any spaces within the organization that you would like to add or remove them from on this screen." %}
 1. Confirm your changes and selections by clicking on the "Apply" button on the bottom of the screen.
 {% asset roles-08-confirm-changes.png alt="Confirm your changes and selections by clicking on the Apply button on the bottom of the screen." %}


### PR DESCRIPTION
This changeset adds an important missing piece to the user role management instructions for Stratos - the User checkbox must always be checked.

## Changes proposed in this pull request:
- Adds the missing instruction

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/add-missing-note/docs/orgs-spaces/roles/)

## Security considerations:
- None; public-facing instructions for user management