### PR TITLE
update docs on maintenance/support

### DIFF
--- a/_docs/ops/customer-support.md
+++ b/_docs/ops/customer-support.md
@@ -6,79 +6,77 @@ sidenav: true
 title: Ongoing customer support
 ---
 
-The platform requires regular support and maintenance activities to remain in a
-compliant state. If you are on support and you can’t complete any of the items
-personally, you are responsible for ensuring that an appropriate person does it.
-If you haven't already reached out on Slack, reach out during standup to get
-visibility with the people who might best help.
+Platform operators are scheduled for regular 2-week rotations to provide customer support. This document outlines the customer support process and responsibilities.
 
 ## Are you new to platform support?
+{:.no_toc}
 
 - Join/unmute [`#cg-support`](https://gsa-tts.slack.com/messages/cg-support/)
-- Ensure you are added to the `Platform experts` group in Zendesk, and that the person you are replacing on support is removed.
+- Join [`#cg-supportstream`](https://gsa-tts.slack.com/messages/cg-supportstream/) to get notifications on Slack for Zendesk tickets
 
-## Support Rotations
+## Support rotation checklist
+{:.no_toc}
 
-cloud.gov utilizes a tiered support model, with `Tier 1` handling frequently requested support issues that do not require the assistance of a platform engineer. `Tier 1` support personnel can escalate an issue to the `Platform experts` group when more intensive assistance is required to resolve a support issue.
+On the first day of a support rotation:
 
-The cloud.gov team utilizes a staggered pair rotation for the `Platform experts` group. Support assignments for this group last two weeks. One team member exits support duty each week, with a new member starting their two-week rotation. With the other support team member in the middle of their two-week rotation, we ensure continuity of situational awareness, task handoffs, and work in progress.
+- Update the [`#cg-support`](https://gsa-tts.slack.com/messages/cg-support/) Slack channel topic to include your name as the support contact.
 
-The support team is not required to "pair" in the traditional sense unless the task as hand necessitates doing so. Having multiple platform engineers rather than a single person on support allows us to better serve our customers by:
+Every day on a support rotation:
 
-- Improving  situational awareness and communication through necessary, regular check-ins
-- Increasing debugging capabilities and problem-solving capacity (cloud.gov is a vast system to reason over, and more minds are better than one)
-- Providing a higher likelihood of coverage during planned or unplanned absences
-- Allowing for multiple tasks to be worked at once
+- table of contents
+{:toc}
 
-As the `Platform experts` group has free cycles, they can pick up tasks from the backlog designated with the `support-team` label. These tasks aim to improve our ability to support the platform by paying down technical debt, adding automation, improving monitoring and alerting, or adding to system documentation such as run-books. Because support team members inevitably face interruptions that cause context switching, the `support-team` backlog is groomed by the team with this in mind. These stories are not mission-critical, easy to pick up, and easy to hand off to another team member.
+## Handle support requests in Zendesk
 
-All members of the support team should also monitor requests for support in Zendesk (and other channels) to identify commonly asked questions or frequently requested issues. These topics should be added to [new or existing knowledge base articles]({{ site.baseurl }}/knowledge-base) to make answering these requests more efficient going forward.
+Most customers submit questions by emailing [support@cloud.gov](mailto:support@cloud.gov), which creates a ticket in our Zendesk instance.
 
-## Zendesk Support Process
+The support process for handling tickets created in Zendesk is:
 
-1. All support requests should be answered within Zendesk. Avoid responding via
-   Google Groups or email, since it will distort our metrics.
-1. All new requests for support are assigned by default to the `Tier 1` support group, and are escalated 
-   to the `Platform experts` group as needed.
-1. There are two people designated to the `Platform experts` group every week. Each week,
-   one person is swapped for another to ensure that there is overlapping
-   context awareness.
-1. At the start of the week, the entire support team should schedule a 15 min meeting
-   to review unresolved issues from the previous week.
-1. Every day, the support team should set up a brief meeting to review and
-   assign New and Open issues. If they like, they can cowork or just assign
-   themselves issues.
-1. For specialized tickets, like security and compliance, the support team can
-   assign tasks to other team members, but they will need to follow up and make
-   sure the status of the ticket is accurate.
-1. Before the day is over, the support team will ensure that all New issues are
-   acknowledged and set to Open or Pending (more details below).
-1. Everyone currently on support should join #cg-supportstream to get notifications on Slack. This
-   can be useful to alert and coordinate with other team members.
-1. Commonly asked questions or frequently requested items should be considered for 
-   adding to the [cloud.gov knowledge base]({{ site.baseurl }}/knowledge-base).
+- All support requests should be answered within Zendesk. Avoid responding via Google Groups or email, since it will distort our metrics.
+- `Tier 1` support has primary responsibility to do the work of responding to Zendesk tickets, and
+`Platform experts` serve as second-tier support providing technical expertise.
+- If `Tier 1` support personnel need assistance in responding to a customer issue, they will escalate the ticket to the `Platform experts` group in Zendesk. The main responsibility of the platform operator on support is to provide technical diagnoses/advice/details where needed. The most efficient way to do that is to write comments on the
+associated posts in [`#cg-supportstream`](https://gsa-tts.slack.com/messages/cg-supportstream).
+- `Tier 1` support may also ask for pairing time to work out responses
+together.
+- Before the day is over, the support team will ensure that all New issues are acknowledged and set to [Open or Pending](#support-status).
+
+If you are on support and you can’t complete any of the items personally, **you are responsible for ensuring that an appropriate person does it**. If you haven't already reached out on Slack, reach out during standup to get visibility with the people who might best help.
+
+For specialized tickets, like security and compliance, the support team can assign tasks to other team members, but they will need to follow up and make sure the status of the ticket is accurate.
+
+See also: [Detailed guidance on working with our support tools](https://docs.google.com/document/d/1QXZvcUl-6gtI7jEQObXV9FyiIpJC-Fx1R7RzB0C6PHM/edit#heading=h.80zn694rriw3).
+
+## Monitor \#cg-support
+
+Some customers have access to post questions in the `#cg-support` channel. As with Zendesk support requests, `Tier 1` support operators will be primarily responsible for answering these questions and can escalate to the platform operator on support as necessary.
+
+## Update documentation
+
+Platform operators on the support rotation should monitor requests for support in Zendesk (and other channels) to identify commonly asked questions or frequently requested issues. These topics should be added to [new or existing knowledge base articles]({{ site.baseurl }}/knowledge-base) to make answering these requests more efficient going forward.
 
 ## Support Status
+{:.no_toc}
 
-### New
+**New**
 
 We've not responded. The support team will coordinate on a response to the customer before the
 end of day (5:00 PM local time). If we do not know the answer, we let the customer
 know that we’ll get back to them within 24-48hrs.
 
-### Open
+**Open**
 
 We’ve assigned the ticket but we’ve not responded, or the customer has
 responded, and the ticket is waiting on our input. We will use this status if, for
 example, we require additional research. Open status should not last more than a day
 and we should let the customer know if we need more time.
 
-### Pending
+**Pending**
 
 We've responded to the ticket and may get a follow up response. If there is no further
 activity, the issue auto-closes in 5 days. A ticket can move back to Open for a
 day if a response from the customer requires additional research.
 
-### Solved
+**Solved**
 
 We've responded in a manner that does not expect a response from the customer.

--- a/_docs/ops/maintenance-list.md
+++ b/_docs/ops/maintenance-list.md
@@ -45,7 +45,7 @@ that cards to fix alerts are prioritized properly.
 
 ## Provide support backup
 
-As necessary and requested, provide assistance to the platform operator on a [support rotation](({{ site.baseurl }}/docs/ops/customer-support)) concurrent to your maintenance rotation.
+As necessary and requested, provide assistance to the platform operator on a [support rotation]({{ site.baseurl }}/docs/ops/customer-support) concurrent to your maintenance rotation.
 
 ## Review expiring certificates
 

--- a/_docs/ops/maintenance-list.md
+++ b/_docs/ops/maintenance-list.md
@@ -7,10 +7,11 @@ title: Ongoing platform maintenance
 ---
 
 
+
 ## Daily maintenance checklist
 {:.no_toc}
 
-The tasks on this checklist should be performed each day by the members of the `Platform experts` group currently on support rotation.
+The tasks on this checklist should be performed each day by the platform operator who is currently on the maintenance rotation.
 
 - table of contents
 {:toc}
@@ -42,18 +43,9 @@ exists for tuning the alert.
 Be prepared to represent support needs at the next grooming meeting to ensure
 that cards to fix alerts are prioritized properly.
 
-## Review open support requests
+## Provide support backup
 
-- Review the New (yellow) and Open (red) Zendesk tickets.
-- `Tier 1` support has primary responsibility to do the work of answering these, and
-you serve as second-tier support providing technical expertise.
-- If `Tier 1` support personnel need assistance in responding to a customer issue, they will escalate the ticket to the `Platform experts` group in Zendesk. Your main responsibility is to provide technical
-diagnoses/advice/details where needed. The most efficient way to do that is to write comments on the
-associated posts in [`#cg-supportstream`](https://gsa-tts.slack.com/messages/cg-supportstream).
-- `Tier 1` support may also ask you for pairing time to work out responses
-together.
 
-See also: [Detailed guidance on working with our support tools](https://docs.google.com/document/d/1QXZvcUl-6gtI7jEQObXV9FyiIpJC-Fx1R7RzB0C6PHM/edit#heading=h.80zn694rriw3).
 
 ## Review expiring certificates
 

--- a/_docs/ops/maintenance-list.md
+++ b/_docs/ops/maintenance-list.md
@@ -8,30 +8,32 @@ title: Ongoing platform maintenance
 
 
 ## Daily maintenance checklist
+{:.no_toc}
 
 The tasks on this checklist should be performed each day by the members of the `Platform experts` group currently on support rotation.
 
-### PR as you go
+- table of contents
+{:toc}
 
-If you see a way to make this checklist better, just submit a PR to the
-[cg-site](https://github.com/cloud-gov/cg-site) repo for `content/docs/ops/maintenance-list.md`
-
-### Review and respond to alerts
+## Review and respond to alerts
 
 Review all alerts on [Prometheus](https://prometheus.fr.cloud.gov/alerts) (requires the VPN).
 
-#### Investigate open alerts
+## Investigate open alerts
+
 - Use our guides for reviewing cloud.gov alerts ([prometheus](https://github.com/cloud-gov/cg-deploy-prometheus/tree/master/bosh) for alert descriptions, links to the relevant rules, and starting points for reviewing each type of alert.
 - Was the alert caused by known maintenance or testing in dev environments? Check with other members of the cloud.gov team if you can't determine the source.
 - Is this a recurring alert? Search alert history to determine how frequently it is occuring and what event may have started its firing.
 - Should the underlying condition have caused an alert? Alerts should only be raised when they're something we need to remediate.
 
-#### Is the alert a real issue?
+### Is the alert a real issue?
+
 If the alert may indicate a security issue follow the
 [Security Incident Response Guide]({{ site.baseurl }}/docs/ops/security-ir)
 , otherwise work to remediate its cause.
 
-#### Is the alert a false-positive?
+### Is the alert a false-positive?
+
 If the alert can be tuned to reduce the number of false-positives with less than
 two hours of work, do it.  If more work is required to tune the alert, add a card
 to capture the work that needs to be done or +1 an existing card if one already
@@ -42,24 +44,16 @@ that cards to fix alerts are prioritized properly.
 
 ## Review open support requests
 
-* Review the New (yellow) and Open (red) Zendesk tickets. 
-* `Tier 1` support has primary responsibility to do the work of answering these, and
-you serve as second-tier support providing technical expertise. 
-* If `Tier 1` support personnel need assistance in responding to a customer issue, they will escalate the ticket to the `Platform experts` group in Zendesk. Your main responsibility is to provide technical
+- Review the New (yellow) and Open (red) Zendesk tickets.
+- `Tier 1` support has primary responsibility to do the work of answering these, and
+you serve as second-tier support providing technical expertise.
+- If `Tier 1` support personnel need assistance in responding to a customer issue, they will escalate the ticket to the `Platform experts` group in Zendesk. Your main responsibility is to provide technical
 diagnoses/advice/details where needed. The most efficient way to do that is to write comments on the
 associated posts in [`#cg-supportstream`](https://gsa-tts.slack.com/messages/cg-supportstream).
-* `Tier 1` support may also ask you for pairing time to work out responses
+- `Tier 1` support may also ask you for pairing time to work out responses
 together.
 
 See also: [Detailed guidance on working with our support tools](https://docs.google.com/document/d/1QXZvcUl-6gtI7jEQObXV9FyiIpJC-Fx1R7RzB0C6PHM/edit#heading=h.80zn694rriw3).
-
-## Support rotation
-
-Review the [detailed guide on customer support]({{site.baseurl}}/docs/ops/customer-support).
-
-## Weekly support tasks
-
-Update the [`#cg-support`](https://gsa-tts.slack.com/messages/cg-support/) topic to include your name as the support contact.
 
 ## Review expiring certificates
 
@@ -70,7 +64,7 @@ You can also view this information in each of our four environments, `tooling`, 
 
 ## Ensure all VMs are running the current stemcell
 
-- Lookup the most recent published stemcell version at: https://bosh.cloudfoundry.org/stemcells/
+- Lookup the most recent published stemcell version at: <https://bosh.cloudfoundry.org/stemcells/>
 
 - From the jumpbox in each of our four environments, `tooling`, `development`,
   `staging` and `production`, run `bosh deployments` and verify the stemcell in
@@ -101,9 +95,9 @@ You can also view this information in each of our four environments, `tooling`, 
       experience or confidence in the deployment.  If you're not sure, '3' is a
       good starting point.
 
-## Ensure automated platform builds are successful
+## Monitor automated platform builds
 
-The platform's CI builds can be automatically triggered by third-party resources when updates are released (ie. source code, stemcell). Check Concourse for any automated builds that failed, review the logs of the failed build task, and escalate the failure to platform ops if a cursory triage and rebuild does not fix this issue. 
+The platform's CI builds can be automatically triggered by third-party resources when updates are released (ie. source code, stemcell). Monitor the `#cg-platform` and `#cg-platform-news` Slack channels for notifications about any failed builds. For any automated builds that failed, review the logs of the failed build task in Concourse, and escalate the failure to platform ops if a cursory triage and rebuild does not fix this issue.
 
 ## Review AWS CloudTrail events
 
@@ -113,19 +107,21 @@ Run [cloud-trail-check.sh](https://github.com/cloud-gov/cg-scripts/blob/master/c
 and review the output
 
 ### Hard way
+
 > [Get familiar with the documentation for CloudTrail logs](http://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html).
 
 Use the [AWS Console](http://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-console.html)
 to [review API activity history](http://docs.aws.amazon.com/awscloudtrail/latest/userguide/view-cloudtrail-events-console.html)
 for the _EventNames_ listed below.
 Or, use the AWS CLI with the appropriate `$event_name`, and parse the emitted JSON:
+
 ```sh
 aws cloudtrail lookup-events --lookup-attributes AttributeKey=EventName,AttributeValue=$event_name
 ```
 
 These `EventNames` should be attributed to human individuals on the cloud.gov team:
 
-* ConsoleLogin
+- ConsoleLogin
 
 All human-generated events should be mapped to named users, e.g. `firstname.lastname`, and NOT to `Administrator`.
 Discuss the event(s) with the indicated [cloud.gov operator(s)](https://docs.google.com/spreadsheets/d/1mW3tphZ98ExmMxLHPogSpTq8DzYr5Oh8_SHnOTvjRWM/edit)
@@ -146,9 +142,9 @@ All events in the following `EventNames` should be attributed to Terraform:
 
 Terraform runs on instances that use instance profile roles, so authorized events will include:
 
-* a user name like `i-17deadbeef1234567`
-* a source IP address within AWS.
-* an AWS access key starting with `ASIA`
+- a user name like `i-17deadbeef1234567`
+- a source IP address within AWS.
+- an AWS access key starting with `ASIA`
 
 If you observe any non-Terraform activity, discuss the event(s) with the
 indicated cloud.gov operator(s) (see above)
@@ -157,6 +153,7 @@ If you're unable to ascertain an event was authorized, follow the
 [Security Incident Response Guide]({{site.baseurl}}/docs/ops/security-ir).
 
 ## Review vulnerability and compliance reports
+
 - [Nessus Vulnerability Reports](https://nessus.fr.cloud.gov/)
 - [Nessus Compliance Reports](https://nessus.fr.cloud.gov/)
 - [CloudFoundry Alerts](https://www.cloudfoundry.org/category/security/)
@@ -165,19 +162,27 @@ If you're unable to ascertain an event was authorized, follow the
 If the reports contain any HIGH items work to remediate them.
 
 ### Is an update from our IaaS provider required to remediate?
+
 Open a case with the IaaS provider and monitor the case until it has been
 resolved.
 
 ### Is a stemcell update required to remediate?
+
 Ask for a date when new stemcells will be delivered in #security in the
 [CF Slack](https://cloudfoundry.slack.com/).
 
 ### Is a bosh release update required to remediate?
+
 Update the bosh release and file a PR for the changes.  Once the PR is merged,
 ensure the updated release is deployed to all required VMs.
 
+## PR as you go
+
+If you see a way to make this checklist better, just submit a PR to the
+[cg-site](https://github.com/cloud-gov/cg-site) repo for `content/docs/ops/maintenance-list.md`
+
 ---
 
-### Page information
+## Page information
 
 To view modifications to this page, review the [git commit history](https://github.com/cloud-gov/cg-site/commits/master/_docs/ops/maintenance-list.md).

--- a/_docs/ops/maintenance-list.md
+++ b/_docs/ops/maintenance-list.md
@@ -45,7 +45,7 @@ that cards to fix alerts are prioritized properly.
 
 ## Provide support backup
 
-
+As necessary and requested, provide assistance to the platform operator on a [support rotation](({{ site.baseurl }}/docs/ops/customer-support)) concurrent to your maintenance rotation.
 
 ## Review expiring certificates
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- update docs on maintenance/support to reflect separate maintenance/support rotations and responsibilities

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/update-maintenance-support-docs)

The easiest way to review the changes made by the PR is to view them in the Pages site build preview:

https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/update-maintenance-support-docs/docs/ops/customer-support/
https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/update-maintenance-support-docs/docs/ops/maintenance-list/

## Security Considerations

None
