### PR TITLE
Remove "single port" rubric

### DIFF
--- a/_docs/overview/portfolio-analysis.md
+++ b/_docs/overview/portfolio-analysis.md
@@ -70,7 +70,7 @@ Ideal applications follow as many of the [12-Factor App](https://12factor.net/) 
 1. **Backing services**: Does the application retry or fail gracefully if a service it connects to is unavailable?
 1. **Build, release, run**: Can you build the deployment artifacts outside of the deployment environment, for example in a continuous deployment system?
 1. **Processes**: Does the application keep its state in a backing service, rather than shared memory or filesystem?
-1. **Port binding**: Does the application listen for requests over HTTP on a single port?
+1. **Port binding**: Does the application listen for requests over HTTP?
   - Applications that only accept requests over straight TCP are also possible, but may require additional work on the cloud.gov side to get going.
 1. **Concurrency**: Does the application scale correctly without modification when you run additional instances of it behind a load-balancer?
   - Applications that require instances to be aware of each other are also possible, but may require additional work to configure correctly.


### PR DESCRIPTION
Now that [Cloud Foundry applications can listen on multiple/custom ports](https://docs.cloudfoundry.org/devguide/custom-ports.html), this guidance is outdated and should be removed to avoid dissuading potential customers that have apps which listen on multiple ports.

## Changes proposed in this pull request:
- Remove phrase which implies less flexibility than is actually there.

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/patch-12)


## Security Considerations

None, just a text change.