### PR TITLE
Announce MySQL 5.7 deprecation

### DIFF
--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -114,7 +114,7 @@ Name               | Description                                                
 A couple of notes regarding the optional `version` parameter:
 
 - It is currently only supported for dedicated MySQL and PostgreSQL instances; if you specify it for any other type of instance it is ignored.
-- It only supports major version numbers; if you specify a minor/patch level version, e.g., "11.8" for PostgreSQL or "5.7.22" for MySQL, the command will fail.
+- It only supports major version numbers (e.g. "8.0"); if you specify a minor/patch level version (e.g., "11.8" for PostgreSQL or "8.0.32" for MySQL), the command will fail.
 - The version number must be provided in double quotes (`"`); this is because the value is treated as a string to account for different engine types and version schemes.
 
 These are the current supported major versions for PostgreSQL:
@@ -125,7 +125,6 @@ These are the current supported major versions for PostgreSQL:
 
 These are the current supported major versions for MySQL:
 
-- 5.7
 - 8.0
 
 The `backup_retention_period` can be no less than 14 days but extended up to 35 days.

--- a/_posts/2023-06-01-aws-ending-support-mysql-57.md
+++ b/_posts/2023-06-01-aws-ending-support-mysql-57.md
@@ -43,3 +43,5 @@ To upgrade your existing MySQL 5.7 database to MySQL 8.0:
   ```shell
   cg-manage-rds import -f backup.sql <mysql80-database-name>
   ```
+
+If you have any issues with this process, please contact [support@cloud.gov](mailto:support@cloud.gov).

--- a/_posts/2023-06-01-aws-ending-support-mysql-57.md
+++ b/_posts/2023-06-01-aws-ending-support-mysql-57.md
@@ -1,0 +1,45 @@
+---
+layout: post
+title: Upgrade your databases - AWS ending support for MySQL 5.7 in December 2023
+date: June 1, 2023
+excerpt: "AWS is ending support for MySQL 5.7 databases starting in December 2023. Read on for instructions for how to upgrade your brokered databases."
+---
+
+[AWS RDS is ending support for MySQL versions 5.7.x starting in December 2023](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html).
+
+## What this means for you
+
+As a cloud.gov customer, if you are running a MySQL 5.7 database, then you will need to upgrade that database to at least MySQL version 8.0 by December 2023. **Affected customers will receive direct outreach from the cloud.gov team.**
+
+To upgrade your database from MySQL 5.7 to 8.0, see the [guidance below](#how-to-upgrade).
+
+If you do not upgrade your database by December 2023, then AWS will automatically upgrade your database to the next supported major version (currently 8.0) during the next maintenance window for your database.
+
+## Updates to brokered database plans
+
+As of today, June 1, 2023, it is no longer possible to create an RDS database using MySQL version 5.7 for any of the `mysql` plans in the marketplace. By default, version "8.0" will be used for new MySQL databases.
+
+You can find more information about creating/updating RDS databases on [our database services documentation](({{ site.baseurl }}{% link _docs/services/relational-database.md %})).
+
+## How to upgrade
+
+To upgrade your existing MySQL 5.7 database to MySQL 8.0:
+
+1. Target your organization and space
+1. Create a new database service using the same database plan as your MySQL 5.7 database:
+
+  ```shell
+  cf create-service aws-rds <plan-name> <mysql-80-database-name>
+  ```
+
+1. Use the [`cg-manage-rds` plugin](https://github.com/cloud-gov/cg-manage-rds#usage) to export a backup of your MySQL 5.7 database:
+
+  ```shell
+  cg-manage-rds export -f backup.sql <mysql57-database-name>
+  ```
+
+1. Import the backup into your MySQL 8.0 database:
+
+  ```shell
+  cg-manage-rds import -f backup.sql <mysql80-database-name>
+  ```

--- a/_posts/2023-06-05-aws-ending-support-mysql-57.md
+++ b/_posts/2023-06-05-aws-ending-support-mysql-57.md
@@ -33,7 +33,12 @@ You can find more information about creating/updating RDS databases on [our data
 
 To upgrade your existing MySQL 5.7 database to MySQL 8.0:
 
-1. Target your organization and space
+1. Target your organization and space:
+
+    ```sh
+    cf target -o <ORG> -s <SPACE>
+    ```
+
 1. Create a new database service using the same database plan as your MySQL 5.7 database:
 
     ```shell

--- a/_posts/2023-06-05-aws-ending-support-mysql-57.md
+++ b/_posts/2023-06-05-aws-ending-support-mysql-57.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Upgrade your databases - AWS ending support for MySQL 5.7 in December 2023
-date: June 1, 2023
+date: June 5, 2023
 excerpt: "AWS is ending support for MySQL 5.7 databases starting in December 2023. Read on for instructions for how to upgrade your brokered databases."
 ---
 
@@ -15,9 +15,17 @@ To upgrade your database from MySQL 5.7 to 8.0, see the [guidance below](#how-to
 
 If you do not upgrade your database by December 2023, then AWS will automatically upgrade your database to the next supported major version (currently 8.0) during the next maintenance window for your database.
 
+## Important dates
+
+|When|What|
+|-|-|
+| **June 5, 2023** | MySQL 5.7 databases can no longer be created on cloud.gov |
+| **June 5 2023 - December 2023** | Window for customers to self-upgrade their MySQL databases to 8.0 |
+| **December 2023** | MySQL 5.7 databases are fully deprecated by AWS. Any remaining databases are auto-upgraded to the next supported major version. |
+
 ## Updates to brokered database plans
 
-As of today, June 1, 2023, it is no longer possible to create an RDS database using MySQL version 5.7 for any of the `mysql` plans in the marketplace. By default, version "8.0" will be used for new MySQL databases.
+As of today, June 5, 2023, it is no longer possible to create an RDS database using MySQL version 5.7 for any of the `mysql` plans in the marketplace. By default, version "8.0" will be used for new MySQL databases.
 
 You can find more information about creating/updating RDS databases on [our database services documentation](({{ site.baseurl }}{% link _docs/services/relational-database.md %})).
 
@@ -28,20 +36,46 @@ To upgrade your existing MySQL 5.7 database to MySQL 8.0:
 1. Target your organization and space
 1. Create a new database service using the same database plan as your MySQL 5.7 database:
 
-  ```shell
-  cf create-service aws-rds <plan-name> <mysql-80-database-name>
-  ```
+    ```shell
+    cf create-service aws-rds <plan-name> <mysql-80-database-name>
+    ```
 
 1. Use the [`cg-manage-rds` plugin](https://github.com/cloud-gov/cg-manage-rds#usage) to export a backup of your MySQL 5.7 database:
 
-  ```shell
-  cg-manage-rds export -f backup.sql <mysql57-database-name>
-  ```
+    ```shell
+    cg-manage-rds export -f backup.sql <mysql57-database-name>
+    ```
 
 1. Import the backup into your MySQL 8.0 database:
 
-  ```shell
-  cg-manage-rds import -f backup.sql <mysql80-database-name>
-  ```
+    ```shell
+    cg-manage-rds import -f backup.sql <mysql80-database-name>
+    ```
+
+1. Optionally, use the [`cf-service-connect` plugin](https://github.com/cloud-gov/cf-service-connect) to connect to your MySQL 8.0 database and verify that it contains the expected data:
+
+    ```shell
+    cf connect-to-service <app-name> <mysql80-database-name>
+    ```
+
+1. Bind your MySQL 8.0 database to your application:
+
+    ```shell
+    cf bind-service <app-name> <mysql80-database-name>
+    ```
+
+1. Unbind your MySQL 5.7 database from your application:
+
+    ```shell
+    cf unbind-service <app-name> <mysql57-database-name>
+    ```
+
+1. Restage your application (the `--rolling` flag is optional but ensures no downtime):
+
+    ```shell
+    cf restage <app-name> --rolling
+    ```
+
+1. Verify that your application is still working and operating with the expected data.
 
 If you have any issues with this process, please contact [support@cloud.gov](mailto:support@cloud.gov).


### PR DESCRIPTION
Related to https://github.com/cloud-gov/aws-broker/issues/302

## Changes proposed in this pull request:

- Announce deprecation of MySQL 5.7 and outline upgrade steps
- Update RDS documentation to remove references to MySQL 5.7

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/announce-mysql57-deprecation)


## Security Considerations

None
