### PR TITLE
Add second skip link to improve accessibility for keyboard navigation users

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,8 @@ GEM
     ffi (1.15.5)
     forwardable-extended (2.6.0)
     google-protobuf (3.22.2-arm64-darwin)
+    google-protobuf (3.22.2-x86_64-darwin)
+    google-protobuf (3.22.2-x86_64-linux)
     html-proofer (3.19.4)
       addressable (~> 2.3)
       mercenary (~> 0.3)
@@ -69,6 +71,10 @@ GEM
     mercenary (0.4.0)
     nokogiri (1.14.2-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.2-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.14.2-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.22.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -84,6 +90,10 @@ GEM
     safe_yaml (1.0.5)
     sass-embedded (1.60.0-arm64-darwin)
       google-protobuf (~> 3.21)
+    sass-embedded (1.60.0-x86_64-darwin)
+      google-protobuf (~> 3.21)
+    sass-embedded (1.60.0-x86_64-linux-gnu)
+      google-protobuf (~> 3.21)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     typhoeus (1.4.0)
@@ -95,6 +105,8 @@ GEM
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
+  x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   addressable (>= 2.8.0)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This site uses a customized [U.S. Web Design System](https://v2.designsystem.dig
 
 ## Key Functionality
 This repository contains the following examples and functionality:
- 
+
 ✅  Publish blog posts, press releases, announcements, etc. To modify this code, check out `blog/index.html`, which manages how the posts are listed. You should then check out `_layouts/post.html` to see how individual posts are structured.
 
 ✅ Publish single one-off pages. Instead of creating lots of folders throughout the root directory, you should put single pages in `_pages` folder and change the `permalink` at the top of each page. Use sub-folders only when you really need to.
@@ -49,20 +49,20 @@ permalink: /document-with-sidenav
 ---
 ```
 
-✅ Enable search with [Search.gov](https://search.gov) by adding option to `_config.yml`. 
+✅ Enable search with [Search.gov](https://search.gov) by adding option to `_config.yml`.
 
 ```
 ---
 searchgov:
   endpoint: https://search.gov  # You should not change this.
-  affiliate: pages-uswds-example # replace this with your search.gov account 
+  affiliate: pages-uswds-example # replace this with your search.gov account
   access_key: your-access-key # This is placeholder. Not private.
   inline: true #this renders the results on the same domain. Otherwise, it will render the results in the search.gov domain
 ---
 ```
 
 ## How to edit cloud.gov content
-- Non-developers should focus on editing markdown content in the `_posts`, `_docs`, and `_pages` folder. Generally most of the cloud.gov content will be in the _docs file. 
+- Non-developers should focus on editing markdown content in the `_posts`, `_docs`, and `_pages` folder. Generally most of the cloud.gov content will be in the _docs file.
 
 - Pricing updates can go directly into `_data/pricing.yml` file and if any of the aws services need to be updated that can occur in the `_data/services.yml` file.
 
@@ -78,7 +78,7 @@ searchgov:
     - The `homepage` can be editted more directly by manipulating the `.html` in `home.html`
     - The `pricing` page is mostly edited with the `pricing.html`
     - The `getting-started` page is in the `_pages/sign-up.md` folder.
-    
+
 - `_layouts/` may require the least amount of editing of all the files since they are primarily responsible for printing the content.
 
 - `search/index.html` is used by search.gov.
@@ -104,7 +104,7 @@ Note that when built by cloud.gov Pages, `npm run pages` is used instead of the
     npm start
 ```
 
-Open your web browser to [localhost:4000](http://localhost:4000/) to view your
+Open your web browser to [localhost:3000](http://localhost:3000/) to view your
 site.
 
 ### Testing
@@ -133,13 +133,13 @@ To run `lychee` locally, use the `link-checker` npm script:
 
 ```shell
 # can use any globbing pattern or filepath
-GITHUB_TOKEN=<your-github-token> npm run link-checker -- ./_site/**/*.html 
+GITHUB_TOKEN=<your-github-token> npm run link-checker -- ./_site/**/*.html
 ```
 
 You can also use multiple patterns/filepaths:
 
 ```shell
-GITHUB_TOKEN=<your-github-token> npm run link-checker -- ./*.md ./_site/**/*.html 
+GITHUB_TOKEN=<your-github-token> npm run link-checker -- ./*.md ./_site/**/*.html
 ```
 
 Including a `GITHUB_TOKEN` environment variable will reduce the number of 429 responses returned by GitHub, since
@@ -152,7 +152,7 @@ review and address any errors.
 
 - [Jekyll](https://jekyllrb.com/docs/) - The primary site engine that builds your code and content.
 - [Front Matter](https://jekyllrb.com/docs/frontmatter) - The top of each page/post includes keywords within `--` tags. This is meta data that helps Jekyll build the site, but you can also use it to pass custom variables.
-- [U.S. Web Design System v 2.0](https://v2.designsystem.digital.gov) 
+- [U.S. Web Design System v 2.0](https://v2.designsystem.digital.gov)
 
 ## Contributing
 

--- a/_docs/ops/security-ir.md
+++ b/_docs/ops/security-ir.md
@@ -59,7 +59,7 @@ For full details, read on.
 
 ### Initiate
 
-An incident begins when someone becomes aware of a potential incident. We define "incident" broadly, following [NIST SP 800-61](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf), as "a violation or imminent threat of violation of computer security policies, acceptable use policies, or standard security practices" (6). This is a deliberately broad definition, designed to encompass any scenario that might threaten the security of cloud.gov.
+An incident begins when someone becomes aware of a potential incident. We define "incident" broadly, following [NIST SP 800-61](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf), as "a violation or imminent threat of violation of computer security policies, acceptable use policies, or standard security practices" (6). This is a deliberately broad definition, designed to encompass any scenario that might threaten the security of cloud.gov.
 
 When a person outside the cloud.gov team (the *reporter*) notices a cloud.gov-related incident, they should begin reporting it by using the [TTS incident response process](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/security-incidents/), and then post about it in [`#cloud-gov`](https://gsa-tts.slack.com/messages/cloud-gov/) using `@cg-team`. If they don't get acknowledgment from the cloud.gov team right away, they should escalate by contacting the cloud.gov leads directly until they receive acknowledgment of their report.
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,7 @@ This appears at the top of the page letting the user know it's an official gover
 
 <div class="page-landing-page layout-demo ">
   <a class="usa-skipnav" href="#main-content">Skip to main content</a>
-  {% if page.sidenav == true or page.sidenav == "pages-documentation" %}
+  {% if page.sidenav %}
       <a class="usa-skipnav" href="#section-nav">Skip to section navigation</a>
   {% endif %}
   <div class="site-banner usa-banner">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,6 +4,9 @@ This appears at the top of the page letting the user know it's an official gover
 
 <div class="page-landing-page layout-demo ">
   <a class="usa-skipnav" href="#main-content">Skip to main content</a>
+  {% if page.sidenav == true or page.sidenav == "pages-documentation" %}
+      <a class="usa-skipnav" href="#section-nav">Skip to section navigation</a>
+  {% endif %}
   <div class="site-banner usa-banner">
     <div class="usa-accordion">
       <header class="usa-banner__header">

--- a/_includes/pages/sidenav.html
+++ b/_includes/pages/sidenav.html
@@ -1,9 +1,9 @@
-{%- comment -%} 
+{%- comment -%}
 The sidenav is not loaded by default on the main pages. To include this navigation you can either use the
 _layouts/page.html layout template, or you can add "sidenav: true" in the front-matter of your pages
 {%- endcomment -%}
 
-<aside class="usa-layout-docs-sidenav desktop:grid-col-4 padding-bottom-4">
+<aside id="section-nav" class="usa-layout-docs-sidenav desktop:grid-col-4 padding-bottom-4">
   <nav>
     <ul class="usa-sidenav">
       {% for nav_section in site.data.pages.navigation.sidenav %}

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,12 +1,12 @@
-{%- comment -%} 
+{%- comment -%}
 The sidenav is not loaded by default on the main pages. To include this navigation you can either use the
 _layouts/page.html layout template, or you can add "sidenav: true" in the front-matter of your pages
 {%- endcomment -%}
 
-<aside class="usa-layout-docs-sidenav desktop:grid-col-4 padding-bottom-4">
+<aside id="section-nav" class="usa-layout-docs-sidenav desktop:grid-col-4 padding-bottom-4">
   <nav>
     <ul class="usa-sidenav">
-      
+
       {%- for nav_item in include.documentation_navigation -%}
       {%- assign nav_id = 'side-nav-' | append: nav_item.identifier -%}
 
@@ -21,7 +21,7 @@ _layouts/page.html layout template, or you can add "sidenav: true" in the front-
           {%- endif -%}
           {{ nav_item.name | escape }}
         </a>
-      
+
         <ul class="usa-sidenav__sublist {% if relevant_parent != nav_item.identifier %}display-none{% endif %}"
          id="{{ nav_id }}" aria-hidden="true">
         {%- unless nav_item.children -%}
@@ -57,7 +57,7 @@ _layouts/page.html layout template, or you can add "sidenav: true" in the front-
         </ul>
       </li>
 
-      
+
       {%- endfor -%}
     </ul>
   </nav>

--- a/_layouts/data.html
+++ b/_layouts/data.html
@@ -7,7 +7,7 @@ This is an example showing how you can load date from the _data/ folder
 {% endcomment %}
 
 
-<div class="usa-layout-docs usa-section">
+<div id="main-content" class="usa-layout-docs usa-section">
   <div class="grid-container">
     <div class="grid-row grid-gap">
       <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@ The home page uses wide.html layout, since it extends full width of page
 
 <body>
   {% include header.html %}
-  
+
   {% case page.navigation %}
     {% when "pages" %}
       {% include menu.html primary_navigation=site.data.pages.navigation.primary  secondary_navigation=site.data.pages.navigation.secondary %}
@@ -19,7 +19,7 @@ The home page uses wide.html layout, since it extends full width of page
       {% include menu.html primary_navigation=site.primary_navigation  secondary_navigation=site.secondary_navigation %}
   {% endcase %}
 
-  <main id="main-content">
+  <main>
     {{ content }}
   </main>
 

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -16,17 +16,17 @@ This template is for a single page that does not have a date associated with it.
           {% include pages/sidenav.html %}
       {% endcase %}
 
-      <div class="usa-layout-docs__main desktop:grid-col-8 usa-prose bg-white padding-y-8 padding-x-4">
+      <div id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose bg-white padding-y-8 padding-x-4">
         <h1>{{ page.title }}</h1>
         {{ content }}
-        
-        
+
+
         <div class="grid-row">
           <div class="grid-col flex-4"></div>
           <div class="grid-col flex-1"><p><a href="{{ site.github_url }}/edit/{{ site.github_branch }}/{{ page.relative_path }}">Suggest edits</a></p></div>
         </div>
-        
-        
+
+
       </div>
     </div>
   </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,7 +6,7 @@ layout: default
 This template is for a single page that does not have a date associated with it. For example, an about page.
 {% endcomment %}
 
-<div class="usa-layout-docs usa-section {{ page.bg-color-class }}">
+<div id="main-content" class="usa-layout-docs usa-section {{ page.bg-color-class }}">
   <div class="grid-container maxw-desktop">
     {{ content }}
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ layout: default
 This is used in blog posts. The index page can be found at blog/index.html
 {% endcomment %}
 
-<div class="usa-layout-docs usa-section">
+<div id="main-content" class="usa-layout-docs usa-section">
   <div class="grid-container maxw-desktop">
     <div class="grid-row grid-gap">
       <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">

--- a/_layouts/wide.html
+++ b/_layouts/wide.html
@@ -6,4 +6,6 @@ layout: default
 This template is used when you want to fill the width of the page. By default, it's only used in the homepage
 {% endcomment %}
 
+<div id="main-content">
 {{ content }}
+</div>

--- a/_pages/pages/documentation/customer-responsibilities.md
+++ b/_pages/pages/documentation/customer-responsibilities.md
@@ -21,7 +21,7 @@ GitHub is used across the government (see [this dashboard](https://gsa.github.io
 
 #### You own your content
 
-Pages provides templates for you to start with in configuring your sites, but is not responsible for editing or updating the content or local configuration of your site. The Pages team ensures that the publishing mechanism remains available to you so that your content edits can be published within minutes. Your content must be low impact according to [FIPS 199](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.199.pdf) and each branch on GitHub is published publicly by Pages. Pages is not suitable for hosting the following types of information:
+Pages provides templates for you to start with in configuring your sites, but is not responsible for editing or updating the content or local configuration of your site. The Pages team ensures that the publishing mechanism remains available to you so that your content edits can be published within minutes. Your content must be low impact according to [FIPS 199](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.199.pdf) and each branch on GitHub is published publicly by Pages. Pages is not suitable for hosting the following types of information:
 - PII (Personally Identifiable Information)
 - FOUO (For Official Use Only)
 - CUI (Confidential Unclassified Information)


### PR DESCRIPTION
This is work to address #2320, an issue which I discovered in work on cloud-gov/product#2493:

- The `#main-content` ID, which is the target of the "Skip to main content" skip link, is assigned on `<main>` 
- On pages where the sidenav is rendered (cloud.gov Pages documentation and cloud.gov documentation sections) the existing skip link takes users to the top of the sidenav `<aside>`, which is a long list of links they have to tab through before reaching the `<h1>` and the page content.

## Changes proposed in this pull request:
- The `#main-content` ID has been moved a step inward to a container which does _not_ contain the sidenav `<aside>` but still contains the `<h1>` and page content.
- On pages where the sidenav is rendered (cloud.gov Pages documentation and cloud.gov documentation sections) an additional skip link is included, "Skip to section navigation"

Also, unrelated to accessibility, but wrapped up here for convenience because they're such small changes:
- the README now indicates the new port (3000) instead of the old port (4000) for local developer preview of this site.
- two links from documentation pages to NIST URLs had outdated http: protocols, which are changed to https:
- x86_64-linux platform has been added to `Gemfile.lock` to resolve an issue with the link checker

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/2320-add-skip-link)

## Security Considerations
None. This is a navigation and DOM change to a static website.
