### PR TITLE
linking to egress rules

### DIFF
--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -194,6 +194,8 @@ name                 service   plan                bound apps   last operation
 test-oracle          aws-rds   medium-oracle-se2                create succeeded
 ```
 
+By default, when new spaces are created in your organization an application security group (ASG) is applied that restricts access to only the internal cloud.gov network. You will need to [update egress traffic](/docs/management/space-egress/) rules to allow for your app to reach the database. 
+
 ## Update an instance
 
 To update an existing service instance to a different plan run the following command:

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -194,7 +194,7 @@ name                 service   plan                bound apps   last operation
 test-oracle          aws-rds   medium-oracle-se2                create succeeded
 ```
 
-By default, when new spaces are created in your organization an application security group (ASG) is applied that restricts access to only the internal cloud.gov network. You will need to [update egress traffic](/docs/management/space-egress/) rules to allow for your app to reach the database. 
+By default, when new spaces are created in your organization, an application security group (ASG) is applied that doesn't allow any outgoing traffic. You will need to [update egress traffic]({{ site.baseurl }}{% link _docs/management/space-egress.md %}) rules to allow for your app to reach the database. 
 
 ## Update an instance
 


### PR DESCRIPTION
Adding a bread crumb so that people don't waste time wondering why their database won't connect to their app

## Changes proposed in this pull request:
Add a link to egress rules because, realistically it is part of setting up the database. 

(I don't think this works with forks?)
<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/LindsayYoung:patch-5)


## Security Considerations
doc update 
