### PR TITLE
Update aws-elasticsearch.md

### DIFF
--- a/_docs/services/aws-elasticsearch.md
+++ b/_docs/services/aws-elasticsearch.md
@@ -52,7 +52,7 @@ cf create-service aws-elasticsearch es-medium my-elastic-service
 Note: AWS Elasticsearch creation times will vary and is outside of Cloud.gov's control. AWS says approximately 15-30 mins per node.
 
 ## Changing instance plans
-Please note that you can only update to a larger plan size. Downgrading to a smaller plan size is not supported.
+Please note that you cannot use the broker to update the instance plan at this time.
 
 ## Options
 

--- a/_docs/services/aws-elasticsearch.md
+++ b/_docs/services/aws-elasticsearch.md
@@ -51,6 +51,9 @@ cf create-service aws-elasticsearch es-medium my-elastic-service
 
 Note: AWS Elasticsearch creation times will vary and is outside of Cloud.gov's control. AWS says approximately 15-30 mins per node.
 
+## Changing instance plans
+Please note that you can only update to a larger plan size. Downgrading to a smaller plan size is not supported.
+
 ## Options
 
 name             | required | description              | example


### PR DESCRIPTION
Adding that customers can only update to a larger plan size, updating to a smaller plan size is not supported.

## Changes proposed in this pull request:
-Improving documentation to list that changing to smaller plan sizes are not supported.
-
-

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/ArsHaider-patch-1)


## Security Considerations
None, simply improving documentation.
