### PR TITLE
Update secrets doc

### DIFF
--- a/_docs/ops/secrets.md
+++ b/_docs/ops/secrets.md
@@ -66,7 +66,7 @@ aws-vault add cloud-gov-govcloud
 
 ### Configure MFA for aws-vault
 
-All operators must have MFA enabled, which is taken care of as a part of the platform operator onboarding process.  This can be confirmed by checking in the AWS console under `Services -> IAM -> Users -> firstname.lastname -> Security Credentials`, or in the command line with `aws iam list-virtual-mfa-devices`. 
+All operators must have MFA enabled, which is taken care of as a part of the platform operator onboarding process.  This can be confirmed by checking in the AWS console under `Services -> IAM -> Users -> firstname.lastname -> Security Credentials`.
 
 After confirming that MFA is enabled for your account, run these commands to set command line variables (where `mfa_serial` is the full ARN of your MFA device found in the AWS console):
 

--- a/_docs/ops/secrets.md
+++ b/_docs/ops/secrets.md
@@ -68,10 +68,9 @@ aws-vault add cloud-gov-govcloud
 
 All operators must have MFA enabled, which is taken care of as a part of the platform operator onboarding process.  This can be confirmed by checking in the AWS console under `Services -> IAM -> Users -> firstname.lastname -> Security Credentials`.
 
-After confirming that MFA is enabled for your account, run these commands to set command line variables (where `mfa_serial` is the full ARN of your MFA device found in the AWS console):
+After confirming that MFA is enabled for your account, run this command to set a command line variable for your MFA device identifier (where `mfa_serial` is the full ARN of your MFA device found in the AWS console):
 
 ```sh
-me=firstname.lastname
 mfa_serial=arn:aws:iam::xxxxx:mfa/firstname.lastname
 ```
 

--- a/_docs/ops/secrets.md
+++ b/_docs/ops/secrets.md
@@ -66,11 +66,18 @@ aws-vault add cloud-gov-govcloud
 
 ### Configure MFA for aws-vault
 
-All operators must have MFA enabled, which is taken care of as a part of the platform operator onboarding process.  This can be confirmed by checking in the AWS console under `Services -> IAM -> Users -> firstname.lastname -> Security Credentials`, or in the command line with `aws iam list-virtual-mfa-devices`.  Confirm that MFA is enabled for your account, then use the following commands to add the ARN of the MFA device to the local Amazon configuration in order to enable short lived tokens:
+All operators must have MFA enabled, which is taken care of as a part of the platform operator onboarding process.  This can be confirmed by checking in the AWS console under `Services -> IAM -> Users -> firstname.lastname -> Security Credentials`, or in the command line with `aws iam list-virtual-mfa-devices`. 
+
+After confirming that MFA is enabled for your account, run these commands to set command line variables (where `mfa_serial` is the full ARN of your MFA device found in the AWS console):
 
 ```sh
-me=$(aws iam get-user | jq -r '.User.UserName')
-mfa_serial=$(aws iam list-virtual-mfa-devices | jq --arg me "$me" -r '.VirtualMFADevices[]|select(.User.UserName==$me) | .SerialNumber')
+me=firstname.lastname
+mfa_serial=arn:aws:iam::xxxxx:mfa/firstname.lastname
+```
+
+Then run these commands to set the local Amazon configuration in order to enable short lived tokens (replacing profile name and `region` as appropriate):
+
+```sh
 echo '[profile cloud-gov-govcloud]' >> ~/.aws/config
 echo 'region = us-gov-west-1' >> ~/.aws/config
 echo "mfa_serial = $mfa_serial" >> ~/.aws/config
@@ -85,6 +92,8 @@ aws-vault exec cloud-gov-govcloud bash
 ```
 
 If you do this, running `env | grep AWS` will show you a new set of credentials which are different from the primary IAM role credentials because they are short lived and issued at runtime.  This means that if a malicious script or program attempts to read `~/.aws/credentials` or `~/.aws/config` they will be unable to retrieve the primary credentials.
+
+If you run into issues running `aws` CLI commands, double check that the `region` configured for the profile in your `~/.aws/config` is correct.
 
 ### Next Steps for aws-vault configuration and usage
 

--- a/_docs/ops/secrets.md
+++ b/_docs/ops/secrets.md
@@ -93,7 +93,7 @@ aws-vault exec cloud-gov-govcloud bash
 
 If you do this, running `env | grep AWS` will show you a new set of credentials which are different from the primary IAM role credentials because they are short lived and issued at runtime.  This means that if a malicious script or program attempts to read `~/.aws/credentials` or `~/.aws/config` they will be unable to retrieve the primary credentials.
 
-If you run into issues running `aws` CLI commands, double check that the `region` configured for the profile in your `~/.aws/config` is correct.
+If you run into issues running `aws` CLI commands, double-check that the `region` configured for the profile in your `~/.aws/config` is correct.
 
 ### Next Steps for aws-vault configuration and usage
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Our docs for enabling & configuring aws-vault include example `aws` CLI commands. However, if you are new & onboarding to the team (as I was), then at the point when you are configuring `aws-vault`, you have no ability to run `aws` CLI commands. Thus, there is a chicken & egg problem where the docs suggest running `aws` CLI commands in order to setup `aws-vault`, but you don't have the credentials to run `aws` commands until `aws-vault` is configured.

One **could** temporarily add a secret & access key to `~/.aws/config` in order to setup `aws-vault` as a stop-gap measure, but that seems against the spirit of recommending people to use `aws-vault`. 

Instead, I updated the docs to direct people to the AWS console to get the information they need for setting up `aws-vault`.

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/update-secrets-doc)


## Security Considerations

- No security considerations that I'm aware of
