### PR TITLE
Update notification channel for support

### DIFF
--- a/_pages/pages/documentation/custom-domains.md
+++ b/_pages/pages/documentation/custom-domains.md
@@ -116,7 +116,7 @@ If you are using CAA records, you must have a record for letsencrypt.org. This a
 ## Notify Pages
 Once your DNS changes are complete, notify Pages support via:
 - email: `pages-support@gsa.gov`
-- Slack: `#pages-support`
+- Slack: `#cg-pages`
 
 Someone from the Pages support team will assist you and make the updates to the Pages platform.
 


### PR DESCRIPTION
The docs originally said to notify Pages support at `#pages-support`.  I believe the correct channel is `#cg-pages`.  This commit updates the docs.

## Changes proposed in this pull request:

- Update documentation to reflect the correct support channel in Slack

## Security Considerations

This is just a documentation update.