### PR TITLE
Add structure for new release notes

### DIFF
--- a/_posts/2022-05-26-release-notes.md
+++ b/_posts/2022-05-26-release-notes.md
@@ -11,4 +11,17 @@ Happy end of May! The cloud.gov team is working on providing change logs so ever
 
 ## Customer Facing
 
+* The Drupal 8 example was brought back into a working state.
+  * [Github Repo](https://github.com/cloud-gov/cf-ex-drupal8)
+* The names and descriptions of the database plans offerings were improved.
+  * Checkout the offerings in the [dashboard marketplace](https://dashboard.fr.cloud.gov/marketplace/2oBn9LBurIXUNpfmtZCQTCHnxUM/dcfb1d43-f22c-42d3-962c-7ae04eda24e7/plans)
+  * [Github Issue](https://github.com/cloud-gov/aws-broker/issues/199)
+
 ## Platform Changes
+
+* BPM - 1.1.18 up from 1.1.17
+* Clamav - 31 up from 30
+* Secureproxy - 56 up from 53
+* Syslog - 11.7.10 up from 11.7.9
+* Snort - 574 up from 573
+* UAA - 75.20.0 up from 75.19.0

--- a/_posts/2022-05-26-release-notes.md
+++ b/_posts/2022-05-26-release-notes.md
@@ -1,0 +1,14 @@
+---
+layout: post
+date: May 26th 2022
+title: "May 26th cloud.gov Change Log"
+excerpt: The cloud.gov team is working on providing change logs so everyone can see new features and updates.
+---
+
+Happy May! The cloud.gov team is working on providing change logs so everyone can see new features and updates. Highlights this time include new stemcells.
+
+# Change Log
+
+## Customer Facing
+
+## Platform Changes

--- a/_posts/2022-05-26-release-notes.md
+++ b/_posts/2022-05-26-release-notes.md
@@ -5,7 +5,7 @@ title: "May 26th cloud.gov Change Log"
 excerpt: The cloud.gov team is working on providing change logs so everyone can see new features and updates.
 ---
 
-Happy May! The cloud.gov team is working on providing change logs so everyone can see new features and updates. Highlights this time include new stemcells.
+Happy end of May! The cloud.gov team is working on providing change logs so everyone can see new features and updates. Highlights this time include new stemcells.
 
 # Change Log
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add new release notes for 5-26-2022

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/5-26-2022-release-notes)

## Security Considerations
None
