### PR TITLE
CORS example should include protocol

### DIFF
--- a/_docs/services/s3.md
+++ b/_docs/services/s3.md
@@ -185,7 +185,7 @@ cat << EOF > cors.json
 {
   "CORSRules": [
     {
-      "AllowedOrigins": ["otherapp.hostname.gov", "anotherapp.hostname.com"],
+      "AllowedOrigins": ["https://otherapp.hostname.gov", "https://anotherapp.hostname.com"],
       "AllowedHeaders": ["*"],
       "AllowedMethods": ["HEAD", "GET"],
       "ExposeHeaders": ["ETag"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fixes documentation on specifying CORS policy
    AllowedOrigins requires the protocol be specified. Reference: 
    https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManageCorsUsing.html#cors-allowed-origin

## Security Considerations

None, this is a change in documentation that doesn't affect any running system.