### PR TITLE
Replace 18F vulnerability reporting policy with GSA policy, which has superseded it

### DIFF
--- a/_docs/ops/repos.md
+++ b/_docs/ops/repos.md
@@ -14,7 +14,7 @@ cloud.gov is built and maintained by a team within the General Services administ
 
 cloud.gov is an open source project based on [Cloud Foundry](https://www.cloudfoundry.org/) with additional components built by our team and other community members. This includes using open source for security: We use a combination of [ClamAV](https://www.clamav.net), [AIDE](https://aide.github.io/) and [Snort](https://www.snort.org) on each system, with [OpenZAP](https://www.zaproxy.org) to do blackbox testing.  We also run [Prometheus](https://prometheus.io) and a full [ELK stack](https://www.elastic.co/elk-stack) with [ElastAlert](https://github.com/Yelp/elastalert) for additional monitoring and alerting. We do use a commercial tool for [CIS benchmarking](https://www.cisecurity.org/cis-benchmarks/) and further blackbox testing. We welcome you to audit our security or contribute to it — or to make any other kind of contribution, from documentation to design.
 
-If you'd like to contribute security research, see our [vulnerability disclosure policy](https://18f.gsa.gov/vulnerability-disclosure-policy/).
+If you'd like to contribute security research, see our [vulnerability disclosure policy](https://www.gsa.gov/vulnerability-disclosure-policy).
 
 If you're interested in contributing to cloud.gov but not sure where to start, or if you have questions about contributing, feel free to join the [18F DevOps or open source chat channels](https://chat.18f.gov/) and explain your question. You can also open an issue with your question in a relevant repository.
 

--- a/_docs/ops/security-ir.md
+++ b/_docs/ops/security-ir.md
@@ -19,7 +19,7 @@ This document outlines cloud.gov's internal process for responding to security i
 
 *If you're responding to an incident, [here's our IR checklist]({{ site.baseurl }}{% link _docs/ops/security-ir-checklist.md %}) as a short, actionable companion to this guide.*
 
-(If you're a member of the public who has noticed something in cloud.gov that may be a security problem, please see [our vulnerability disclosure policy and reporting process](https://18f.gsa.gov/vulnerability-disclosure-policy/). As it explains, we want security researchers to feel comfortable reporting vulnerabilities they’ve discovered, as set out in that policy, so that we can fix them and keep our information safe.)
+(If you're a member of the public who has noticed something in cloud.gov that may be a security problem, please see [our vulnerability disclosure policy and reporting process](https://www.gsa.gov/vulnerability-disclosure-policy). As it explains, we want security researchers to feel comfortable reporting vulnerabilities they’ve discovered, as set out in that policy, so that we can fix them and keep our information safe.)
 
 ## Overview
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -25,7 +25,7 @@
               <a href="https://cloud.gov/docs/ops/repos/">Open source and in the public domain</a>
             </li>
             <li>
-              <a href="https://18f.gsa.gov/vulnerability-disclosure-policy/">Vulnerability disclosure policy</a>
+              <a href="https://www.gsa.gov/vulnerability-disclosure-policy">Vulnerability disclosure policy</a>
             </li>
           </ul>
         </div>

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -25,7 +25,7 @@ You should not include any passwords or sensitive environment variables in your 
 
 ### Report a vulnerability
 
-We welcome vulnerability reports [according to our vulnerability disclosure policy](https://18f.gsa.gov/vulnerability-disclosure-policy/), which includes how to best contact us for this kind of information.
+We welcome vulnerability reports [according to our vulnerability disclosure policy](https://www.gsa.gov/vulnerability-disclosure-policy), which includes how to best contact us for this kind of information.
 
 ### Questions from the public and industry
 

--- a/_pages/pages/contact.md
+++ b/_pages/pages/contact.md
@@ -27,7 +27,7 @@ title: cloud.gov Pages - Contact
   <div class="grid-row">
     <h2>Report a vulnerability</h2>
     <p>
-      We welcome vulnerability reports <a href="https://18f.gsa.gov/vulnerability-disclosure-policy/">according to our vulnerability disclosure policy</a>. We accept and discuss vulnerability reports on <a href="https://hackerone.com/tts">HackerOne</a>, via email at <a href="mailto:tts-vulnerability-reports@gsa.gov">tts-vulnerability-reports@gsa.gov</a>, or <a href="https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform">through this reporting form</a>. Please review our vulnerability disclosure policy before reporting a vulnerability.
+      We welcome vulnerability reports <a href="https://www.gsa.gov/vulnerability-disclosure-policy">according to our vulnerability disclosure policy</a>. Please review our vulnerability disclosure policy before reporting a vulnerability.
     </p>
   </div>
 </section>


### PR DESCRIPTION
## Changes proposed in this pull request:
- See title

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/18f-gsa-vuln-disclosure)


## Security Considerations
@jameshochadel will check if the SSP requires updates too.
