### PR TITLE
Document how to modify a space's security groups

### DIFF
--- a/_docs/management/space-egress.md
+++ b/_docs/management/space-egress.md
@@ -40,4 +40,18 @@ When you push your application to cloud.gov, the staging process may require out
 
 For applications that need access to S3, you have the option of running them under the `public-egress` ASG, or running them in the `restricted-egress` ASG, and using a proxy application (e.g., [squid proxy](http://www.squid-cache.org/), [HA proxy](http://www.haproxy.org/), etc.) to proxy traffic to your S3 bucket(s). Reference implementations showing how to do this will be available soon, or you may reach out to the cloud.gov team for support.
 
-To modify the ASG that applies to your space, you can open a support ticket by emailing [support@cloud.gov](mailto:support@cloud.gov) and requesting the addition of a new ASG to apply to your space.
+To inspect and modify the ASG that apply to your spaces, you can use the following CF CLI subcommands. Run `cf <subcommand> --help` to find out more about a specific command, or consult [the CF CLI documentation site](https://cli.cloudfoundry.org/en-US/v6/).
+
+| CF CLI subcommand | Description | 
+| :- | :- |
+| `cf security-group`                         | Show a single security group |
+| `cf security-groups`                        | List all security groups |
+| `cf bind-security-group`                    | Bind a security group to a particular space, or all existing spaces of an org |
+| `cf unbind-security-group`                 | Unbind a security group from a space |
+| `cf bind-staging-security-group`            | Bind a security group to the list of security groups to be used for staging applications globally |
+| `cf staging-security-groups`                | List security groups globally configured for staging applications |
+| `cf unbind-staging-security-group`          | Unbind a security group from the set of security groups for staging applications globally |
+| `cf bind-running-security-group`            | Bind a security group to the list of security groups to be used for running applications |
+| `cf running-security-groups`                | List security groups globally configured for running applications |
+| `cf unbind-running-security-group`          | Unbind a security group from the set of security groups for running applications globally |
+


### PR DESCRIPTION
[Communication with cloud.gov support is not actually required](https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1644352086463949?thread_ts=1644352032.164059&cid=C09CR1Q9Z) to make ASG changes on a space.

## Changes proposed in this pull request:
- replace directions to contact support with a table of the available commands for adjusting the ASGs bound to space

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/patch-11)

## Security Considerations
By making this support interaction into self-service documentation, we eliminate a potential vector for a bad actor to phish someone with administrative credentials to do something only admins can do.