### PR TITLE
Fix pages support email

### DIFF
--- a/_pages/pages/documentation/custom-domains.md
+++ b/_pages/pages/documentation/custom-domains.md
@@ -115,7 +115,7 @@ If you are using CAA records, you must have a record for letsencrypt.org. This a
 
 ## Notify Pages
 Once your DNS changes are complete, notify Pages support via:
-- email: `pages-support@gsa.gov`
+- email: `pages-support@cloud.gov`
 - Slack: `#cg-pages`
 
 Someone from the Pages support team will assist you and make the updates to the Pages platform.


### PR DESCRIPTION
## Changes proposed in this pull request:
- correct pages support email on custom domains page, close #2248

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/fix-pages-support-email-2248)

## Security Considerations
None
