### PR TITLE
Fix link scanning for Google Analytics

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,4 +1,4 @@
-# General URLs/patterns to ignore 
+# General URLs/patterns to ignore
 localhost
 s3://
 .*\.cloud\.gov
@@ -13,6 +13,9 @@ https://s3-\$\{(AWS_DEFAULT_REGION|aws_default_region)\}.amazonaws.com/
 http://\$\{(bucket_name|BUCKET_NAME)\}.s3-website-\$\{(AWS_DEFAULT_REGION|aws_default_region)\}.amazonaws.com/
 https://username:password
 192\.0\.2\.[0-9]{1,3}
+.*document.location.protocol\s\?\s'https://ssl'\s:\s'http://www'
+^https://ssl.?$
+^http://www.?$
 
 # URLs with no known replacements
 https://fugacious.18f.gov/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -13,7 +13,6 @@ https://s3-\$\{(AWS_DEFAULT_REGION|aws_default_region)\}.amazonaws.com/
 http://\$\{(bucket_name|BUCKET_NAME)\}.s3-website-\$\{(AWS_DEFAULT_REGION|aws_default_region)\}.amazonaws.com/
 https://username:password
 192\.0\.2\.[0-9]{1,3}
-.*document.location.protocol\s\?\s'https://ssl'\s:\s'http://www'
 ^https://ssl.?$
 ^http://www.?$
 


### PR DESCRIPTION
## Changes proposed in this pull request:
 
Add ignore for URLs detected from Google Analytics source code, such as:

```
ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
```

This issue was causing periodic link scanning failures for websites with Google Analytics enabled, such as: https://docs.cloudfoundry.org/devguide/deploy-apps/app-lifecycle.html#crash-events.

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/fix-link-scanning-forGA)


## Security Considerations

None
