### PR TITLE
Darken theme colors to increase contrast where they are used in sidenav

### DIFF
--- a/_assets/css/theme/_uswds-theme-color.scss
+++ b/_assets/css/theme/_uswds-theme-color.scss
@@ -29,8 +29,8 @@ $theme-color-base-lightest:         'gray-cool-3';
 $theme-color-base-lighter:          'gray-cool-10';
 $theme-color-base-light:            'gray-cool-20';
 $theme-color-base:                  'gray-cool-40';
-$theme-color-base-dark:             'gray-cool-50';
-$theme-color-base-darker:           'gray-cool-60';
+$theme-color-base-dark:             'gray-cool-70';
+$theme-color-base-darker:           'gray-cool-80';
 $theme-color-base-darkest:          'gray-warm-90';
 $theme-color-base-ink:              'gray-warm-90';
 


### PR DESCRIPTION
Addresses #2303

## Changes proposed in this pull request:
- Darken theme colors to increase contrast where they are used in sidenav

**Note** that this affects not only the sidenav in the cloud.gov Pages Documentation section, where an accessibility scan revealed this issue, but also the sidenav in the cloud.gov _platform_ Documentation section, which also suffers from this contrast issue. 

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/2303-contrast)

## Security Considerations
None. This remediates accessibility issues.
