### PR TITLE
Correct a link to the cloud.gov diagrams repo

### DIFF
--- a/_docs/ops/repos.md
+++ b/_docs/ops/repos.md
@@ -32,7 +32,7 @@ Components run as applications on top of the platform, for users:
 
 Components run as applications on top of the platform, for our team:
 
-- [Compliance documentation system diagrams](https://github.com/cloud-gov/cg-diagramss)
+- [Compliance documentation system diagrams](https://github.com/cloud-gov/cg-diagrams)
 
 Custom components for our Cloud Foundry deployment:
 


### PR DESCRIPTION
Correction to a link in the "Code repositories" document -- removed trailing "s".

## Changes proposed in this pull request:
- Correction to a link in the "Code repositories" document -- removed trailing "s".
- Supersedes #2143 

:sunglasses: [PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/mheadd-patch-37)

## Security Considerations
None
