### PR TITLE
Update aws elasticache

### DIFF
--- a/_docs/services/aws-elasticache.md
+++ b/_docs/services/aws-elasticache.md
@@ -41,7 +41,7 @@ Name               | Description                                                
 
 A couple of notes regarding the optional `version` parameter:
 
-- It only supports major version numbers; if you specify a minor/patch level version, e.g., "6.2.1" , the command will fail with the exception of 5.0.6.
+- It only supports major version numbers; if you specify a minor/patch level version, e.g., "6.2.1" , the command will fail with the exception of 5.0.6 which is a major version with a minor version release.
 - The version number must be provided in double quotes (`"`); this is because the value is treated as a string to account for different versions.
 
 These are the current supported major versions for Redis:

--- a/_docs/services/aws-elasticache.md
+++ b/_docs/services/aws-elasticache.md
@@ -41,12 +41,12 @@ Name               | Description                                                
 
 A couple of notes regarding the optional `version` parameter:
 
-- It only supports major version numbers; if you specify a minor/patch level version, e.g., "6.2.1" , the command will fail.
+- It only supports major version numbers; if you specify a minor/patch level version, e.g., "6.2.1" , the command will fail with the exception of 5.0.6.
 - The version number must be provided in double quotes (`"`); this is because the value is treated as a string to account for different versions.
 
 These are the current supported major versions for Redis:
 
-- 5.0
+- 5.0.6
 - 6.0
 - 6.2
 - 7.0 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Addition of custom releases
- default of 6.2
- addition of 6 and 7 versions 

<!-- Replace "update_aws_elasticache" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)


## Security Considerations
 None
