### PR TITLE
update PMO guidance on KEVs

### DIFF
--- a/_posts/2021-11-15-dhs-bod-22-01.md
+++ b/_posts/2021-11-15-dhs-bod-22-01.md
@@ -18,8 +18,10 @@ For cloud.gov customers, there are three responsibility realms with respect to K
     - Some past buildpacks are known to include KEVs. If you have re-staged or updated your application after November 10, 2021, then you do not have any buildpack-level KEVs.
     - In the future, we will review updates to the DHS KEV list, and will notify customers when you need to restage your app to mitigate the vulnerability.
 
-* **cloud.gov responsibility**: Ensuring the entire underlying infrastructure of our platform does not include KEVs. We do not publicly confirm nor deny our status with respect to DHS BODs, but you can open a support request for more information.
+* **cloud.gov responsibility**: It's cloud.gov's responsibility to ensure there are no KEVs within our underlying infrastructure. We do not publicly confirm nor deny our status with respect to DHS BODs, nor can we provide updates via the FedRAMP Max.gov repository (per PMO guidance). If you need more information, please open a [cloud.gov support request]({{site.baseurl}}/contact/#support-for-people-who-use-cloudgov).
 
 PHP buildpack users: The [PHP buildpack](https://github.com/cloudfoundry/php-buildpack/releases) v4.4.46 (released on cloud.gov October 13, 2021) included Apache httpd 2.4.49, which is on the KEV list. Our release of PHP buildpack v4.4.49 on November 10, 2021, included the patched httpd. Customers using the PHP buildpack should restage their applications, if they have not already, so PHP apps will use the updated buildpack. 
 
 The related CVE, [CVE-2021-41773](https://nvd.nist.gov/vuln/detail/CVE-2021-41773) was **not exploitable on cloud.gov** unless a customer took the unusual steps of overriding the default values of the PHP buildpack, as [described more fully in the Cloud Foundry documentation](https://docs.cloudfoundry.org/buildpacks/php/gsg-php-config.html), by changing settings in `httpd-directories.conf` and `httpd-modules.conf`.
+
+Version information: Originally published 2021-11-15, updated 2023-06-12 to clarify PMO guidance on notifications.


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- PMO notified us we can't use max.gov to update customers on KEV status, only on the POA&M status report (which isn't available to them). "That information should remain within your POA&M and not be posted."

## Security Considerations
Clarifying how we share vuln info, no risk.
