### PR TITLE
Remove obsolete sections, reorg

### DIFF
--- a/_docs/services/external-domain-service.md
+++ b/_docs/services/external-domain-service.md
@@ -17,41 +17,20 @@ Both plans offer:
 The domain-with-cdn plan also provides Content Distribution Network (CDN) caching (using [AWS CloudFront](https://aws.amazon.com/cloudfront/)), for
 fast delivery of content to your users.
 
-## Plans
+### Plans
 
 Plan Name         | Plan Description                                                                      |
 ------------------|---------------------------------------------------------------------------------------|
 `domain`          | Custom domain with automatically renewing ssl certificate.                            |
 `domain-with-cdn` | Caching distributed CDN with custom domain and automatically renewing ssl certificate |
 
-## Before you use the domain-with-cdn plan
-
-### Compliance impact
-
-When you use cloud.gov in general, your application inherits the compliance of the cloud.gov FedRAMP P-ATO, which inherits compliance from the AWS GovCloud FedRAMP P-ATO. This service is a little different. When you use this service, you opt into using an AWS service (CloudFront) that is not in the cloud.gov FedRAMP P-ATO boundary, but is in the AWS Commercial FedRAMP P-ATO boundary (see [Services in Scope](https://aws.amazon.com/compliance/services-in-scope/)).
-
-You are responsible for obtaining appropriate authorization from your agency to use CloudFront for your system. The appropriate steps depend on your agency; they may include discussing this with your Authorizing Official and documenting it as part of your ATO (for example as part of [SC-12](https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#!/control?version=5.1&number=SC-12) or [SA-9](https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#!/control?version=5.1&number=SA-9)).
-
-### Technical considerations
-
-Before setting up this service, review [how the CDN works](#more-about-how-the-cdn-works)
-
-## CNAME and ALIAS records
-
-This service requires you to create a CNAME or ALIAS record, and these are slightly different. The exact difference is beyond the scope of this article,
-but what is important to note is that if your domain is an `apex` domain, that is it has only one dot (e.g. `example.gov`, `my-agency.gov`) you must use
-ALIAS records, but not all DNS providers offer ALIAS records. These are limitations in the DNS specification, and not specific to this service. 
-
-
-## Options
-
-### `domain` plan
+## `domain` plan
 
 Name      | Required   | Description                   | Example                           |
 ----------|------------|-------------------------------|-----------------------------------|
 `domains` | *Required* | Your custom domain or domains | `"my-domain.gov,www.my-domain.gov"` or `["my-domain.gov",  "www.my-domain.gov"]` |
 
-### `domain-with-cdn` plan
+## `domain-with-cdn` plan
 
 Name              | Required   | Description                                   | Example                           |
 ------------------|------------|-----------------------------------------------|-----------------------------------|
@@ -63,19 +42,19 @@ Name              | Required   | Description                                   |
 `error_responses` | optional   | dictionary of code:path to respond for errors | `{"404": "/errors/404.html"}`     |
 `path`            | optional   | A custom path to serve from                   | `/some/path`                      |
 
-#### origin and insecure_origin
+### origin and insecure_origin
 You can use this option to send traffic to a custom origin, rather than to your app running on cloud.gov
 If your custom origin is served over HTTP without HTTPS available, set `insecure_origin` to `true`. This flag
 does not apply to apps hosted on cloud.gov.
 
-#### forward_cookies option
+### forward_cookies option
 
 This option allows you to control what cookies to pass on to your application. By default, all cookies are passed.
 You can specify a list of cookie names (comma-separated) to forward, ignoring others. To pass no cookies, pass an empty string, e.g.
 `cf create-service external-domain domain-with-cdn my-cdn -c '{"domains": "example.gov,www.example.gov", "forward_cookies": ""}'`.
 You can explicitly set the default of forwarding all cookies with the string `"*"` (note that this is a special string, not a glob/regex).
 
-#### forward_headers option
+### forward_headers option
 
 This option lets you configure what headers to forward to your application. [CloudFront preconfigures
 some of these](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-headers-behavior), 
@@ -83,7 +62,7 @@ and unless you are using a custom origin, we set the `Host` header.
 You can add up to nine additional headers or header patterns but note that CloudFront considers forwarded headers
 in its cache calculation, so more unique header combinations will cause more cache misses.
 
-#### error_responses option
+### error_responses option
 
 This option lets you send custom error pages for specific error codes. Set this with an object, where the keys are the error codes (as strings) and the values
 are the path to the custom error page, for example:
@@ -98,7 +77,7 @@ cf create-service external-domain domain-with-cdn -c '{"domains": "example.gov",
 ```
 Note that only these error codes can be customized: 400, 403, 404, 405, 414, 416, 500, 501, 502, 503, 504
 
-#### path option
+### path option
 
 You can use this option to send traffic to a custom path at either the default or custom origin.
 ```
@@ -161,8 +140,13 @@ $ cf update-service my-cdn -c '{"origin": ""}'  # passing empty string
 $ cf update-service my-cdn -c '{"origin": null}'  # passing null
 ```
 
+## Technical considerations for domain-with-cdn plan
 
-## More about how the CDN works
+### CNAME and ALIAS records
+
+This service requires you to create a CNAME or ALIAS record, and these are slightly different. The exact difference is beyond the scope of this article,
+but what is important to note is that if your domain is an `apex` domain, that is it has only one dot (e.g. `example.gov`, `my-agency.gov`) you must use
+ALIAS records, but not all DNS providers offer ALIAS records. These are limitations in the DNS specification, and not specific to this service. 
 
 ### Caching
 
@@ -185,12 +169,6 @@ querystrings are part of the cache key, and querystrings are forwarded to your a
 
 Cookies are passed through the CDN by default, meaning that cookie-based authentication will work as expected.
 
-#### Header forwarding
+### Header forwarding
 
 CloudFront forwards a [limited set of headers](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-headers-behavior) by default. 
-
-#### Advanced DDOS protection
-
-Customers who have a cloud.gov [Supplemental or Premium Support Package](https://cloud.gov/support-packages/), or are enrolled through our GSA Cloud Service, can opt to add
-AWS Advanced Shield to their CloudFront distribution, as a Customer Custom Resource. Our cloud.gov support team will
-broker the customization for the customer; the customer maintains responsibility for configuration management and change control (e.g CM-3, CM-6)


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- The "Compliance Impact" section is about 2 or 3 years out of date. We had Cloudfront included in our Annual Assessment two (or three) years ago, after CloudFront came into the FedRAMP® boundary in AWS E/W
- To me, the other considerations make more sense under the relevant service.

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/peterb/update-extern-domain)


## Security Considerations
Clean up and reorg. No further considerations
