### PR TITLE
update s3 broker docs with notes about setting object ownership

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 -
 
 <!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
-:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)
+:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)
 
 
 ## Security Considerations

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -19,15 +19,13 @@ https://username:password
 https://example.gov
 .*\.us-gov-west-1.vpce.amazonaws.com
 https://www.congress.gov/bill/.*
+https://www.pivotaltracker.com/story/show/.*
 
 # URLs with no known replacements
 https://fugacious.18f.gov/
 https://www.digitalgov.gov/event/hands-on-workshop-with-cloud-gov/
 https://www.fedramp.gov/assets/resources/documents/CSP_Digital_Identity_Requirements.pdf
 https://www.dta.gov.au/what-we-do/platforms/cloud/
-https://www.pivotaltracker.com/story/show/180851852
-https://www.pivotaltracker.com/story/show/180851850
-https://www.pivotaltracker.com/story/show/183724805
 https://www.fedramp.gov/assets/resources/documents/CSP_TLS_Requirements.pdf
 http://docs.cloudfoundry.org/deploying/aws/cf-stub.html
 http://docs.cloudfoundry.org/deploying/common/consul-security.html

--- a/_docs/services/s3.md
+++ b/_docs/services/s3.md
@@ -52,7 +52,8 @@ Name               | Description                                                
 To create a bucket using the `BucketOwnerEnforced` object ownership:
 
 ```sh
-cf create-service s3 basic -c '{"object_ownership": "BucketOwnerEnforced"}'
+cf create-service s3 basic \
+  -c '{"object_ownership": "BucketOwnerEnforced"}'
 ```
 
 ## How to create an instance for your sandbox

--- a/_docs/services/s3.md
+++ b/_docs/services/s3.md
@@ -45,7 +45,7 @@ These are the optional parameters that you can specify when creating a new bucke
 
 Name               | Description                                                    | Default Value          |
 ---                | ---                                                            | ---                    |
-`object_ownership` | The object ownership strategy to use for the bucket. See <https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html> for more details. Valid values: `ObjectWriter`, `BucketOwnerPreferred`, `BucketOwnerEnforced` | `ObjectWriter`
+`object_ownership` | [The object ownership strategy](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html) to use for the bucket. Valid values: `ObjectWriter`, `BucketOwnerPreferred`, `BucketOwnerEnforced` | `ObjectWriter`
 
 #### Examples of optional parameters
 

--- a/_docs/services/s3.md
+++ b/_docs/services/s3.md
@@ -14,18 +14,18 @@ You can store application content in S3 using a [managed service]({{ site.baseur
 
 ## Plans
 
-Plan Name | Description | 
+Plan Name | Description |
 --------- | ----------- | -----
-`basic`   | A single private bucket  | 
-`basic-public` | A single public bucket, where the files are **all public** to read | 
-`basic-sandbox` | Similar plan as `basic`, but bucket is deleted when `cf delete-service <SERVICE-INSTANCE-NAME>` is executed | 
-`basic-public-sandbox` | Similar plan as `basic-public`, but bucket is deleted when `cf delete-service <SERVICE-INSTANCE-NAME>` is executed | 
+`basic`   | A single private bucket  |
+`basic-public` | A single public bucket, where the files are **all public** to read |
+`basic-sandbox` | Similar plan as `basic`, but bucket is deleted when `cf delete-service <SERVICE-INSTANCE-NAME>` is executed |
+`basic-public-sandbox` | Similar plan as `basic-public`, but bucket is deleted when `cf delete-service <SERVICE-INSTANCE-NAME>` is executed |
 
 *Additional Cost:* All buckets have a limit of 5TB in storage. After 5TB, each additional terabyte will cost $100 per month.
 
 ## How to create an instance
 
-First decide if the S3 bucket contents should be private or public. Objects placed in a private bucket are only accessible using the bucket credentials unless specifically [shared with others](http://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html). Objects placed in a public bucket are accessible to anyone with the link. 
+First decide if the S3 bucket contents should be private or public. Objects placed in a private bucket are only accessible using the bucket credentials unless specifically [shared with others](http://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html). Objects placed in a public bucket are accessible to anyone with the link.
 
 To create a private bucket use the `basic` plan:
 
@@ -37,6 +37,22 @@ To create a public bucket use the `basic-public` plan:
 
 ```sh
 cf create-service s3 basic-public <SERVICE_INSTANCE_NAME>
+```
+
+### Setting optional parameters
+
+These are the optional parameters that you can specify when creating a new bucket:
+
+Name               | Description                                                    | Default Value          |
+---                | ---                                                            | ---                    |
+`object_ownership` | The object ownership strategy to use for the bucket. See <https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html> for more details. Valid values: `ObjectWriter`, `BucketOwnerPreferred`, `BucketOwnerEnforced` | `ObjectWriter`
+
+#### Examples of optional parameters
+
+To create a bucket using the `BucketOwnerEnforced` object ownership:
+
+```sh
+cf create-service s3 basic -c '{"object_ownership": "BucketOwnerEnforced"}'
 ```
 
 ## How to create an instance for your sandbox
@@ -72,13 +88,13 @@ cf bind-service <APP_NAME> \
     -c '{"additional_instances": ["<ADDITIONAL_SERVICE_INSTANCE_NAME>"]}'
 ```
 
-The credentials created for this binding will have access to both the bucket managed by `<SERVICE_INSTANCE_NAME>` and `<ADDITIONAL_SERVICE_INSTANCE_NAME>`, and the bucket managed by `<ADDITIONAL_SERVICE_INSTANCE_NAME>` will be listed in the `additional_buckets` field of the credentials. 
+The credentials created for this binding will have access to both the bucket managed by `<SERVICE_INSTANCE_NAME>` and `<ADDITIONAL_SERVICE_INSTANCE_NAME>`, and the bucket managed by `<ADDITIONAL_SERVICE_INSTANCE_NAME>` will be listed in the `additional_buckets` field of the credentials.
 
 ### Interacting with your S3 bucket from outside cloud.gov
 
 You may want to use your S3 service as a repository for file transfer between humans, or for communicating content with other systems hosted outside of cloud.gov. You can manage credentials for accessing your S3 bucket using [service keys](https://docs.cloudfoundry.org/devguide/services/service-keys.html). The service key details provide you with the credentials that are used with common file transfer programs by humans or configured in external systems. Typically you would create a unique service key for each external client of the bucket to make it easy to rotate credentials in case they are leaked.
 
-You can create a service key by running `cf create-service-key <SERVICE_INSTANCE_NAME> <KEY_NAME>`. (For example, to create a key for user Bob for the S3 bucket `mybucket`, you would run `cf create-service-key mybucket Bob`.) To later revoke access (eg when no longer required, or when compromised), you can run `cf delete-service-key <SERVICE_INSTANCE_NAME> <KEY_NAME>`. To get the credentials from the service key, you can run `cf service-key <SERVICE_INSTANCE_NAME> <KEY_NAME>`; you will see a JSON description of the credentials. 
+You can create a service key by running `cf create-service-key <SERVICE_INSTANCE_NAME> <KEY_NAME>`. (For example, to create a key for user Bob for the S3 bucket `mybucket`, you would run `cf create-service-key mybucket Bob`.) To later revoke access (eg when no longer required, or when compromised), you can run `cf delete-service-key <SERVICE_INSTANCE_NAME> <KEY_NAME>`. To get the credentials from the service key, you can run `cf service-key <SERVICE_INSTANCE_NAME> <KEY_NAME>`; you will see a JSON description of the credentials.
 
 Clients will need the following information from this JSON description:
 
@@ -87,7 +103,7 @@ Clients will need the following information from this JSON description:
 * `region`
 * `bucket`
 
-Treat these values as sensitive! 
+Treat these values as sensitive!
 
 To create a service key that can access multiple buckets, you can use the `additional_instances` option described above.
 
@@ -106,7 +122,7 @@ For example, you might want to use the [AWS Command Line Interface](https://aws.
 # For example:
 # . ./getcreds.sh
 
-set -e 
+set -e
 
 SERVICE_INSTANCE_NAME=your-s3-service-instance-name-here
 KEY_NAME=your-service-key-name-here
@@ -193,7 +209,7 @@ You can implement a backup scheme by storing your buckets under /data/year/month
 
 ## Encryption
 
-Every AWS S3 Bucket configured through cloud.gov is [encrypted at rest](https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html). We use the industry standard AES-256 encryption algorithm to encrypt your data on the server that hosts your AWS S3 Bucket. 
+Every AWS S3 Bucket configured through cloud.gov is [encrypted at rest](https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html). We use the industry standard AES-256 encryption algorithm to encrypt your data on the server that hosts your AWS S3 Bucket.
 
 ### Rotating credentials
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- update s3 broker docs with notes about setting object ownership

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/preview/cloud-gov/cg-site/update-s3-broker-docs)


## Security Considerations

None