### PR TITLE
Remove link to obsolete Pages contact form, and also fix two broken links

### DIFF
--- a/_docs/deployment/deployment.md
+++ b/_docs/deployment/deployment.md
@@ -3,7 +3,7 @@ parent: deployment
 layout: docs
 sidenav: true
 title: Basic deployment instructions
-redirect_from: 
+redirect_from:
     - /docs/apps/deployment/
 weight: -100
 ---
@@ -51,7 +51,7 @@ By default, `cf push` will deploy the working state of all the files you have in
 
 ## Next steps on application architecture
 
-1. cloud.gov works best with applications that follow the [Twelve-Factor App](http://12factor.net/) guidelines. This is more of a comprehensive philosophy than a set of requirements, and it helps explain how cloud.gov expects applications to behave.
+1. cloud.gov works best with applications that follow the [Twelve-Factor App](https://12factor.net/) guidelines. This is more of a comprehensive philosophy than a set of requirements, and it helps explain how cloud.gov expects applications to behave.
 1. The Cloud Foundry [Considerations for Designing and Running an Application in the Cloud](https://docs.cloudfoundry.org/devguide/deploy-apps/prepare-to-deploy.html) apply to cloud.gov as well, including more details about the core principles above.
 1. The cloud.gov [production-ready guide]({{ site.baseurl }}{% link _docs/deployment/production-ready.md %}) explains how to prepare your application for success in production on cloud.gov.
 

--- a/_pages/pages/contact.md
+++ b/_pages/pages/contact.md
@@ -10,7 +10,7 @@ title: cloud.gov Pages - Contact
   <h1>Contact</h1>
   <div class="grid-row">
     <h2>Interested in using Pages?</h2>
-    <p>If you’re interested in using Pages at your agency, email the Pages team at <a href="mailto:inquiries@cloud.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20website%20project%20or%20your%20questions%20about%20Pages:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A">inquiries@cloud.gov</a> with your name, agency or office, and information about the website you want to build or migrate. We’ll schedule a call to answer your questions and help you get started. You can also sign up using <a href="https://docs.google.com/forms/d/1S6314RZC3WCGuuNeqozjR-VNyMdn6OS74dVE8f4zXrI/viewform">this Google form</a> if your agency can access Google forms.</p>
+    <p>If you’re interested in using Pages at your agency, email the Pages team at <a href="mailto:inquiries@cloud.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20website%20project%20or%20your%20questions%20about%20Pages:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A">inquiries@cloud.gov</a> with your name, agency or office, and information about the website you want to build or migrate. We’ll schedule a call to answer your questions and help you get started.</p>
   </div>
   <div class="grid-row">
     <h2>For existing Pages users</h2>

--- a/_posts/2021-02-05-cloud-gov_a_different_kind_of_cloud.md
+++ b/_posts/2021-02-05-cloud-gov_a_different_kind_of_cloud.md
@@ -8,7 +8,7 @@ excerpt: The cloud.gov platform acts as a concierge for your cloud deployments,
 ---
 As a program manager or CIO tasked with moving applications to the cloud, one of the first questions you might find yourself faced with is: which cloud should I move to?
 
-One of the many benefits of the continued advancement of cloud technologies is that [there are lots of different cloud deployment and operational models](https://cic.gsa.gov/basics/cloud-basics/) to choose from. And it’s also one of the main drawbacks. 
+One of the many benefits of the continued advancement of cloud technologies is that [there are lots of different cloud deployment and operational models](https://bluexp.netapp.com/blog/cvo-blg-cloud-computing-deployment-models-and-architectures) to choose from. And it’s also one of the main drawbacks. 
 
 Which cloud option is right for your project? Which service model offers the best mix of cost effectiveness, security, and ease of use? 
 


### PR DESCRIPTION
Fixes #2365 as well as two broken links discovered along the way.

## Changes proposed in this pull request:
- Removes an obsolete link to a Pages interest contact form that may not reach anyone able to monitor it.
- Fixes a broken link to 12factor.net that was not using HTTPS.
- Replaces a broken link to a resource describing cloud deployment and operational models. HT to @markdboyd for the replacement link.

## Security Considerations
None. This removes an obsolete link from the website and fixes two broken links.

## Preview

### Removal of contact form:

Pages contact page: [Preview Site](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/2365-remove-old-pages-contact-form/pages/contact/)  / [Live Site](https://cloud.gov/pages/contact/)

### Broken links

Platform deployment documentation: [Preview Site](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/2365-remove-old-pages-contact-form/docs/deployment/deployment/) / [Live Site](https://cloud.gov/docs/deployment/deployment/)

Platform post of 2021-02-05: [Preview Site](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/2365-remove-old-pages-contact-form/2021/02/05/cloud-gov_a_different_kind_of_cloud/) / [Live Site](https://cloud.gov/2021/02/05/cloud-gov_a_different_kind_of_cloud/) 
