### PR TITLE
Remove preview link from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,9 +3,5 @@
 -
 -
 
-<!-- Replace "BRANCH_NAME" in the following URL before you submit this PR. -->
-:sunglasses:[PREVIEW URL](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/BRANCH_NAME)
-
-
 ## Security Considerations
 [Note the any security considerations here, or make note of why there are none]


### PR DESCRIPTION
The Preview link appears in the `pages/build` check when the build is complete

## Changes proposed in this pull request:
- Remove preview link from PR template


## Security Considerations
None