### PR TITLE
Fix first deployment docs

### DIFF
--- a/_docs/getting-started/your-first-deploy.md
+++ b/_docs/getting-started/your-first-deploy.md
@@ -53,7 +53,7 @@ cf target -o sandbox-gsa -s harry.truman
     ```sh
     cf push APPNAME
     ```
-1. You'll see a series of messages noting the stages of creating the app. When complete, it'll say "App started" and give information about your app. Use the `urls` line (`urls: [ROUTENAME].app.cloud.gov`) to visit your app on the web.
+1. You'll see a series of messages noting the stages of creating the app. When complete, it'll say "App started" and give information about your app. Use the `routes` line (`routes: [ROUTENAME].app.cloud.gov`) to visit your app on the web.
 1. Try editing the app locally (without committing) and run `cf push <APPNAME>` again to see your changes. The changes will be reflected even without being committed to Git. cloud.gov is not Git-aware – it simply deploys whatever is contained in the directory that you `push` from. You can set up [continuous deployment]({{ site.baseurl }}{% link _docs/management/continuous-deployment.md %}) from a Git repository.
 1. Visit the dashboard ([`https://dashboard.fr.cloud.gov/`](https://dashboard.fr.cloud.gov/)) to see your options for managing your application via your browser.
 1. If you're done, you can delete your app by running `cf delete <APPNAME>` (it's up to you whether to keep it running for more experiments or delete it).


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update docs for getting app URL on first deployment

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/fix-first-deploy-docs)


## Security Considerations

None
