### PR TITLE
Add automated platform component builds triage

### DIFF
--- a/_docs/ops/maintenance-list.md
+++ b/_docs/ops/maintenance-list.md
@@ -103,6 +103,10 @@ You can also view this information in each of our four environments, `tooling`, 
       experience or confidence in the deployment.  If you're not sure, '3' is a
       good starting point.
 
+## Ensure automated platform builds are successful
+
+The platform's CI builds can be automatically triggered by third-party resources when updates are released (ie. source code, stemcell). Check Concourse for any automated builds that failed, review the logs of the failed build task, and escalate the failure to platform ops if a cursory triage and rebuild does not fix this issue. 
+
 ## Review AWS CloudTrail events
 
 ### Easy way


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add to maintenance checklist to check CI builds passed for platform components that are triggered by third-party resources.

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/apb/maintenance-ci-build-check)


## Security Considerations
None
