### PR TITLE
Fix typo in Sidecar Processes post

### DIFF
--- a/_kbarticles/2023-04-18-Sidecar-Processes.md
+++ b/_kbarticles/2023-04-18-Sidecar-Processes.md
@@ -9,7 +9,7 @@ excerpt: Using sidecar processes.
 Sidecar processes are additional processes you can run in the same container as your application.
 
 ## How do sidecar processes work?
-When deploying a sidecar with your application Cloud Foundry packages the code and configuration needed for running the application and sidecar in the same droplet. The droplet is then deployed in the same container with the application and sidecar being deployed in parellel. The application and sidecar have independent health checks.
+When deploying a sidecar with your application Cloud Foundry packages the code and configuration needed for running the application and sidecar in the same droplet. The droplet is then deployed in the same container with the application and sidecar being deployed in parallel. The application and sidecar have independent health checks.
 
 ## Use Case
 Sidecars can be used on processes which depend on each other or need to run in the same container.


### PR DESCRIPTION
## Changes proposed in this pull request:

fixes a single letter typo. Preview link didn't work, likely because this is built from a fork.

## Security Considerations
none
