### PR TITLE
Remind people to replace the BRANCH_NAME in PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 -
 -
 
+<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
 :sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)
 
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add an explicit instruction to ensure the Federalist preview URL gets edited.

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/pr-reminder)


## Security Considerations
None, this is just comment text that appears when editing Markdown.