### PR TITLE
add pages application link, remove select anchor

### DIFF
--- a/_assets/js/app.js
+++ b/_assets/js/app.js
@@ -10,8 +10,8 @@ var sideNavChild = document.querySelectorAll(".usa-sidenav__sublist--middle-gene
 var subLists = document.querySelectorAll("ul.usa-sidenav__sublist");
 var middleSubList = document.querySelectorAll(".usa-sidenav__sublist ul");
 
-anchors.add('h2');
-anchors.add('h3');
+anchors.add('h2').remove('.no-anchor');
+anchors.add('h3').remove('.no-anchor');
 
 
 function openCurrentSubNav(self){

--- a/_pages/pages/federalist-migration.md
+++ b/_pages/pages/federalist-migration.md
@@ -12,9 +12,9 @@ title: cloud.gov Pages - Federalist Migration
         <p class="usa-intro">Pages offers the same great services provided to you with your current Federalist agreement, with a new name and new features coming soon.</p>
       </div>
       <div class="tablet:grid-col-4 usa-section--dark margin-top-8">
-        <h2>Interested in being an early Pages adopter?</h2>
-        <p class="usa-intro">Contact us for help on the migration process</p>
-        <p><a class="usa-button usa-button--big" href="mailto:inquiries@cloud.gov"> Get in touch</a></p>
+        <h2 class="no-anchor">Interested in being an early Pages adopter?</h2>
+        <p class="usa-intro">The new application is live now!</p>
+        <p><a class="usa-button usa-button--big" href="https://pages.cloud.gov"> Try it out</a></p>
       </div>
     </div>
 </section>


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add link to Pages application on the migration page
- Towards #2184
- Doesn't make header changes but should help in the short-term

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/ddb-pages-application-link)


## Security Considerations
None
