### PR TITLE
Reference security.txt in our contact page

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -19,7 +19,8 @@ If you have a U.S. federal government email address, you can [get access to a fr
 
 Email [**support@cloud.gov**](mailto:support@cloud.gov?body=What%20are%20you%20trying%20to%20do%3F%0A%0AWhat%20do%20you%20expect%20to%20happen%3F%0A%0AWhat%20actually%20happened%3F%0A%0AAttach%20relevant%20logs%20or%20screenshots%20%28remove%20sensitive%20information%29%3A). We provide support during business hours for U.S. East and West Coasts. We don't guarantee support outside those hours, though we're always monitoring for issues that might affect customers.
 
-If you need help with an application security incident, the request should come from the System Owner or Org Manager, to help us validate the request.
+If you need help with an application security incident, the request should come from the System Owner or Org Manager, to help us validate the request. For an active incident, refer to our
+standard (security.txt)[{{ site.baseurl }}/.well-known/security.txt] file.
 
 You should not include any passwords or sensitive environment variables in your email (we don't need them to help you, and you should keep them protected).
 


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Reference security.txt in our /contact page
-

<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/peterb-add-security-txt-ref)


## Security Considerations
None. Adding reference to already public information.
