### PR TITLE
fix: Update pagination plugin to properly cache includes

### DIFF
--- a/_plugins/paginate-patch.rb
+++ b/_plugins/paginate-patch.rb
@@ -12,12 +12,15 @@ module Jekyll
     # Source issue: https://github.com/sverrirs/jekyll-paginate-v2/issues/209
     #
 
+    ## Updated from PR https://github.com/sverrirs/jekyll-paginate-v2/blob/01d7bfbe9a88f28c05c144d52c0df5d75f65a32a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+
     class PaginationPage < Page
       def initialize(page_to_copy, cur_page_nr, total_pages, index_pageandext)
         @site = page_to_copy.site
         @base = ''
         @url = ''
         @name = index_pageandext.nil? ? 'index.html' : index_pageandext
+        @path = page_to_copy.path
 
         self.process(@name) # Creates the basename and ext member values
 
@@ -36,12 +39,6 @@ module Jekyll
         # Store the current page and total page numbers in the pagination_info construct
         self.data['pagination_info'] = {"curr_page" => cur_page_nr, 'total_pages' => total_pages }
 
-        # Retain the extention so the page exists in site.html_pages
-        self.ext = page_to_copy.ext
-
-        # Map the first page back to the source file path, to play nice with other plugins
-        self.data['path'] = page_to_copy.path if cur_page_nr == 1
-
         # Perform some validation that is also performed in Jekyll::Page
         validate_data! page_to_copy.path
         validate_permalink! page_to_copy.path
@@ -51,6 +48,8 @@ module Jekyll
       end
 
       def set_url(url_value)
+        @path = url_value.delete_prefix '/'
+        @dir  = File.dirname(@path)
         @url = url_value
       end
     end # class PaginationPage


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updates pagination plugin to fix `_includes` components being improperly cached across collections
- See https://github.com/cloud-gov/pages-uswds-jekyll/issues/297 for reference

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/fix-pagination-caching/news/page/2/)


## Security Considerations
None
