### PR TITLE
Clarify private egress page with notice

### DIFF
--- a/_docs/ops/private-egress.md
+++ b/_docs/ops/private-egress.md
@@ -6,6 +6,8 @@ sidenav: true
 title: Private egress
 ---
 
+## NOTICE: We do not currently offer isolation segments or private egress to customers. This document was part of previous exploratory work for this feature, but it was never completed and is no longer on our roadmap.
+
 To provide customers access to services running on their private network, we provision dedicated isolation segments in separate networks that connect to customer networks over VPN.
 
 To set up private egress for an organization:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add notice to private egress page that this is not available for customers

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/apb/clarify-private-egress)


## Security Considerations
None
