### PR TITLE
Fix broken CISA.gov links in cg-site

### DIFF
--- a/_docs/compliance/meeting-tic-requirements.md
+++ b/_docs/compliance/meeting-tic-requirements.md
@@ -9,7 +9,7 @@ redirect_from:
 
 Agencies hosting workloads on cloud.gov need to ensure compliance
 with the [DHS CISA Trusted Internet
-Connections](https://www.cisa.gov/trusted-internet-connections)
+Connections](https://www.cisa.gov/tic-guidance)
 program.  In September 2019, OMB released [Memo
 M-19-26](https://www.whitehouse.gov/wp-content/uploads/2019/09/M-19-26.pdf),
 that specified new standards for TIC 3.0, and DHS CISA is currently

--- a/_docs/ops/maintenance-list.md
+++ b/_docs/ops/maintenance-list.md
@@ -149,7 +149,7 @@ If you're unable to ascertain an event was authorized, follow the
 - [Nessus Vulnerability Reports](https://nessus.fr.cloud.gov/)
 - [Nessus Compliance Reports](https://nessus.fr.cloud.gov/)
 - [CloudFoundry Alerts](https://www.cloudfoundry.org/category/security/)
-- [US Cert Alerts](https://www.us-cert.gov/ncas/alerts)
+- [US Cert Alerts](https://www.cisa.gov/news-events/cybersecurity-advisories)
 
 If the reports contain any HIGH items work to remediate them.
 

--- a/_posts/2021-12-22-log4j_vulnerability_bod_22-02_update.md
+++ b/_posts/2021-12-22-log4j_vulnerability_bod_22-02_update.md
@@ -8,7 +8,7 @@ The cloud.gov team has continued working on the Log4j vulnerability, also known 
 Update 2021-12-27: In compliance with directives from the FedRAMP JAB, cloud.gov has completed our ED-22-01 response per the CISA-provided template. The report is available to our authorized customers on the FedRAMP Secure Repository in Max.gov, or by request to support@cloud.gov. 
 cloud.gov Customer Responsibilities
 
-* Customers are responsible for ensuring that their Java applications are fully patched or otherwise have this vulnerability mitigated. For guidance, refer to [CISA’s Log4J guidance](https://us-cert.cisa.gov/apache-log4j-vulnerability-guidance).
+* Customers are responsible for ensuring that their Java applications are fully patched or otherwise have this vulnerability mitigated. For guidance, refer to [CISA’s Log4J guidance](https://www.cisa.gov/news-events/cybersecurity-advisories/aa21-356a).
 * If you have reporting requirements, e.g. [ED 22-02](https://www.cisa.gov/emergency-directive-22-02), regarding cloud.gov components that you leverage:
   * cloud.gov brokered AWS Elasticsearch components were patched at the latest by Dec 21, 2021.
   * All other cloud.gov brokered components, AWS RDS, AWS S3, AWS Elasticache Redis, External Domains, Service Accounts and Identity Provider, were patched by Dec 13, 2021.


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix errors in link checker:
Errors per input

Errors in _site/docs/ops/maintenance-list/index.html
* [https://www.us-cert.gov/ncas/alerts](https://www.us-cert.gov/ncas/alerts): Failed: Network error

Errors in _site/2021/12/22/log4j_vulnerability_bod_22-02_update/index.html
* [https://us-cert.cisa.gov/apache-log4j-vulnerability-guidance](https://us-cert.cisa.gov/apache-log4j-vulnerability-guidance): Failed: Network error

Errors in _site/docs/compliance/meeting-tic-requirements/index.html
* [https://www.cisa.gov/trusted-internet-connections](https://www.cisa.gov/trusted-internet-connections): Failed: Network error

--

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)


## Security Considerations
Relink to public websites. No security impact.
