### PR TITLE
add large file handling guidelines to pages docs

### DIFF
--- a/_data/pages/navigation.yml
+++ b/_data/pages/navigation.yml
@@ -103,6 +103,8 @@ sidenav:
         href: /pages/documentation/bundler-on-pages/
       - text: Supported site engines
         href: /pages/documentation/supported-site-engines/
+      - text: Large file handling
+        href: /pages/documentation/large-file-handling/
       - text: Renaming your site's repository
         href: /pages/documentation/renaming-site-repository/
       - text: Monorepos on Pages

--- a/_pages/pages/documentation/large-file-handling.md
+++ b/_pages/pages/documentation/large-file-handling.md
@@ -1,0 +1,35 @@
+---
+title: Large File Handling
+permalink: /pages/documentation/large-file-handling/
+layout: docs
+navigation: pages
+sidenav: pages-documentation
+
+---
+
+There are a few guidelines and restrictions to be aware of when dealing with large files, or a large number of files.
+
+## General Guidelines
+
+Due to restrictions imposed by Github and cloud.gov, as well as the internal infrastructure of Federalist, sometimes builds fail when running out of disk space. This usually shows up as an error in build logs like `"Disk quota exceeded"` or `"No space left on device"`. The Federalist team is looking into longer-term upgrades to help ease these restrictions. In the meantime, here are a few general rules and tips:
+- Regular build container provide 2GB of total user space. Because dependencies like those included in your `Gemfile` or `package.json` will be installed here, it's a good rule of thumb to keep your total Github repository size under 1GB.
+  - You can minimize your dependency size by removing development dependencies from `package.json` and using using [`npx`](https://www.npmjs.com/package/npx) to call development scripts.
+  - You can also minimize your total build size by optimizing images and compressing files that are intended for download.
+- If your site starts hitting this initial limit, you can request an upgrade to 4GB of user space. Send an email to [federalist-support@gsa.gov](mailto:federalist-support@gsa.gov).
+- If your site is going over both of these limits, one temporary workaround is to create a new site just to store certain large assets like images, PDFs, or slide decks. For example, you could host large reports in a separate repository which deploys to `reports.example.gov` and then link to these assets from your primary site.
+
+## Details
+
+### Federalist Build Containers
+
+Federalist offer two sizes of build containers ("regular": 4GB and "large": 6GB). The maximum size is limited by the size of containers available on [cloud.gov](https://cloud.gov). The first 2GB of each container is taken up by dependencies installed by Federalist (Ruby, Node, Python, and additional packages for each) leaving either 2GB or 4GB for the user space.
+
+### Github
+
+Github is not intended to store large files or a large number of files. There are caps on the size on an individual file and the total size of a single repository:
+- Individual file size: 100MB<sup>*</sup>
+- Single repository size: Recommended to keep below 1GB
+
+More details can be found [on their website](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github).
+
+_*[Git LFS](https://git-lfs.github.com/) can support larger file storage but currently does not integrate with the Federalist build process_

--- a/_pages/pages/documentation/large-file-handling.md
+++ b/_pages/pages/documentation/large-file-handling.md
@@ -32,4 +32,4 @@ Github is not intended to store large files or a large number of files. There ar
 
 More details can be found [on their website](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github).
 
-_*[Git LFS](https://git-lfs.github.com/) can support larger file storage but currently does not integrate with the Federalist build process_
+_*[Git LFS](https://git-lfs.github.com/) can support larger file storage but currently does not integrate with the Pages build process_

--- a/_pages/pages/documentation/large-file-handling.md
+++ b/_pages/pages/documentation/large-file-handling.md
@@ -11,7 +11,7 @@ There are a few guidelines and restrictions to be aware of when dealing with lar
 
 ## General Guidelines
 
-Due to restrictions imposed by Github and cloud.gov, as well as the internal infrastructure of Federalist, sometimes builds fail when running out of disk space. This usually shows up as an error in build logs like `"Disk quota exceeded"` or `"No space left on device"`. The Federalist team is looking into longer-term upgrades to help ease these restrictions. In the meantime, here are a few general rules and tips:
+Due to restrictions imposed by Github and cloud.gov, as well as the internal infrastructure of Pages, sometimes builds fail when running out of disk space. This usually shows up as an error in build logs like `"Disk quota exceeded"` or `"No space left on device"`. The Pages team is looking into longer-term upgrades to help ease these restrictions. In the meantime, here are a few general rules and tips:
 - Regular build container provide 2GB of total user space. Because dependencies like those included in your `Gemfile` or `package.json` will be installed here, it's a good rule of thumb to keep your total Github repository size under 1GB.
   - You can minimize your dependency size by removing development dependencies from `package.json` and using using [`npx`](https://www.npmjs.com/package/npx) to call development scripts.
   - You can also minimize your total build size by optimizing images and compressing files that are intended for download.

--- a/_pages/pages/documentation/large-file-handling.md
+++ b/_pages/pages/documentation/large-file-handling.md
@@ -22,7 +22,7 @@ Due to restrictions imposed by Github and cloud.gov, as well as the internal inf
 
 ### Pages Build Containers
 
-Federalist offer two sizes of build containers ("regular": 4GB and "large": 6GB). The maximum size is limited by the size of containers available on [cloud.gov](https://cloud.gov). The first 2GB of each container is taken up by dependencies installed by Federalist (Ruby, Node, Python, and additional packages for each) leaving either 2GB or 4GB for the user space.
+Pages offer two sizes of build containers ("regular": 4GB and "large": 6GB). The maximum size is limited by the size of containers available on [cloud.gov](https://cloud.gov). The first 2GB of each container is taken up by dependencies installed by Pages (Ruby, Node, Python, and additional packages for each) leaving either 2GB or 4GB for the user space.
 
 ### Github
 

--- a/_pages/pages/documentation/large-file-handling.md
+++ b/_pages/pages/documentation/large-file-handling.md
@@ -20,7 +20,7 @@ Due to restrictions imposed by Github and cloud.gov, as well as the internal inf
 
 ## Details
 
-### Federalist Build Containers
+### Pages Build Containers
 
 Federalist offer two sizes of build containers ("regular": 4GB and "large": 6GB). The maximum size is limited by the size of containers available on [cloud.gov](https://cloud.gov). The first 2GB of each container is taken up by dependencies installed by Federalist (Ruby, Node, Python, and additional packages for each) leaving either 2GB or 4GB for the user space.
 

--- a/_pages/pages/documentation/large-file-handling.md
+++ b/_pages/pages/documentation/large-file-handling.md
@@ -15,7 +15,7 @@ Due to restrictions imposed by Github and cloud.gov, as well as the internal inf
 - Regular build container provide 2GB of total user space. Because dependencies like those included in your `Gemfile` or `package.json` will be installed here, it's a good rule of thumb to keep your total Github repository size under 1GB.
   - You can minimize your dependency size by removing development dependencies from `package.json` and using using [`npx`](https://www.npmjs.com/package/npx) to call development scripts.
   - You can also minimize your total build size by optimizing images and compressing files that are intended for download.
-- If your site starts hitting this initial limit, you can request an upgrade to 4GB of user space. Send an email to [federalist-support@gsa.gov](mailto:federalist-support@gsa.gov).
+- If your site starts hitting this initial limit, you can request an upgrade to 4GB of user space. Send an email to [pages-support@cloud.gov](mailto:pages-support@cloud.gov).
 - If your site is going over both of these limits, one temporary workaround is to create a new site just to store certain large assets like images, PDFs, or slide decks. For example, you could host large reports in a separate repository which deploys to `reports.example.gov` and then link to these assets from your primary site.
 
 ## Details

--- a/_pages/pages/documentation/migration-guide.md
+++ b/_pages/pages/documentation/migration-guide.md
@@ -67,5 +67,4 @@ You are able to start working while IAA is being signed.
 
 ## Additional info
 
-If your site has over 1 GB of images to serve you should look into another way to store those files. Github is not intended to store large amounts of files.
-- Github has no problem storing less than 1GB of different files types. For hosting over 1GB of files, we suggest getting access to a public database service that will load the files. One provider of this type of service is [cloud.gov]({{ site.baseurl }}/). More information on repository size limitations is available [here](https://help.github.com/articles/what-is-my-disk-quota/).
+If your site has over 1 GB of files to serve you should look into another way to store those files. Github is not intended to store large amounts of files. More details are available in the [large file handling guide](/pages/documentation/large-file-handling/).


### PR DESCRIPTION
## Changes proposed in this pull request:
- add large file handling guidelines to pages docs

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/ddb-large-file-handling)


## Security Considerations
None (documentation change)
