### PR TITLE
feat: add Pages external tools doc

### DIFF
--- a/_data/pages/navigation.yml
+++ b/_data/pages/navigation.yml
@@ -70,7 +70,7 @@ sidenav:
         href: /pages/documentation/migration-guide/
       - text: Adding forms
         href: /pages/documentation/forms/
-      - text: Adding search 
+      - text: Adding search
         href: /pages/documentation/search/
       - text: Site templates
         href: /pages/documentation/templates/
@@ -111,3 +111,5 @@ sidenav:
         href: /pages/documentation/renaming-site-repository/
       - text: Monorepos on Pages
         href: /pages/documentation/monorepos-on-pages/
+      - text: External tools and resources
+        href: /pages/documentation/external-tools-and-resources/

--- a/_pages/pages/documentation/external-tools-and-resources.md
+++ b/_pages/pages/documentation/external-tools-and-resources.md
@@ -45,7 +45,7 @@ These tools run before a site update is deployed to production and look at the s
 
 #### Live site scanning
 
-These tools run after a preview or production update is deployed to the sit. They check the live site to identify vulnerabilities.
+These tools run after a preview or production update is deployed to the site. They check the live site to identify vulnerabilities.
 
 - [OWASP Zap](https://www.zaproxy.org/)
 - [Invicti](https://www.invicti.com/)

--- a/_pages/pages/documentation/external-tools-and-resources.md
+++ b/_pages/pages/documentation/external-tools-and-resources.md
@@ -8,11 +8,11 @@ sidenav: pages-documentation
 
 An outline of external tools and resources customer could leverage outside of the cloud.gov Pages platform to improve site accessibility, user experience, and security posture.
 
-Cloud.gov Pages sites' source code is managed via [Git](https://git-scm.com/) version control and hosted on [GitHub](https://www.github.com). The combination of these source code management tools allows cloud.gov Pages customers to leverage open source tools, third-party services, and other resources outside of the cloud.gov Pages platform to improve their development workflow, user experience, and security posture. This will outline different areas of interest with possible resources for customers to research in-depth based on their current priorities, resources, skill sets, and constraints. This is not an endorsement of any single resource or tool so this outline will change as with the landscape and it is only a small sample of possible tools and resources.
+Cloud.gov Pages sites' source code is managed via [Git](https://git-scm.com/) version control and hosted on [GitHub](https://www.github.com). The combination of these source code management tools allows cloud.gov Pages customers to leverage open source tools, third-party services, and other resources outside of the cloud.gov Pages platform to improve their development workflow, user experience, and security posture. This will outline different areas of interest with possible resources for customers to research in-depth based on their current priorities, resources, skill sets, and constraints. This is not an endorsement of any single resource or tool so this outline will change with the landscape and it is only a small sample of possible tools and resources.
 
 ## Continuous integration and deployment
 
-Continuous integration and deployment (CI/CD) refers to the use of automated workflows to build, test, and deploy code. Implementing these automated workflows improves consistency in the development process and adds confidence when deploying updates to the system. CI/CD can be leveraged by cloud.gov Pages customers to automatically run checks against any update to the site source code and protect the production site from errors or security vulnerabilities that could be introduced from an update to the site. The following is a small list of possible CI/CD platforms that could be used in conjunction with your cloud.gov Pages site:
+Continuous integration and deployment (CI/CD) refers to the use of automated workflows to build, test, and deploy code. Implementing these automated workflows improves consistency in the development process and adds confidence when deploying updates to the system. CI/CD can be leveraged by cloud.gov Pages customers to automatically run checks against any update to the site source code and protect the production site from errors or security vulnerabilities that could be introduced from an update to the site. The following are some of the CI/CD platforms that could potentially be used in conjunction with your cloud.gov Pages site:
 
 - [GitHub Actions](https://github.com/features/actions)
 - [CircleCI](https://circleci.com/)
@@ -28,7 +28,7 @@ The above is just a small list of CI/CD platforms that a customer could use to a
 
 ## Automated workflows
 
-The automated workflows in a site's CI/CD system enables cloud.gov Pages customers to leverage external tools, resources, and services. The following sections will outline some possibilities customers may choose to explore.
+The automated workflows in a site's CI/CD system enable cloud.gov Pages customers to leverage external tools, resources, and services. The following sections will outline some possibilities customers may choose to explore.
 
 ### Scanning tools
 
@@ -45,7 +45,7 @@ These tools run before a site update is deployed to production and look at the s
 
 #### Live site scanning
 
-These tools run after a preview or production update is deployed to the site and they check the live site to identify vulnerabilities.
+These tools run after a preview or production update is deployed to the sit. They check the live site to identify vulnerabilities.
 
 - [OWASP Zap](https://www.zaproxy.org/)
 - [Invicti](https://www.invicti.com/)

--- a/_pages/pages/documentation/external-tools-and-resources.md
+++ b/_pages/pages/documentation/external-tools-and-resources.md
@@ -1,0 +1,68 @@
+---
+title: External Tools and Resources
+permalink: /pages/documentation/external-tools-and-resources/
+layout: docs
+navigation: pages
+sidenav: pages-documentation
+---
+
+An outline of external tools and resources customer could leverage outside of the cloud.gov Pages platform to improve site accessibility, user experience, and security posture.
+
+Cloud.gov Pages sites' source code is managed via [Git](https://git-scm.com/) version control and hosted on [GitHub](https://www.github.com). The combination of these source code management tools allows cloud.gov Pages customers to leverage open source tools, third-party services, and other resources outside of the cloud.gov Pages platform to improve their development workflow, user experience, and security posture. This will outline different areas of interest with possible resources for customers to research in-depth based on their current priorities, resources, skill sets, and constraints. This is not an endorsement of any single resource or tool so this outline will change as with the landscape and it is only a small sample of possible tools and resources.
+
+## Continuous integration and deployment
+
+Continuous integration and deployment (CI/CD) refers to the use of automated workflows to build, test, and deploy code. Implementing these automated workflows improves consistency in the development process and adds confidence when deploying updates to the system. CI/CD can be leveraged by cloud.gov Pages customers to automatically run checks against any update to the site source code and protect the production site from errors or security vulnerabilities that could be introduced from an update to the site. The following is a small list of possible CI/CD platforms that could be used in conjunction with your cloud.gov Pages site:
+
+- [GitHub Actions](https://github.com/features/actions)
+- [CircleCI](https://circleci.com/)
+- [Jenkins](https://www.jenkins.io/)
+- [Concourse CI](https://concourse-ci.org/)
+- [Bamboo](https://www.atlassian.com/software/bamboo)
+
+The above is just a small list of CI/CD platforms that a customer could use to automate their development and deployment workflows.
+
+## Branch protections
+
+[Branch protections](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) in a GitHub repository allow cloud.gov Pages customers to add additional security measures to make sure the site's production source code is updated through a well defined process and protects it from errors or security vulnerabilities. Customers can define branch protection rules to designate user approval or require passing [status checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-status-checks-before-merging) before merging into the production source code's branch. [Status Checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-status-checks-before-merging) are the automated workflows run by your CI/CD platform whenever a branch is added or updated. Customers can leverage external tools, resources and services through these automated workflows and protect site source code through the status checks associated with them.
+
+## Automated workflows
+
+The automated workflows in a site's CI/CD system enables cloud.gov Pages customers to leverage external tools, resources, and services. The following sections will outline some possibilities customers may choose to explore.
+
+### Scanning tools
+
+Source code and live site scanning are required to obtain an Authorization to Operate (ATO) a federal information system like a cloud.gov Pages site. Being able to incorporate these tools into the CI/CD process will provide the best outcomes for customer sites. The following is a list of possible scanning tools:
+
+#### Static Code Analysis
+
+These tools run before a site update is deployed to production and look at the site's source code to identify vulnerabilities or suggest best practices.
+
+- [CodeQL](https://codeql.github.com/)
+- [SonarQube](https://docs.sonarqube.org/latest/)
+- [Snyk](https://snyk.io/)
+- [Checkmarx](https://checkmarx.com/)
+
+#### Live site scanning
+
+These tools run after a preview or production update is deployed to the site and they check the live site to identify vulnerabilities.
+
+- [OWASP Zap](https://www.zaproxy.org/)
+- [Invicti](https://www.invicti.com/)
+- [Qualys](https://www.qualys.com/)
+- [Checkmarx](https://checkmarx.com/)
+
+### Accessibility
+
+These tools run against the site to make it more accessible and improve the user experience for all. They help cloud.gov Pages customers improve their [Section 508](https://www.section508.gov/) compliance posture on their sites.
+
+- [Pa11y CI](https://github.com/pa11y/pa11y-ci)
+- [Axe](https://www.deque.com/axe/)
+
+### Other
+
+Here are some additional tools customers could add to improve their site.
+
+- [Lychee](https://github.com/lycheeverse/lychee) to identify any links on the site that are no longer valid.
+- [ESLint](https://eslint.org/) to identify problems with the javascript syntax.
+- [CSpell](https://cspell.org/) to run spell check against the site.

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,9 +80,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "peer": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -2632,9 +2632,9 @@
       "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -2679,9 +2679,9 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -6311,9 +6311,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
           "peer": true
         }
       }
@@ -8255,9 +8255,9 @@
       "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "requires": {
         "minimist": "^1.2.0"
       }
@@ -8296,9 +8296,9 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",


### PR DESCRIPTION
Closes out https://github.com/cloud-gov/pages-core/issues/4059

## Changes proposed in this pull request:
- Add an outline of external tools and resources a customer could use

:sunglasses:[Preview Page](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/feat-add-pages-external-tools/pages/documentation/external-tools-and-resources/)

## Security Considerations
None
