### PR TITLE
update s3 docs

### DIFF
--- a/_docs/services/s3.md
+++ b/_docs/services/s3.md
@@ -51,6 +51,8 @@ cf create-service s3 basic-sandbox <SERVICE_INSTANCE_NAME>
 
 ### Using S3 from your application
 
+By default, when new spaces are created in your organization, an application security group (ASG) is applied that doesn't allow any outgoing traffic. You will need to [update egress traffic]({{ site.baseurl }}{% link _docs/management/space-egress.md %}) rules to allow for your app to reach the S3 bucket.
+
 To make the bucket usable from your application, you must bind it:
 
 ```sh
@@ -70,7 +72,7 @@ cf bind-service <APP_NAME> \
     -c '{"additional_instances": ["<ADDITIONAL_SERVICE_INSTANCE_NAME>"]}'
 ```
 
-The credentials created for this binding will have access to both the bucket managed by `<SERVICE_INSTANCE_NAME>` and `<ADDITIONAL_SERVICE_INSTANCE_NAME>`, and the bucket managed by `<ADDITIONAL_SERVICE_INSTANCE_NAME>` will be listed in the `additional_buckets` field of the credentials.
+The credentials created for this binding will have access to both the bucket managed by `<SERVICE_INSTANCE_NAME>` and `<ADDITIONAL_SERVICE_INSTANCE_NAME>`, and the bucket managed by `<ADDITIONAL_SERVICE_INSTANCE_NAME>` will be listed in the `additional_buckets` field of the credentials. 
 
 ### Interacting with your S3 bucket from outside cloud.gov
 
@@ -112,10 +114,10 @@ KEY_NAME=your-service-key-name-here
 cf create-service-key "${SERVICE_INSTANCE_NAME}" "${KEY_NAME}"
 S3_CREDENTIALS=`cf service-key "${SERVICE_INSTANCE_NAME}" "${KEY_NAME}" | tail -n +2`
 
-export AWS_ACCESS_KEY_ID=`echo "${S3_CREDENTIALS}" | jq -r .credentials.access_key_id`
-export AWS_SECRET_ACCESS_KEY=`echo "${S3_CREDENTIALS}" | jq -r .credentials.secret_access_key`
-export BUCKET_NAME=`echo "${S3_CREDENTIALS}" | jq -r .credentials.bucket`
-export AWS_DEFAULT_REGION=`echo "${S3_CREDENTIALS}" | jq -r '.credentials.region'`
+export AWS_ACCESS_KEY_ID=`echo "${S3_CREDENTIALS}" | jq -r .access_key_id`
+export AWS_SECRET_ACCESS_KEY=`echo "${S3_CREDENTIALS}" | jq -r .secret_access_key`
+export BUCKET_NAME=`echo "${S3_CREDENTIALS}" | jq -r .bucket`
+export AWS_DEFAULT_REGION=`echo "${S3_CREDENTIALS}" | jq -r '.region'`
 ```
 
 


### PR DESCRIPTION
## Changes proposed in this pull request:
Updates
1. The JQ instructions have an extra `.credential` in them.  
2. Adding a snippet to the security group docs so that people know they need to update that to connect to their apps to their buckets.

(I don't think preview works for forks)

## Security Considerations
Just a doc update
