### PR TITLE
Fix search form button icon

### DIFF
--- a/_includes/searchgov/form.html
+++ b/_includes/searchgov/form.html
@@ -1,4 +1,4 @@
-{%- comment -%} 
+{%- comment -%}
   This will redirect the results to /search template which will handle the js loading
 {%- endcomment -%}
 
@@ -8,15 +8,17 @@
   {%- else -%}
     <form id="search_form" class="usa-search usa-search--small" action="{{include.searchgov.endpoint}}/search" accept-charset="UTF-8" method="get">
   {%- endif -%}
-    
-  
+
+
     <input name="utf8" type="hidden" value="&#x2713;" />
     <input name="affiliate" type="hidden" value="{{include.searchgov.affiliate}}" />
-  
+
     <div role="search">
       <label class="usa-sr-only" for="extended-search-field-small">Search small</label>
       <input class="usa-input usagov-search-autocomplete" id="extended-search-field-small" type="search" name="query" autocomplete="off">
-      <button class="usa-button" type="submit"><span class="usa-sr-only">Search</span></button>
+      <button class="usa-button" type="submit">
+        {% asset "img/usa-icons-bg/search--white.svg" class="usa-search__submit-icon" alt="Search" %}
+      </button>
     </div>
   </form>
 {%- endif -%}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fix search input's button to show magnifying glass icon

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/apb/fix-search-icon/)

## Security Considerations
None
