### PR TITLE
Correct a link to the Cloud.gov diagrams repo.

### DIFF
--- a/_docs/ops/repos.md
+++ b/_docs/ops/repos.md
@@ -32,7 +32,7 @@ Components run as applications on top of the platform, for users:
 
 Components run as applications on top of the platform, for our team:
 
-- [Compliance documentation system diagrams](https://github.com/cloud-gov/cg-diagramss)
+- [Compliance documentation system diagrams](https://github.com/cloud-gov/cg-diagrams)
 
 Custom components for our Cloud Foundry deployment:
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Correction to a link in the "Code repositories" document -- removed trailing "s". 
 

## Security Considerations
None -- just corrected a broken link. 