### PR TITLE
Remove "How Pages works" from Pages navigation

### DIFF
--- a/_data/pages/navigation.yml
+++ b/_data/pages/navigation.yml
@@ -87,8 +87,6 @@ sidenav:
   - text: For developers
     href: /pages/documentation/
     subfolderitems:
-      - text: How Pages works
-        href: /pages/documentation/how-pages-works/
       - text: How builds work
         href: /pages/documentation/how-builds-work/
       - text: Specific build errors


### PR DESCRIPTION
## Changes proposed in this pull request:
- Page has been unpublished, so it should not appear in navigation any longer

## Security Considerations
None