### PR TITLE
update contact info

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@
 
 title: cloud.gov
 email: inquiries@cloud.gov
+support_email: support@cloud.gov
 description: >- # this means to ignore newlines until "baseurl:"
   Expedite your agency’s path to a secure and compliant cloud. cloud.gov provides an application environment that enables rapid deployment and ATO assessment for modern web applications.
 baseurl: "" # the subpath of your site, e.g. /blog

--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@
 
 title: cloud.gov
 email: inquiries@cloud.gov
-support_email: support@cloud.gov
+support_email_address: support@cloud.gov
 description: >- # this means to ignore newlines until "baseurl:"
   Expedite your agency’s path to a secure and compliant cloud. cloud.gov provides an application environment that enables rapid deployment and ATO assessment for modern web applications.
 baseurl: "" # the subpath of your site, e.g. /blog

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -11,13 +11,13 @@ redirect_from:
 
 ### Want to use cloud.gov?
 
-If you're interested in using cloud.gov, email [**inquiries@cloud.gov**](mailto:inquiries@cloud.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20project%20or%20your%20questions%20about%20cloud.gov%3A%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A%0AHow%20did%20you%20first%20hear%20about%20cloud.gov%3F). We’ll schedule a call to answer your questions and help you [get started]({{ site.baseurl }}{% link _pages/sign-up.md %}).
+If you're interested in using cloud.gov, email [**{{site.email}}**](mailto:{{site.email}}?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20project%20or%20your%20questions%20about%20cloud.gov%3A%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A%0AHow%20did%20you%20first%20hear%20about%20cloud.gov%3F). We’ll schedule a call to answer your questions and help you [get started]({{ site.baseurl }}{% link _pages/sign-up.md %}).
 
 If you have a U.S. federal government email address, you can [get access to a free sandbox space]({{ site.baseurl }}{% link _docs/pricing/free-limited-sandbox.md %}).
 
 ### Support for people who use cloud.gov
 
-Email [**support@cloud.gov**](mailto:support@cloud.gov?body=What%20are%20you%20trying%20to%20do%3F%0A%0AWhat%20do%20you%20expect%20to%20happen%3F%0A%0AWhat%20actually%20happened%3F%0A%0AAttach%20relevant%20logs%20or%20screenshots%20%28remove%20sensitive%20information%29%3A). We provide support during business hours for U.S. East and West Coasts. We don't guarantee support outside those hours, though we're always monitoring for issues that might affect customers.
+Email [**{{site.support_email}}**](mailto:{{site.support_email}}?body=What%20are%20you%20trying%20to%20do%3F%0A%0AWhat%20do%20you%20expect%20to%20happen%3F%0A%0AWhat%20actually%20happened%3F%0A%0AAttach%20relevant%20logs%20or%20screenshots%20%28remove%20sensitive%20information%29%3A). See our [customer service objectives page]({{ site.baseurl }}{% link _docs/overview/customer-service-objectives.md %}) for information about our support availability.
 
 If you need help with an application security incident, the request should come from the System Owner or Org Manager, to help us validate the request. For an active incident, refer to our
 standard (security.txt)[{{ site.baseurl }}/.well-known/security.txt] file.
@@ -30,10 +30,10 @@ We welcome vulnerability reports [according to our vulnerability disclosure poli
 
 ### Questions from the public and industry
 
-If you have a question that isn't on behalf of a U.S. government organization (such as if you're a member of the public or representing a company), we invite you to post your question [publicly as an issue on GitHub](https://github.com/cloud-gov/cg-site/issues/new) (requires a free GitHub account), so that we can write an answer available to everyone. If you prefer not to post publicly, you can email [inquiries@cloud.gov](mailto:inquiries@cloud.gov).
+If you have a question that isn't on behalf of a U.S. government organization (such as if you're a member of the public or representing a company), we invite you to post your question [publicly as an issue on GitHub]({{config.github_url}}/issues/new) (requires a free GitHub account), so that we can write an answer available to everyone. If you prefer not to post publicly, you can email [{{site.email}}](mailto:{{site.email}}).
 
-If you are part of a company asking a question to help prepare a response to a RFI/RFQ/RFP (or a similar proposal process), we will ask you to post your question [publicly as an issue on GitHub](https://github.com/cloud-gov/cg-site/issues/new) (requires a free GitHub account). We want to answer publicly so that our answer is available to all companies competing in that process.
+If you are part of a company asking a question to help prepare a response to a RFI/RFQ/RFP (or a similar proposal process), we will ask you to post your question [publicly as an issue on GitHub]({{config.github_url}}/issues/new) (requires a free GitHub account). We want to answer publicly so that our answer is available to all companies competing in that process.
 
-### Interested in working on or contributing to cloud.gov?
+### Interested in working on cloud.gov?
 
-Check out [joining TTS](https://join.tts.gsa.gov/) if you'd like to join cloud.gov or another TTS program, or talk to us in [TTS's public DevOps chat channel](https://chat.18f.gov/) about how to collaborate, including how to contribute to [our open source work]({{ site.baseurl }}{% link _docs/ops/repos.md %}).
+Check out [joining TTS](https://join.tts.gsa.gov/) if you'd like to join cloud.gov or another TTS program.

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -30,9 +30,9 @@ We welcome vulnerability reports [according to our vulnerability disclosure poli
 
 ### Questions from the public and industry
 
-If you have a question that isn't on behalf of a U.S. government organization (such as if you're a member of the public or representing a company), we invite you to post your question [publicly as an issue on GitHub]({{config.github_url}}/issues/new) (requires a free GitHub account), so that we can write an answer available to everyone. If you prefer not to post publicly, you can email [{{site.email}}](mailto:{{site.email}}).
+If you have a question that isn't on behalf of a U.S. government organization (such as if you're a member of the public or representing a company), we invite you to post your question [publicly as an issue on GitHub]({{site.github_url}}/issues/new) (requires a free GitHub account), so that we can write an answer available to everyone. If you prefer not to post publicly, you can email [{{site.email}}](mailto:{{site.email}}).
 
-If you are part of a company asking a question to help prepare a response to a RFI/RFQ/RFP (or a similar proposal process), we will ask you to post your question [publicly as an issue on GitHub]({{config.github_url}}/issues/new) (requires a free GitHub account). We want to answer publicly so that our answer is available to all companies competing in that process.
+If you are part of a company asking a question to help prepare a response to a RFI/RFQ/RFP (or a similar proposal process), we will ask you to post your question [publicly as an issue on GitHub]({{site.github_url}}/issues/new) (requires a free GitHub account). We want to answer publicly so that our answer is available to all companies competing in that process.
 
 ### Interested in working on cloud.gov?
 

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -11,16 +11,16 @@ redirect_from:
 
 ### Want to use cloud.gov?
 
-If you're interested in using cloud.gov, email [**{{site.email}}**](mailto:{{site.email}}?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20project%20or%20your%20questions%20about%20cloud.gov%3A%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A%0AHow%20did%20you%20first%20hear%20about%20cloud.gov%3F). We’ll schedule a call to answer your questions and help you [get started]({{ site.baseurl }}{% link _pages/sign-up.md %}).
+If you're interested in using cloud.gov, email [**{{site.email}}**](mailto:{{site.inquiries_email}}). We’ll schedule a call to answer your questions and help you [get started]({{ site.baseurl }}{% link _pages/sign-up.md %}).
 
 If you have a U.S. federal government email address, you can [get access to a free sandbox space]({{ site.baseurl }}{% link _docs/pricing/free-limited-sandbox.md %}).
 
 ### Support for people who use cloud.gov
 
-Email [**{{site.support_email}}**](mailto:{{site.support_email}}?body=What%20are%20you%20trying%20to%20do%3F%0A%0AWhat%20do%20you%20expect%20to%20happen%3F%0A%0AWhat%20actually%20happened%3F%0A%0AAttach%20relevant%20logs%20or%20screenshots%20%28remove%20sensitive%20information%29%3A). See our [customer service objectives page]({{ site.baseurl }}{% link _docs/overview/customer-service-objectives.md %}) for information about our support availability.
+Email [**{{site.support_email_address}}**](mailto:{{site.support_email}}). See our [customer service objectives page]({{ site.baseurl }}{% link _docs/overview/customer-service-objectives.md %}) for information about our support availability.
 
 If you need help with an application security incident, the request should come from the System Owner or Org Manager, to help us validate the request. For an active incident, refer to our
-standard (security.txt)[{{ site.baseurl }}/.well-known/security.txt] file.
+standard [security.txt]({{ site.baseurl }}/.well-known/security.txt) file.
 
 You should not include any passwords or sensitive environment variables in your email (we don't need them to help you, and you should keep them protected).
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update contact page to use config values for emails to encourage consistency
- Remove link to defunct Google form for access to a public channel that is no longer encouraged for communicating with the cloud.gov team

## Security Considerations

None
