### PR TITLE
fix formatting of external domain broker DNS record instructions

### DIFF
--- a/_docs/overview/cloudgov-team.md
+++ b/_docs/overview/cloudgov-team.md
@@ -16,7 +16,7 @@ redirect_from:
 
 ---
 
-cloud.gov is built and maintained by a team within the U.S. General Services Administration’s [Technology Transformation Service](http://www.gsa.gov/portal/category/25729) portfolio. cloud.gov is a cost-recoverable service funded by charging a fee to the teams that use it.
+cloud.gov is built and maintained by a team within the U.S. General Services Administration’s [Technology Transformation Service](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services) portfolio. cloud.gov is a cost-recoverable service funded by charging a fee to the teams that use it.
 
 Our mission is broader than making it easier for government agencies to adopt cloud deployment. The mission of cloud.gov is to enable agencies to deliver services to the public as fast as they can develop them while applying best practices in security and compliance with minimal effort.
 
@@ -26,7 +26,7 @@ As an agile project, cloud.gov is always under development. We periodically ask 
 
 18F was founded in 2014 and has been deploying new products since soon after. As 18F scaled up the number of teams, it became clear that cloud operations could be a bottleneck. The list of good practices for government digital services introduced by law and federal agency requirements was far greater than the accompanying support implementers need to do them efficiently.
 
-To solve the bottleneck problem, 18F focused on technical operations that could act as force-multipliers for each team, including stronger cloud operations. cloud.gov emerged from this focus. The first prototype of the platform took about three months to complete, and teams began to deploy their work to production about a month after that. Today, it is a product managed outside of 18F that is available to [other government agencies]({{ site.baseurl }}{% link _docs/overview/who-can-use-cloudgov.md %}). 
+To solve the bottleneck problem, 18F focused on technical operations that could act as force-multipliers for each team, including stronger cloud operations. cloud.gov emerged from this focus. The first prototype of the platform took about three months to complete, and teams began to deploy their work to production about a month after that. Today, it is a product managed outside of 18F that is available to [other government agencies]({{ site.baseurl }}{% link _docs/overview/who-can-use-cloudgov.md %}).
 
 One of our goals for cloud.gov is to give other agencies access to the same gains in productivity that 18F and other parts of TTS have seen from using cloud.gov. By making the model available for other agencies, as well as making it replicable as an open source project, we hope to increase the efficiency with which any agency can deliver digital services. The potential economy of scale is huge.
 

--- a/_docs/services/external-domain-service.md
+++ b/_docs/services/external-domain-service.md
@@ -92,51 +92,79 @@ cf create-service external-domain domain-with-cdn -c '{"path": "/some/path"}'
 
 ## How to create an instance of this service
 
-1. For each of the domains you want to add to the service, create a DNS CNAME or ALIAS record for this name:
+1. For each of the domains you want to add to the service, create a DNS CNAME or ALIAS record with the name:
 
    ```text
    _acme-challenge.<DOMAIN>.
    ```
 
-   and with this value:
+   and the value:
 
    ```text
    _acme-challenge.<DOMAIN>.external-domains-production.cloud.gov.
    ```
 
-   For example, if you wanted to set up a service for `www.example.gov` and `example.gov`,
-   you'd start by creating the CNAME or ALIAS records:
+   For example, if you wanted to set up a service for `www.example.gov`, you would create a CNAME or ALIAS record with the name:
 
-   ```shell
-   _acme-challenge.example.gov. # record name
-   _acme-challenge.example.gov.external-domains-production.cloud.gov. # record value
+   ```text
+   _acme-challenge.example.gov.
    ```
 
-   ```shell
-   _acme-challenge.www.example.gov. # record name
-   _acme-challenge.www.example.gov.external-domains-production.cloud.gov. # record value
+   and the value:
+
+   ```text
+   _acme-challenge.example.gov.external-domains-production.cloud.gov.
+   ```
+
+   Or for `example.gov`, you would create a CNAME or ALIAS record with the name:
+
+   ```text
+   _acme-challenge.www.example.gov.
+   ```
+
+   and the value:
+
+   ```text
+   _acme-challenge.www.example.gov.external-domains-production.cloud.gov.
    ```
 
    These records will be validated upon service creation, so be sure to set these up ahead of time.
 
-2. **Optional: Complete this step now only for sites that have not yet launched, or for sites that can withstand downtime.** For each of the domains you want to add to the service, create a DNS CNAME or ALIAS record:
+2. **Optional: Complete this step now only for sites that have not yet launched, or for sites that can withstand downtime.** For each of the domains you want to add to the service, create a DNS CNAME or ALIAS record with the name:
 
-   ```shell
-   <DOMAIN> # record name
-   <DOMAIN>.external-domains-production.cloud.gov. # record value
+   ```text
+   <DOMAIN>.
+   ```
+
+   and the value:
+
+   ```text
+   <DOMAIN>.external-domains-production.cloud.gov.
    ```
 
    For example, if you wanted to set up a service for
-   `www.example.gov` and `example.gov`, you'd create these CNAME/ALIAS records:
+   `www.example.gov`, you would create a CNAME or ALIAS record with the name:
 
-   ```shell
-   www.example.gov. # record name
-   www.example.gov.external-domains-production.cloud.gov. # record value
+   ```text
+   www.example.gov.
    ```
 
-   ```shell
-   example.gov. # record name
-   example.gov.external-domains-production.cloud.gov. # record value
+   and the value:
+
+   ```text
+   www.example.gov.external-domains-production.cloud.gov.
+   ```
+
+   Or, for `example.gov`, you would create a CNAME or ALIAS record with the name:
+
+   ```text
+   example.gov.
+   ```
+
+   and the value:
+
+   ```text
+   example.gov.external-domains-production.cloud.gov.
    ```
 
 3. Create the cf domain for each of the domains you are adding to the service:


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix formatting of external domain broker DNS record instructions that leading underscores are not obscured

Compare https://cloud.gov/docs/services/external-domain-service/#how-to-create-an-instance-of-this-service

to

https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/fix-external-domain-doc-formatting/docs/services/external-domain-service/#how-to-create-an-instance-of-this-service

Notice that the leading `_` is missing on the current cloud.gov version for the first `_acme-challenge` record mentioned in step 1, which can create confusion and errors for customers

## Security Considerations

None
