### PR TITLE
add documentation on new credential rotation feature

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -18,6 +18,7 @@ https://username:password
 .*\.fr\.cloud\.gov
 https://example.gov
 .*\.us-gov-west-1.vpce.amazonaws.com
+https://github.com/cloudfoundry/stacks/releases/
 
 # URLs with no known replacements
 https://fugacious.18f.gov/
@@ -41,5 +42,4 @@ https://docs.cloud.gov/getting-started/one-off-tasks/#cf-ssh
 https://app.docusign.com/templates
 https://www.congress.gov/
 http://jpattonassociates.com/wp-content/uploads/2015/03/story_mapping.pdf
-https://github.com/cloudfoundry/stacks/releases/tag/1.176.0
 https://tf.nist.gov/tf-cgi/servers.cgi

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -41,3 +41,5 @@ https://docs.cloud.gov/getting-started/one-off-tasks/#cf-ssh
 https://app.docusign.com/templates
 https://www.congress.gov/
 http://jpattonassociates.com/wp-content/uploads/2015/03/story_mapping.pdf
+https://github.com/cloudfoundry/stacks/releases/tag/1.176.0
+https://tf.nist.gov/tf-cgi/servers.cgi

--- a/_posts/2017-06-01-release-notes.md
+++ b/_posts/2017-06-01-release-notes.md
@@ -11,7 +11,7 @@ Curious what’s new that you might find helpful as a cloud.gov application deve
 
 ### Fixed
 - TLS certificates (for custom domains) provided by the [CDN Route service]({{ site.baseurl }}/docs/services/cdn-route) are now automatically obtained with [less risk of rate-limiting](https://cloudgov.statuspage.io/incidents/z49pkl4ms21j).
-- We improved monitoring and reliability for the [Redis]({{ site.baseurl }}/docs/services/redis) and [Elasticsearch](https://github.com/18F/cg-site/blob/6418e8e933f887896a102d8575f1c7af468d1d2f/content/docs/services/elasticsearch24) services, enabling them to automatically restart if non-responsive.
+- We improved monitoring and reliability for the [Redis]({{ site.baseurl }}/docs/services/redis) and [Elasticsearch](https://github.com/cloud-gov/cg-site/blob/6418e8e933f887896a102d8575f1c7af468d1d2f/content/docs/services/elasticsearch24.md) services, enabling them to automatically restart if non-responsive.
 
 ### Removed
 - cloud.gov documentation no longer provides instructions for using the deprecated East/West environment, because all customer applications have migrated to the GovCloud environment.

--- a/_posts/2017-08-16-release-notes.md
+++ b/_posts/2017-08-16-release-notes.md
@@ -11,7 +11,7 @@ Curious what’s new that you might find helpful as a cloud.gov user? Here are h
 ### Added
 
 * Space managers can [add any member of your organization to a space from the dashboard]({{ site.baseurl }}/docs/apps/managing-teammates#space-users).
-* Documentation for how to take [snapshots and restore backups of your ElasticSearch service data](https://github.com/18F/cg-site/blob/6418e8e933f887896a102d8575f1c7af468d1d2f/content/docs/services/elasticsearch24).
+* Documentation for how to take [snapshots and restore backups of your ElasticSearch service data](https://github.com/cloud-gov/cg-site/blob/6418e8e933f887896a102d8575f1c7af468d1d2f/content/docs/services/elasticsearch24.md).
 * All customers can now use [Oracle’s SE2 relational database]({{ site.baseurl }}/docs/services/relational-database).
 
 ### Changed

--- a/lychee.toml
+++ b/lychee.toml
@@ -63,9 +63,7 @@ headers = []
 ### Exclusions
 ###
 # Exclude URLs from checking (supports regex)
-exclude = [
-  "https://tf.nist.gov/tf-cgi/servers.cgi"
-]
+exclude = []
 
 # Exclude URLs contained in a file from checking
 # If a file named `.lycheeignore` exists in the current working directory,


### PR DESCRIPTION
## Changes proposed in this pull request:

- add documentation on new credential rotation feature for brokered databases

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/add-rds-rotate-creds-doc): https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/add-rds-rotate-creds-doc/docs/services/relational-database/#rotate-your-credentials


## Security Considerations

The credential rotation feature is self-service and it increases potential for good security hygiene of rotating credentials, which the documentation facilitates.
