### PR TITLE
Update document history of compliance docs for MAIN

### DIFF
--- a/_docs/ops/configuration-management.md
+++ b/_docs/ops/configuration-management.md
@@ -141,5 +141,6 @@ Whenever possible, the proposed changes should be tested locally. Because of the
 ### Page information
 
 * Last modified on: {% last_modified_at %}
-* [Recent document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (since 2020-02-05)
-* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)
+* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
+* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (from 2020-02-05 to 2022-11-08)
+* [Much older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)

--- a/_docs/ops/contingency-plan.md
+++ b/_docs/ops/contingency-plan.md
@@ -202,5 +202,6 @@ This plan is most effective if all core cloud.gov team members know about it, re
 ### Page information
 
 * Last modified on: {% last_modified_at %}
-* [Recent document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (since 2020-02-05)
-* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)
+* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
+* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (from 2020-02-05 to 2022-11-08)
+* [Much older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)

--- a/_docs/ops/continuous-integration.md
+++ b/_docs/ops/continuous-integration.md
@@ -46,5 +46,6 @@ This is where all customer workloads live. All the same rules apply to our produ
 ### Page information
 
 * Last modified on: {% last_modified_at %}
-* [Recent document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (since 2020-02-05)
-* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)
+* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
+* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (from 2020-02-05 to 2022-11-08)
+* [Much older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)

--- a/_docs/ops/continuous-monitoring.md
+++ b/_docs/ops/continuous-monitoring.md
@@ -261,5 +261,6 @@ Examples:
 ### Page information
 
 * Last modified on: {% last_modified_at %}
-* [Recent document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (since 2020-02-05)
-* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)
+* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
+* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (from 2020-02-05 to 2022-11-08)
+* [Much older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)

--- a/_docs/ops/security-ir-checklist.md
+++ b/_docs/ops/security-ir-checklist.md
@@ -95,5 +95,6 @@ If we've leaked secrets in Github, _once the Incident Response team has told us 
 ### Page information
 
 * Last modified on: {% last_modified_at %}
-* [Recent document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (since 2020-02-05)
-* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)
+* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
+* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (from 2020-02-05 to 2022-11-08)
+* [Much older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)

--- a/_docs/ops/security-ir.md
+++ b/_docs/ops/security-ir.md
@@ -251,7 +251,8 @@ Guidelines for addressing Low-sev issues:
 ### Page information
 
 * Last modified on: {% last_modified_at %}
-* [Recent document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (since 2020-02-05)
-* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)
+* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
+* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (from 2020-02-05 to 2022-11-08)
+* [Much older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)
 
 [FedRAMP ISSO TRR reps]: https://docs.google.com/document/d/1jGddQkjkQ6e9B0UTq9hfQqHe0btAbTeBGL_DxkozAcg/edit

--- a/_docs/ops/service-disruption-guide.md
+++ b/_docs/ops/service-disruption-guide.md
@@ -133,5 +133,6 @@ They also have a baseline expectation that we have good answers to the following
 ### Page information
 
 * Last modified on: {% last_modified_at %}
-* [Recent document history](<https://github.com/cloud-gov/cg-site/commits/master/>{{ page.path }}) (since 2020-02-05)
-* [Older document history](<https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/>{{ page.slug }}.md) (before 2020-02-05)
+* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
+* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (from 2020-02-05 to 2022-11-08)
+* [Much older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Fix doc history
-

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/peterb-doc-history)


## Security Considerations
Nil. Fixes doc history
