### PR TITLE
Add missing alt tags to homepage images

### DIFF
--- a/_pages/pricing.md
+++ b/_pages/pricing.md
@@ -25,7 +25,7 @@ redirect_from:
       {% for product in site.data.pricing %}
       <div class="desktop:grid-col">
         <div class="intro">
-          {% asset "{{ product.image }}" class="square-15" %}
+          {% asset "{{ product.image }}" class="square-15" alt="" %}
           <h2>{{ product.package_name }}</h2>
         </div>
         <table class="usa-table usa-table--borderless">
@@ -85,7 +85,7 @@ redirect_from:
     </div>
     <div class="grid-row grid-gap">
       <div class="diagram tablet:grid-col margin-y-5">
-        {% asset pricing-example-FY20 %}
+        {% asset pricing-example-FY20 alt="" %}
       </div>
     </div>
     <div class="grid-row grid-gap">

--- a/_pages/pricing.md
+++ b/_pages/pricing.md
@@ -85,7 +85,7 @@ redirect_from:
     </div>
     <div class="grid-row grid-gap">
       <div class="diagram tablet:grid-col margin-y-5">
-        {% asset pricing-example-FY20 alt="" %}
+        {% asset pricing-example-FY20 alt="Illustration of sample app running in dev, staging, and production environments" %}
       </div>
     </div>
     <div class="grid-row grid-gap">

--- a/_pages/support-packages.md
+++ b/_pages/support-packages.md
@@ -24,7 +24,7 @@ bg-color-class: bg-accent-warm-light
       {% for product in site.data.support-packages %}
         <div class="desktop:grid-col">
           <div class="intro">
-            {% asset "{{ product.image }}" class="square-15" %}
+            {% asset "{{ product.image }}" class="square-15" alt="" %}
             <h2>{{ product.package_name }}</h2>
           </div>
           <table class="usa-table usa-table--borderless">

--- a/_posts/2017-11-20-release-notes-buildpacks-volume-services-other-new-features.md
+++ b/_posts/2017-11-20-release-notes-buildpacks-volume-services-other-new-features.md
@@ -20,7 +20,7 @@ We’ve been hard at work shipping out new features to help you make your apps b
   
   Thanks to our antipodal compatriots with the [Australian Government Digital Transformation Agency](https://www.dta.gov.au/what-we-do/platforms/cloud/) for this code contribution.
 
-{% asset dashboard-envs.png alt="Screenshot of the environment variable editing view on the dashboard" %}
+{% asset dashboard-envs.png alt="Screenshot of the environment variable editing view on the dashboard in which a user-defined environment variable with the name 'app_version' has been assigned the value '1.0.1'" %}
 
 ### Updates
 

--- a/_posts/2017-11-20-release-notes-buildpacks-volume-services-other-new-features.md
+++ b/_posts/2017-11-20-release-notes-buildpacks-volume-services-other-new-features.md
@@ -20,7 +20,7 @@ We’ve been hard at work shipping out new features to help you make your apps b
   
   Thanks to our antipodal compatriots with the [Australian Government Digital Transformation Agency](https://www.dta.gov.au/what-we-do/platforms/cloud/) for this code contribution.
 
-{% asset dashboard-envs.png alte="Screenshot of the environment variable editing view on the dashboard" %}
+{% asset dashboard-envs.png alt="Screenshot of the environment variable editing view on the dashboard" %}
 
 ### Updates
 

--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@ redirect_from:
   <div class="bg-accent-warm-light padding-4">
     <div class="grid-row grid-gap">
       <div class="tablet:grid-col-2"></div>
-      <div class="tablet:grid-col-2">{% asset FEC-logo.svg class="square-10" %}</div>
+      <div class="tablet:grid-col-2">{% asset FEC-logo.svg alt="FEC logo" class="square-10" %}</div>
       <div class="tablet:grid-col-8">
         <h3>Federal Election Commission</h3>
         <h4>FEC website</h4>
@@ -201,21 +201,21 @@ redirect_from:
       <h5>
         <a href="https://regulations.atf.gov/" class="usa-link usa-link--external">ATF eRegs</a>
       </h5>
-      {% asset ATF-logo.svg %}
+      {% asset ATF-logo.svg alt="ATF logo" %}
       Bureau of Alcohol, Tobacco, Firearms, and Explosives
     </div>
     <div class="tablet:grid-col partner-card">
       <h5>
         <a href="https://dsld.od.nih.gov/" class="usa-link usa-link--external">Dietary Supplement Label Database</a>
       </h5>
-      {% asset NIH-logo.svg %}
+      {% asset NIH-logo.svg alt="NIH logo" %}
       National Institutes of Health
     </div>
     <div class="tablet:grid-col partner-card">
       <h5>
         <a href="https://collegescorecard.ed.gov/" class="usa-link usa-link--external">College Scorecard</a>
       </h5>
-        {% asset Dept-of-Education-logo.svg %}
+        {% asset Dept-of-Education-logo.svg alt="Department of Education logo" %}
         Department of Education
     </div>
   </div>
@@ -224,21 +224,21 @@ redirect_from:
       <h5>
         <a href="https://crime-data-explorer.fr.cloud.gov/" class="usa-link usa-link--external">Crime Data Explorer</a>
       </h5>
-      {% asset FBI-logo.svg %}
+      {% asset FBI-logo.svg alt="FBI logo" %}
       Federal Bureau of Investigation
     </div>
     <div class="tablet:grid-col partner-card">
       <h5>
         <a href="https://www.airnow.gov/" class="usa-link usa-link--external">AirNow</a>
       </h5>
-      {% asset EPA-logo.svg %}
+      {% asset EPA-logo.svg alt="EPA logo" %}
       Environmental Protection Agency
     </div>
     <div class="tablet:grid-col partner-card">
       <h5>
         <a href="https://analytics.usa.gov" class="usa-link usa-link--external">Analytics.usa.gov</a>
       </h5>
-        {% asset GSA-logo.svg %}
+        {% asset GSA-logo.svg alt="GSA logo" %}
         General Services Administration
     </div>
   </div>


### PR DESCRIPTION
## Changes proposed in this pull request:
- In support of https://github.com/cloud-gov/product/issues/2436 this adds missing alt tags to agency logos on homepage

## Security Considerations
None