### PR TITLE
add article on fixing certificate errors 

### DIFF
--- a/_kbarticles/2022-11-04-fixing-certificate-errors-aws-egress-proxy.md
+++ b/_kbarticles/2022-11-04-fixing-certificate-errors-aws-egress-proxy.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title: "Fixing certificate validation errors from AWS CLI when using the cg-egress-proxy"
+date: November 4, 2022
+excerpt: How to fix certificate errors if you are using the AWS CLI from an application protected by the cg-egress-proxy
+---
+
+If you are using the [`cg-egress-proxy`](https://github.com/GSA/cg-egress-proxy) to restrict the egress traffic for your application, you may experience certificate validation errors which prevent you from [interacting with brokered AWS services using the CLI](https://cloud.gov/docs/services/s3/#interacting-with-your-s3-bucket-from-outside-cloudgov).
+
+The cause of the issue is that AWS CLI is overriding certificates that cloud.gov provides and preventing the AWS CLI from being able to validate TLS connections, thus causing CLI commands to fail.
+
+To force the AWS CLI to use the system CA cert stores, you can add this environment variable:
+
+```shell
+AWS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+```
+
+Environment variables can be set for your application either by using a [manifest](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#env-block) or the [`cf set-env` CLI command](https://cli.cloudfoundry.org/en-US/v7/set-env.html).

--- a/_pages/pages/documentation/supported-site-engines.md
+++ b/_pages/pages/documentation/supported-site-engines.md
@@ -61,7 +61,7 @@ To instruct search engines not to index the `preview` builds of your site, try a
 {% endraw %}
 ***Note:*** This code sample assumes the live version of your site's code is maintained in the `main` branch of your site's code repository.
 
-For all versions of your site that aren't built from `main`, the source code of the site will contain the code above. For an example, see [here](https://federalist-proxy.app.cloud.gov/preview/18f/federalist-docs/wslack-patch-1/), view source, and jump to line 57.
+For all versions of your site that aren't built from `main`, the source code of the site will contain the code above.
 
 ### Jekyll Plugins
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- add article on fixing certificate errors when using AWS CLI and egress proxy
-
-

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/kb-article-fixing-certificate-errors-aws-egress-proxy)


## Security Considerations

None, just updating documentation
