### PR TITLE
fix link to JAB TRR contact info

### DIFF
--- a/_docs/ops/security-ir.md
+++ b/_docs/ops/security-ir.md
@@ -250,4 +250,4 @@ Guidelines for addressing Low-sev issues:
 * [Recent document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (since 2020-02-05)
 * [Older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)
 
-[FedRAMP ISSO TRR reps]: (https://docs.google.com/document/d/1jGddQkjkQ6e9B0UTq9hfQqHe0btAbTeBGL_DxkozAcg/edit)
+[FedRAMP ISSO TRR reps]: https://docs.google.com/document/d/1jGddQkjkQ6e9B0UTq9hfQqHe0btAbTeBGL_DxkozAcg/edit


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix broken link for JAB contact info


<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/update-links-to-jab-contacts)


## Security Considerations

None
