### PR TITLE
Remove obsolete federalist references

### DIFF
--- a/_docs/orgs-spaces/new-org.md
+++ b/_docs/orgs-spaces/new-org.md
@@ -15,9 +15,9 @@ To create a new organization through this process, you must be an existing custo
 
 ### Org name
 
-The new organization will be named for both the customer (e.g. "GSA") and the system, such as "CTO" or "18f-federalist". For a prototyping organization, the system name should be "prototyping".
+The new organization will be named for both the customer (e.g. "GSA") and the system, such as "CTO" or "tts-analytics". For a prototyping organization, the system name should be "prototyping".
 
-The org and system then are combined with a dash, e.g. "gsa-18f-federalist".
+The org and system then are combined with a dash, e.g. "gsa-tts-analytics".
 
 Note: Names cannot contain spaces and should instead use dashes (-).
 

--- a/_pages/pages/documentation/cloud-gov.md
+++ b/_pages/pages/documentation/cloud-gov.md
@@ -6,7 +6,7 @@ navigation: pages
 sidenav: pages-documentation
 ---
 
-As mentioned elsewhere, Pages is built on top of the [cloud.gov platform-as-a-service]({{ site.baseurl }}) (PaaS). cloud.gov takes care of the vast majority of the systems functionality that enables Pages, especially by maintaining a FedRAMP authorization. cloud.gov also provides security, logging, authentication, cryptographic protection, monitoring, and provisioning services that Pages consumes. Federalist's [compliance memo]({{site.baseurl}}/assets/documents/pages-compliance-memo.pdf) & [extension letter]({{site.baseurl}}/assets/documents/Federalist-ATO-Extension-Letter.pdf) explains the technical relationship in detail.
+As mentioned elsewhere, Pages is built on top of the [cloud.gov platform-as-a-service]({{ site.baseurl }}) (PaaS). cloud.gov takes care of the vast majority of the systems functionality that enables Pages, especially by maintaining a FedRAMP authorization. cloud.gov also provides security, logging, authentication, cryptographic protection, monitoring, and provisioning services that Pages consumes. Pages' [compliance memo]({{site.baseurl}}/assets/documents/pages-compliance-memo.pdf) and [extension letter]({{site.baseurl}}/assets/documents/Federalist-ATO-Extension-Letter.pdf) explain the technical relationship in detail.
 
 ## How Pages and cloud.gov collaborate
 

--- a/_pages/pages/documentation/custom-domains.md
+++ b/_pages/pages/documentation/custom-domains.md
@@ -40,10 +40,10 @@ An "apex" or "2nd level" domain is the "root" of your domain and will contain on
 
 #### Examples
 
-| apex domains  | subdomains           |
-| ------------- | -------------------- |
-| `example.gov` | `www.example.gov`    | 
-| `18f.gov`     | `federalist.18f.gov` |
+| apex domains  | subdomains              |
+| ------------- | ----------------------- |
+| `example.gov` | `www.example.gov`       |
+| `18f.gov`     | `accessibility.18f.gov` |
 
 ---
 

--- a/_pages/pages/documentation/supported-site-engines.md
+++ b/_pages/pages/documentation/supported-site-engines.md
@@ -41,7 +41,7 @@ If you [specify front-matter defaults](http://jekyllrb.com/docs/configuration/#f
 
 ### Base URLs
 
-To handle routing sites for previews, Pages automatically sets a `baseurl` path for your site. This essentially nests your site in a subdirectory under the `federalist.18f.gov` domain, such as `federalist.18f.gov/preview/18f/hub/new-draft`, where `/preview/18f/hub` is the `baseurl`.
+To handle routing sites for previews, Pages automatically sets a `baseurl` path for your site. This essentially nests your site in a subdirectory under the `pages.cloud.gov` domain, such as `sites.pages.cloud.gov/preview/18f/hub/new-draft`, where `/preview/18f/hub` is the `baseurl`.
 
 All links to other pages or resources on the site require a `baseurl` prefix. If you're designing a custom template to work with Pages, make sure all references to relative links include `site.baseurl` prefixes, including trailing slashes, as follows:
 

--- a/_pages/pages/features.md
+++ b/_pages/pages/features.md
@@ -14,7 +14,7 @@ title: cloud.gov Pages - Features
       <div class="tablet:grid-col-4 usa-section--dark margin-top-8">
         <h2>Try it for free</h2>
         <p class="usa-intro">Contact us to try Pages temporarily on a prototype or test project.</p>
-        <p><a class="usa-button usa-button--big" href="mailto:inquiries@cloud.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20website%20project%20or%20your%20questions%20about%20federalist:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A"> Get in touch</a></p>
+        <p><a class="usa-button usa-button--big" href="mailto:inquiries@cloud.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20website%20project%20or%20your%20questions%20about%20cloud%2Egov%20Pages:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A"> Get in touch</a></p>
       </div>
     </div>
 </section>
@@ -106,7 +106,7 @@ title: cloud.gov Pages - Features
   <div class="grid-row grid-gap-lg">
     <div class="tablet:grid-col-4 bar-top">
       <p>Try a free test site to see if Pages is right for you.<br>&nbsp;</p>
-      <a class="cg-arrow" href="mailto:inquiries@cloud.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20website%20project%20or%20your%20questions%20about%20federalist:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A">Get in touch</a>
+      <a class="cg-arrow" href="mailto:inquiries@cloud.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20website%20project%20or%20your%20questions%20about%20cloud%2Egov%20Pages:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A">Get in touch</a>
     </div>
     <div class="tablet:grid-col-4 bar-top">
       <p>Join our Slack community to connect and learn from other Pages users across the federal government.</p>

--- a/_posts/2017-08-11-continuous-improvement-more-tools-help-use-cloud-gov.md
+++ b/_posts/2017-08-11-continuous-improvement-more-tools-help-use-cloud-gov.md
@@ -51,6 +51,6 @@ The Federal Bureau of Investigation (FBI) recently launched their new Crime Data
 
 #### Federal Election Commission
 
-The Federal Election Commission (FEC) recently relaunched their flagship website, fec.gov, with cloud.gov. The FEC collects financial reports for all federal elections and discloses fundraising figures to the public. By hosting FEC.gov on cloud.gov and moving its data to the cloud, the FEC anticipates saving 85% in hosting costs and is better prepared for peak traffic events. Read a case study about the FEC here: [{{ site.baseurl }}/overview/customer-stories/fec/]({{ site.baseurl }}/overview/customer-stories/fec/) and check out their new, cloud.gov-hosted website at [https://fec.gov](https://fec.gov)
+The Federal Election Commission (FEC) recently relaunched their flagship website, fec.gov, with cloud.gov. The FEC collects financial reports for all federal elections and discloses fundraising figures to the public. By hosting FEC.gov on cloud.gov and moving its data to the cloud, the FEC anticipates saving 85% in hosting costs and is better prepared for peak traffic events. Read a case study about the FEC here: [{{ site.baseurl }}/overview/customer-stories/fec/]({{ site.baseurl }}/overview/customer-stories/fec/) and check out their new, cloud.gov-hosted website at [https://www.fec.gov](https://www.fec.gov)
 
 !["the new cloud.gov hosted fec homepage" width="624" height="320"]({{site.baseurl}}/assets/ fec-screen.png)

--- a/_posts/2018-01-05-meltdown-statement.md
+++ b/_posts/2018-01-05-meltdown-statement.md
@@ -6,12 +6,12 @@ redirect_from:
   - /updates/2018-01-05-meltdown-statement/
 ---
 
-cloud.gov is tracking the recent public disclosure of vulnerabilities in modern CPUs, named the [Meltdown and Spectre](https://meltdownattack.com/) attacks. 
+cloud.gov is tracking the recent public disclosure of vulnerabilities in modern CPUs, named the [Meltdown and Spectre](https://meltdownattack.com/) attacks.
 We are taking all available steps to mitigate the impact of these vulnerabilities. No customer action is required.
 
 Our cloud infrastructure provider [has already updated their systems](https://aws.amazon.com/security/security-bulletins/AWS-2018-013/) so that cloud.gov customer applications are not vulnerable to Meltdown attacks from other tenants in AWS GovCloud.
 
-When an update for the platform operating system is released, we will apply it. This will prevent Meltdown attacks between customer applications within cloud.gov. We use Ubuntu, which [plans to release an update very soon](https://insights.ubuntu.com/2018/01/04/ubuntu-updates-for-the-meltdown-spectre-vulnerabilities/). Then the [Cloud Foundry team will release a CF-customized version](https://www.cloudfoundry.org/meltdown-spectre-attacks/), and we will apply the update to cloud.gov. This will be [routine maintenance]({{ site.baseurl }}/docs/apps/app-maintenance#operating-system-patching) with no expected downtime.
+When an update for the platform operating system is released, we will apply it. This will prevent Meltdown attacks between customer applications within cloud.gov. We use Ubuntu, which [plans to release an update very soon](https://canonical.com/blog/ubuntu-updates-for-the-meltdown-spectre-vulnerabilities). Then the [Cloud Foundry team will release a CF-customized version](https://www.cloudfoundry.org/meltdown-spectre-attacks/), and we will apply the update to cloud.gov. This will be [routine maintenance]({{ site.baseurl }}/docs/apps/app-maintenance#operating-system-patching) with no expected downtime.
 
 We expect to have this update complete on or before the public release of proof-of-concept Meltdown exploit code on January 9.
 


### PR DESCRIPTION
Fixes #2371 

## Changes proposed in this pull request:
- The two `mailto:`s in `/pages/features` ([preview](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/2371-remove-obsolete-federalist-references/pages/features/)) populate the email body with "your questions about cloud.gov Pages" instead of "...about federalist".
- The Compliance memo and extension letter are described in current terms at `/pages/documentation/cloud-gov` ([preview](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/2371-remove-obsolete-federalist-references/pages/documentation/cloud-gov/))
- `accessibility.18f.gov` is used instead of `federalist.18f.gov` as an example domain at `/pages/documentation/custom-domains` ([preview](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/2371-remove-obsolete-federalist-references/pages/documentation/custom-domains/))
- The `baseurl` documentation at `/pages/documentation/supported-site-engines` ([preview](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/2371-remove-obsolete-federalist-references/pages/documentation/supported-site-engines/)) references `[sites.]pages.cloud.gov` for previews instead of the outdated Federalist domain.
- The sample org name content at `/docs/orgs-spaces/new-org` ([preview](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/2371-remove-obsolete-federalist-references/docs/orgs-spaces/new-org/)) references `tts-analytics` and `gsa-tts-analytics` instead of `18f-federalist` and `gsa-18f-federalist`.

[Preview site](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/2371-remove-obsolete-federalist-references/)

## Security Considerations
None. These are content changes to our website.