### PR TITLE
Fixed outdated dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,6 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 gem "html-proofer", "~> 3.10"
 gem "kramdown-parser-gfm"
 
-gem "nokogiri", ">= 1.11.0.rc4"
+gem "nokogiri", ">= 1.13.2"
 
 gem "addressable", ">= 2.8.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,10 +88,10 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.8.0)
     minitest (5.14.1)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.3)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     nokogumbo (2.0.2)
       nokogiri (~> 1.8, >= 1.8.4)
@@ -100,7 +100,7 @@ GEM
       forwardable-extended (~> 2.6)
     posix-spawn (0.3.15)
     public_suffix (4.0.6)
-    racc (1.5.2)
+    racc (1.6.0)
     rack (2.2.3)
     rainbow (3.0.0)
     rb-fsevent (0.10.4)
@@ -139,7 +139,7 @@ DEPENDENCIES
   jekyll-seo-tag
   jekyll-sitemap
   kramdown-parser-gfm
-  nokogiri (>= 1.11.0.rc4)
+  nokogiri (>= 1.13.2)
   sprockets (~> 3.7)
   tzinfo-data
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2109,9 +2109,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
@@ -5975,9 +5975,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mkdirp": {
       "version": "0.5.5",


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update Node and Ruby dependencies.
- Supersedes #2082 
- Supersedes #2072 

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/fix-deps-01)

## Security Considerations
Updates potentially vulnerable dependencies 