### PR TITLE
retiring admin-ui

### DIFF
--- a/_docs/ops/repos.md
+++ b/_docs/ops/repos.md
@@ -66,7 +66,6 @@ Configuration/deployment support:
 
 Deployment pipelines:
 
-- [Admin user interface](https://github.com/cloud-gov/cg-deploy-admin-ui)
 - [BOSH](https://github.com/cloud-gov/cg-deploy-bosh)
 - [Cloud Foundry](https://github.com/cloud-gov/cg-deploy-cf)
 - [Concourse](https://github.com/cloud-gov/cg-deploy-concourse)


### PR DESCRIPTION
## Changes proposed in this pull request:
- Retiring admin ui
-
-

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/retire-admin-ui)


## Security Considerations
None, retiring admin-ui
