### PR TITLE
Update space egress docs

### DIFF
--- a/_docs/management/space-egress.md
+++ b/_docs/management/space-egress.md
@@ -55,4 +55,4 @@ To inspect or modify the ASG that apply to your spaces, you can use the followin
 | `cf running-security-groups`                | List security groups globally configured for running applications |
 | `cf unbind-running-security-group`          | Unbind a security group from the set of security groups for running applications globally |
 
-If you have additional questions or run into issues, you can open a support ticket by emailing [support@cloud.gov](mailto:support@cloud.gov.
+If you have additional questions or run into issues, you can open a support ticket by emailing [support@cloud.gov](mailto:support@cloud.gov).

--- a/_docs/management/space-egress.md
+++ b/_docs/management/space-egress.md
@@ -40,4 +40,19 @@ When you push your application to cloud.gov, the staging process may require out
 
 For applications that need access to S3, you have the option of running them under the `public-egress` ASG, or running them in the `restricted-egress` ASG, and using a proxy application (e.g., [squid proxy](http://www.squid-cache.org/), [HA proxy](http://www.haproxy.org/), etc.) to proxy traffic to your S3 bucket(s). Reference implementations showing how to do this will be available soon, or you may reach out to the cloud.gov team for support.
 
-To modify the ASG that applies to your space, you can open a support ticket by emailing [support@cloud.gov](mailto:support@cloud.gov) and requesting the addition of a new ASG to apply to your space.
+To inspect or modify the ASG that apply to your spaces, you can use the following cf CLI subcommands. Run `cf <subcommand> --help` to find out more about a specific command, or consult [the cf CLI documentation site](https://cli.cloudfoundry.org/en-US/v6/).
+
+| CF CLI subcommand | Description | 
+| :- | :- |
+| `cf security-group`                         | Show a single security group |
+| `cf security-groups`                        | List all security groups |
+| `cf bind-security-group`                    | Bind a security group to a particular space, or all existing spaces of an org |
+| `cf unbind-security-group`                 | Unbind a security group from a space |
+| `cf bind-staging-security-group`            | Bind a security group to the list of security groups to be used for staging applications globally |
+| `cf staging-security-groups`                | List security groups globally configured for staging applications |
+| `cf unbind-staging-security-group`          | Unbind a security group from the set of security groups for staging applications globally |
+| `cf bind-running-security-group`            | Bind a security group to the list of security groups to be used for running applications |
+| `cf running-security-groups`                | List security groups globally configured for running applications |
+| `cf unbind-running-security-group`          | Unbind a security group from the set of security groups for running applications globally |
+
+If you have additional questions or run into issues, you can open a support ticket by emailing [support@cloud.gov](mailto:support@cloud.gov.


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update the space egress docs to clarify that a user can update space ASG rules that apply using the cf CLI.
- Incorporates the changes in #2080 

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/mheadd-patch-31/docs/management/space-egress/)

## Security Considerations
None
