### PR TITLE
Remove GSA ATO offering from pricing page

### DIFF
--- a/_pages/pages/pricing.md
+++ b/_pages/pages/pricing.md
@@ -13,7 +13,6 @@ title: cloud.gov Pages - Pricing
     <p class="usa-intro">Included in subscription:</p>
     <ul>
       <li>U.S. Web Design System Starter kits in Javascript and Ruby with built-in integrations with Search.gov and GSA Digital Analytics Program to get your site running within minutes.</li>
-      <li>GSA-maintained GSA Authority to Operate (ATO) for all your sites.</li>
       <li>Automated tests and previews before going live.</li>
       <li>Web-based configuration page for managing individual sites.</li>
       <li>Highly scalable content delivery network (CDN) to ensure uptime.</li>


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove GSA ATO offering from pricing page

:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/drewbo-patch-1)


## Security Considerations
None