### PR TITLE
Address missing alternative text accessibility findings in cloud.gov Pages public site

### DIFF
--- a/_pages/pages/documentation/permissions.md
+++ b/_pages/pages/documentation/permissions.md
@@ -26,20 +26,22 @@ Pages Users within an Organization will be able to see all of the Sites in the O
 
 - Navigate to the organizations tab
 - Click edit in the lower right hand corner of the organization pane
-  <img src="{{ site.baseurl }}/assets/pages/images/edit_organizations.png"/>
+  <img src="{{ site.baseurl }}/assets/pages/images/edit_organizations.png"
+       alt="'Your Organizations' pane with an 'Edit' link highlighted"/>
 
-- Click the plus sign under “Members” 
-  <img src="{{ site.baseurl }}/assets/pages/images/add_user.png"/>
+- Click the plus sign under “Members”
+  <img src="{{ site.baseurl }}/assets/pages/images/add_user.png"
+       alt="Organization edit pane with the plus sign button next to 'Add user' highlighted"/>
 
 - Fill out the required fields of Email and Role
  * If you do not know the GitHub username of the invitee you can add it post invite
 
 - Click Invite
 
- 
+
 ## User Acceptance
 
-As a new user to the platform you will be sent an invitation via email. The link in the email will take you directly to the cloud.gov login page to authenticate your credentials.  You will need to create a cloud.gov account and then use these credentials to login to Pages. 
+As a new user to the platform you will be sent an invitation via email. The link in the email will take you directly to the cloud.gov login page to authenticate your credentials.  You will need to create a cloud.gov account and then use these credentials to login to Pages.
 
 \*Note if a user already belongs to these agencies FDIC, EPA, NIH, GSA, DOJ, OMB or has existing cloud.gov credentials they can use their existing account login information to authenticate into Pages.
 

--- a/_pages/pages/index.md
+++ b/_pages/pages/index.md
@@ -75,16 +75,19 @@ example_sites:
 fact_sheets:
   - name: Pages proposal
     thumbnail: /assets/pages/images/home-page/Pages-Proposal-Thumbnail.png
+    thumbnail_alt: Pages proposal fact sheet PDF document thumbnail
     pdfs:
       - link: /assets/pages/documents/Pages-Proposal.pdf
         description: A two-page overview about Pages for stakeholder briefings
   - name: Pages basic diagram
     thumbnail: /assets/pages/images/home-page/how-pages-works-diagram-Thumbnail.png
+    thumbnail_alt: Pages basic diagram fact sheet PDF document thumbnail
     pdfs:
       - link: /assets/pages/documents/how-pages-works-diagram.pdf
         description: An outline of how all of Pages' parts work together.
   - name: Compliance memo & extension
     thumbnail: /assets/pages/images/home-page/pages-compliance-memo-Thumbnail.jpg
+    thumbnail_alt: Compliance memo & extension fact sheet PDF document thumbnail
     pdfs:
       - link: /assets/pages/documents/pages-compliance-memo.pdf
         description: Details about Pages' compliance and Authority to Operate.


### PR DESCRIPTION
Addresses #2302

## Changes proposed in this pull request:
- Add missing alt attributes to images in /pages and /pages/documentation/access-permissions

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/2302-alt-attributes)

## Security Considerations
None. This remediates accessibility issues.
