### PR TITLE
Add MAX.gov account and remove GitHub account requirements in Pages customer responsibilities

### DIFF
--- a/_pages/pages/documentation/customer-responsibilities.md
+++ b/_pages/pages/documentation/customer-responsibilities.md
@@ -42,6 +42,10 @@ Pages does not manage your domain name nor provide DNS services. To launch a sit
 
 If your domain is not an apex (e.g. 2nd level) domain, the process may be more challenging as some DNS providers do not support all required DNS record types. We recommend that you plan a solution before signing an agreement, please see [custom domains]({{site.baseurl}}/pages/documentation/custom-domains) for more details.
 
+#### You must use a MAX.gov account to download the FedRAMP package.
+
+MAX.gov is a suite of government service and resources. You will need a MAX.gov account to access the FedRAMP packgage. MAX.gov accounts are available to those with .gov or .mil email addresses. You will need to [register online for a MAX.gov account](https://portal.max.gov/portal/main/displayRegistrationForm) if you do not already have one. Please [contact MAX.gov](https://portal.max.gov/portal/contactUs) if you require support with this registration process.
+
 ##### SPF, DMARC, and MTA-STS records
 GSA IT requires that your your URL's apex domain has appropriately set DMARC and SPF records in accordance with [BOD 18-01](https://cyber.dhs.gov/bod/18-01/).
 

--- a/_pages/pages/documentation/customer-responsibilities.md
+++ b/_pages/pages/documentation/customer-responsibilities.md
@@ -13,7 +13,7 @@ Using Pages places certain responsibilities on you as the government user of Pag
 
 Pages retains other responsibilities, clarified below. The intent of these policies is to empower you to use Pages to its full potential with awareness of your responsibilities when using advanced features.
 
-#### You must have a GitHub account to work with Pages.
+#### You must use a GitHub account to work with Pages.
 
 Pages is a service that leverages GitHub repositories for publishing. A Pages user with editing access to a repository must authorize the Pages application on their GitHub account **and** Pages must be approved by the parent organizations of repos that are hosted with Pages. Pages users must also have two factor authentication enabled for their GitHub accounts in order to be given access.
 

--- a/_pages/pages/documentation/customer-responsibilities.md
+++ b/_pages/pages/documentation/customer-responsibilities.md
@@ -15,7 +15,7 @@ Pages retains other responsibilities, clarified below. The intent of these polic
 
 #### You must use a GitHub account to work with Pages.
 
-Pages is a service that leverages GitHub repositories for publishing. A Pages user with editing access to a repository must authorize the Pages application on their GitHub account **and** Pages must be approved by the parent organizations of repos that are hosted with Pages. Pages users must also have two factor authentication enabled for their GitHub accounts in order to be given access.
+Pages is a service that leverages GitHub repositories for publishing. A Pages user with editing access to a repository must authorize the Pages application on their GitHub account **and** Pages must be approved by the parent organizations of repos that are hosted with Pages. We strongly recommend that users and organizations enable two factor authentication for their GitHub accounts.
 
 GitHub is used across the government (see [this dashboard](https://gsa.github.io/github-federal-stats/) from our partners in GSA's Office of Government-wide Policy), and a majority of cabinet agencies have a GitHub presence. However, GSA does not endorse Github and there are other ways to launch sites if your agency is not prepared to use GitHub. At this time, no prospective Pages customer has been deterred by integration with GitHub.
 

--- a/_pages/pages/documentation/customer-responsibilities.md
+++ b/_pages/pages/documentation/customer-responsibilities.md
@@ -13,6 +13,12 @@ Using Pages places certain responsibilities on you as the government user of Pag
 
 Pages retains other responsibilities, clarified below. The intent of these policies is to empower you to use Pages to its full potential with awareness of your responsibilities when using advanced features.
 
+#### You must have a GitHub account to work with Pages.
+
+Pages is a service that leverages GitHub repositories for publishing. A Pages user with editing access to a repository must authorize the Pages application on their GitHub account **and** Pages must be approved by the parent organizations of repos that are hosted with Pages. Pages users must also have two factor authentication enabled for their GitHub accounts in order to be given access.
+
+GitHub is used across the government (see [this dashboard](https://gsa.github.io/github-federal-stats/) from our partners in GSA's Office of Government-wide Policy), and a majority of cabinet agencies have a GitHub presence. However, GSA does not endorse Github and there are other ways to launch sites if your agency is not prepared to use GitHub. At this time, no prospective Pages customer has been deterred by integration with GitHub.
+
 #### You own your content
 
 Pages provides templates for you to start with in configuring your sites, but is not responsible for editing or updating the content or local configuration of your site. The Pages team ensures that the publishing mechanism remains available to you so that your content edits can be published within minutes. Your content must be low impact according to [FIPS 199](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.199.pdf) and each branch on GitHub is published publicly by Pages. Pages is not suitable for hosting the following types of information:

--- a/_pages/pages/documentation/customer-responsibilities.md
+++ b/_pages/pages/documentation/customer-responsibilities.md
@@ -13,12 +13,6 @@ Using Pages places certain responsibilities on you as the government user of Pag
 
 Pages retains other responsibilities, clarified below. The intent of these policies is to empower you to use Pages to its full potential with awareness of your responsibilities when using advanced features.
 
-#### You must use a GitHub account to log onto Pages.
-
-Pages is a service that leverages GitHub repositories for publishing. Pages eliminates redundancy by allowing GitHub users with editing access to a repository to configure the site on Pages. This requires Pages users to authorize the Pages application on their GitHub account **and** for Pages to be approved by the parent organizations of repos that are hosted with Pages. Pages users must also have two factor authentication enabled for their GitHub accounts in order to be given access.
-
-GitHub is used across the government (see [this dashboard](https://gsa.github.io/github-federal-stats/) from our partners in GSA's Office of Government-wide Policy), and a majority of cabinet agencies have a GitHub presence. However, GSA does not endorse Github and there are other ways to launch sites if your agency is not prepared to use GitHub. At this time, no prospective Pages customer has been deterred by integration with GitHub.
-
 #### You own your content
 
 Pages provides templates for you to start with in configuring your sites, but is not responsible for editing or updating the content or local configuration of your site. The Pages team ensures that the publishing mechanism remains available to you so that your content edits can be published within minutes. Your content must be low impact according to [FIPS 199](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.199.pdf) and each branch on GitHub is published publicly by Pages. Pages is not suitable for hosting the following types of information:


### PR DESCRIPTION
Changes to Pages customer requirements.

## Changes proposed in this pull request:
- Document MAX.gov account requirement with links to resources (addresses cloud-gov/pages-core#4060)
- Remove section asserting that Pages requires login with a GitHub account.

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/add-max-gov-to-pages-customer-responsibilities)

## Security Considerations
None. This is a website content change.
