### PR TITLE
Add WAVE to Pages documentation

### DIFF
--- a/_pages/pages/documentation/external-tools-and-resources.md
+++ b/_pages/pages/documentation/external-tools-and-resources.md
@@ -59,6 +59,8 @@ These tools run against the site to make it more accessible and improve the user
 - [Pa11y CI](https://github.com/pa11y/pa11y-ci)
 - [Axe](https://www.deque.com/axe/)
 
+WebAIM's [WAVE tools](https://wave.webaim.org/) analyze an individual page for accessibility issues. Extensions are available for several major browsers to allow a WAVE scan to be run against the currently-viewed page.
+
 ### Other
 
 Here are some additional tools customers could add to improve their site.

--- a/_pages/pages/documentation/external-tools-and-resources.md
+++ b/_pages/pages/documentation/external-tools-and-resources.md
@@ -59,7 +59,9 @@ These tools run against the site to make it more accessible and improve the user
 - [Pa11y CI](https://github.com/pa11y/pa11y-ci)
 - [Axe](https://www.deque.com/axe/)
 
-WebAIM's [WAVE tools](https://wave.webaim.org/) analyze an individual page for accessibility issues. Extensions are available for several major browsers to allow a WAVE scan to be run against the currently-viewed page.
+These tools do detailed scans of an individual page, and can be run from a web browser extension or bookmarklet:
+- [WAVE tools](https://wave.webaim.org/)
+- [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html)
 
 ### Other
 


### PR DESCRIPTION
This PR addresses #2312 

## Changes proposed in this pull request:
- Add WebAIM's [WAVE tools](https://wave.webaim.org/) to the list of external tools and resources in the Pages documentation 

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/2312-add-wave-to-pages-docs)

## Security Considerations
None. This is a content change intended to make users aware of a potentially helpful resource. 

