### PR TITLE
rename egress alias of restricted-egress to trusted-local-egress

### DIFF
--- a/_docs/management/space-egress.md
+++ b/_docs/management/space-egress.md
@@ -2,7 +2,7 @@
 parent: management
 layout: docs
 sidenav: true
-redirect_from: 
+redirect_from:
     - /docs/apps/space-egress/
 title: Controlling egress traffic
 ---
@@ -16,8 +16,8 @@ A summary of each of the ASGs that can be applied to your space are as follows:
 | ASG Type | Public Web | AWS S3 (user-provided)| AWS S3 (brokered) | AWS RDS | AWS Elasticache Redis | AWS Elasticsearch | Internal Routes |
 | :-------- |  :-: | :--:  | :--: | :-------: | :---------------------: | :-----------------: | :---------------: |
 | `closed-egress`     | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| `restricted-egress` | ❌ | ❌ | ✅  | ✅ | ✅ | ✅ | ✅ |
-| `public-egress`     | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | 
+| `trusted-local-egress` | ❌ | ❌ | ✅  | ✅ | ✅ | ✅ | ✅ |
+| `public-egress`     | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
 
 
 - ### `closed-egress`
@@ -25,7 +25,7 @@ A summary of each of the ASGs that can be applied to your space are as follows:
   - Requests being executed from within the space can only successfully be sent to other internal routes you have created in your organization.
   - Any requests to the open internet or our brokered services will be blocked.
 
-- ### `restricted-egress`
+- ### `trusted-local-egress`
   - ASG name: `trusted_local_networks_egress`
   - Requests being executed from within the space can only successfully be sent to some of our brokered services or other internal routes you have created in your organization.
     - Accessible brokered services: [AWS RDS](https://cloud.gov/docs/services/relational-database/), [AWS Elasticache Redis](https://cloud.gov/docs/services/aws-elasticache/), [AWS Elasticsearch](https://cloud.gov/docs/services/aws-elasticsearch/), [S3 Object Storage](https://cloud.gov/docs/services/s3/).
@@ -36,7 +36,7 @@ A summary of each of the ASGs that can be applied to your space are as follows:
   - Requests being executed from within the space [can successfully be sent to the open internet]({{ site.baseurl }}{% link _docs/management/static-egress.md %}) and other internal routes you have created in your organization.
   - Applications can make requests to third party APIs.
   - Any requests to our brokered services except for S3 will be blocked.
-  - Applications connecting to their own S3 buckets (not brokered) that reside in AWS Govcloud West will need to use an alternate endpoint for s3:  
+  - Applications connecting to their own S3 buckets (not brokered) that reside in AWS Govcloud West will need to use an alternate endpoint for s3:
  
       `*.vpce-01beaa66570dfb2b9-1hlav4x8.s3.us-gov-west-1.vpce.amazonaws.com`
     ```
@@ -46,13 +46,13 @@ A summary of each of the ASGs that can be applied to your space are as follows:
       
 When you push your application to cloud.gov, the staging process may require outbound connections to the public internet to fetch dependencies and software modules. As such, during the staging process, your app will run under the `public-egress` until it is staged and ready to run. Once this process is complete, your app will run under the ASGs that have been applied, either by default or by modifications that have been made to your space.
 
-For applications that need access to their own S3 buckets, you have the option of running them under the public-egress ASG, or running them in the restricted-egress ASG, and using a proxy application (e.g., squid proxy, HA proxy, etc.) to proxy traffic to your S3 bucket(s). Reference implementations showing how to do this will be available soon, or you may reach out to the cloud.gov team for support.
+For applications that need access to their own S3 buckets, you have the option of running them under the public-egress ASG, or running them in the trusted-local-egress ASG, and using a proxy application (e.g., squid proxy, HA proxy, etc.) to proxy traffic to your S3 bucket(s). Reference implementations showing how to do this will be available soon, or you may reach out to the cloud.gov team for support.
 
 ## Managing egress settings for your org or space
 
 To inspect or modify the ASG that apply to your spaces, you can use the following `cf` CLI subcommands. Run `cf <subcommand> --help` to find out more about a specific command, or consult [the cf CLI documentation site](https://cli.cloudfoundry.org/en-US/v6/).
 
-| CF CLI subcommand | Description | 
+| CF CLI subcommand | Description |
 | :- | :- |
 | `cf security-group`                         | Show a single security group |
 | `cf security-groups`                        | List all security groups |

--- a/_docs/management/space-egress.md
+++ b/_docs/management/space-egress.md
@@ -43,10 +43,12 @@ A summary of each of the ASGs that can be applied to your space are as follows:
       aws --endpoint-url https://bucket.vpce-01beaa66570dfb2b9-1hlav4x8.s3.us-gov-west-1.vpce.amazonaws.com s3 ls s3://my-private-bucket
     ```
       for more details on using alternate endpoints with S3 see [Accessing buckets and S3 access points from S3 interface endpoints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html#accessing-bucket-and-aps-from-interface-endpoints)
-      
+
+Often, production applications need to communicate with an internal, brokered service like a database and make requests to the public internet for third-party APIs. Such applications would need **both `trusted-local-egress` and `public-egress`** applied to their space.
+
 When you push your application to cloud.gov, the staging process may require outbound connections to the public internet to fetch dependencies and software modules. As such, during the staging process, your app will run under the `public-egress` until it is staged and ready to run. Once this process is complete, your app will run under the ASGs that have been applied, either by default or by modifications that have been made to your space.
 
-For applications that need access to their own S3 buckets, you have the option of running them under the public-egress ASG, or running them in the trusted-local-egress ASG, and using a proxy application (e.g., squid proxy, HA proxy, etc.) to proxy traffic to your S3 bucket(s). Reference implementations showing how to do this will be available soon, or you may reach out to the cloud.gov team for support.
+For applications that need access to their own S3 buckets, you have the option of running them under the `public-egress` ASG, or running them in the `trusted-local-egress` ASG, and using a proxy application (e.g., squid proxy, HA proxy, etc.) to proxy traffic to your S3 bucket(s). Reference implementations showing how to do this will be available soon, or you may reach out to the cloud.gov team for support.
 
 ## Managing egress settings for your org or space
 

--- a/_posts/2021-11-16-controlled-space-egress.md
+++ b/_posts/2021-11-16-controlled-space-egress.md
@@ -5,7 +5,7 @@ title: "New Controlled Space Egress"
 excerpt: The cloud.gov platform is releasing new space types to help customers better control app egress.
 ---
 
-To better help our customers control egress from their apps, we are offering additional space types for your organization with new application security group (ASG) rules. These new ASG rules allow space egress to be more locked down to minimize the impacts of possible data exfiltration. Currently, all cloud.gov org spaces allow egress from an app to the open internet, our brokered services ([AWS RDS](https://cloud.gov/docs/services/relational-database/), [AWS Elasticache Redis](https://cloud.gov/docs/services/aws-elasticache/), [AWS Elasticsearch](https://cloud.gov/docs/services/aws-elasticsearch/)), and [internal routes](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#internal-routes) to other apps within your organization. Our additional space ASG offerings will now include `public-egress`, `restricted-egress`, and `closed-egress`. These ASG rules will apply to all apps running within a certain space type and will allow you to group apps based on functionality.
+To better help our customers control egress from their apps, we are offering additional space types for your organization with new application security group (ASG) rules. These new ASG rules allow space egress to be more locked down to minimize the impacts of possible data exfiltration. Currently, all cloud.gov org spaces allow egress from an app to the open internet, our brokered services ([AWS RDS](https://cloud.gov/docs/services/relational-database/), [AWS Elasticache Redis](https://cloud.gov/docs/services/aws-elasticache/), [AWS Elasticsearch](https://cloud.gov/docs/services/aws-elasticsearch/)), and [internal routes](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#internal-routes) to other apps within your organization. Our additional space ASG offerings will now include `public-egress`, `trusted-local-egress`, and `closed-egress`. These ASG rules will apply to all apps running within a certain space type and will allow you to group apps based on functionality.
 
 Here are the following rules associated to the different space ASG types:
 
@@ -14,7 +14,7 @@ Here are the following rules associated to the different space ASG types:
   - Your app can make requests to third party APIs.
   - Your app can connect to our brokered services.
 
-- ### `restricted-egress`
+- ### `trusted-local-egress`
   - Requests being executed from within the app can only successfully be sent to some of our brokered services or other internal routes you have created in your organization.
     - Accessible brokered services: [AWS RDS](https://cloud.gov/docs/services/relational-database/), [AWS Elasticache Redis](https://cloud.gov/docs/services/aws-elasticache/), [AWS Elasticsearch](https://cloud.gov/docs/services/aws-elasticsearch/).
     - Inaccessible brokered service: [S3 Object Storage](https://cloud.gov/docs/services/s3/).


### PR DESCRIPTION
## Changes proposed in this pull request:

- rename egress alias of restricted-egress to trusted-local-egress to reduce confusion, since "restricted" doesn't communicate well that `trusted-local-egress` **grants you access** to talk to your brokered services
- add note about using public and trusted local egress

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/rename-egress-alias)


## Security Considerations

None, just updating public facing documentation
