### PR TITLE
Announce FedRAMP CSP community

### DIFF
--- a/_docs/compliance/compliance-community.md
+++ b/_docs/compliance/compliance-community.md
@@ -1,0 +1,42 @@
+---
+parent: compliance
+layout: docs
+sidenav: true
+title: Compliance community
+weight: 50
+redirect_from:
+  - /docs/intro/security/for-assessors
+  - /intro/security/for-assessors
+  - /overview/security/for-assessors/
+---
+
+
+## Cloud.gov and the compliance community
+
+Part of the mission of cloud.gov is to improve cloud adoption across the U.S. government, irrespective of vendor. In that vein, we support the FedRAMP®️ Compliance Practitioner Community of Practice, an email listserv supported by GSA's [Digital.gov](https://digital.gov/).
+
+The goal of the community is to bring together people working on FedRAMP compliance to address common questions and concerns. The 
+
+## Charter and rules of behavior
+
+The following is the charter for the community. Suggestions for changes are welcome, either via the listserv or as issues/pull request to [this repository](https://github.com/cloud-gov/cg-site). Changes to the charter are approved by cloud.gov.
+
+> Purpose: Provide a forum for compliance staff at cloud service providers (CSPs) that are FedRAMP-authorized, or pursuing FedRAMP authorization.
+>
+> Membership: Open to compliance staff at CSPs listed at https://marketplace.fedramp.gov as authorized or in-process. If the CSP has retained a 3PAO to pursue authorization, they are also eligible for participation. The TTS cloud.gov compliance team will approve memberships.
+>
+> Access: This will be a closed list. Membership and discussions will not be published nor searchable, but will be subject to FOIA. Discussions are not deemed policy-making or advising, as the FedRAMP PMO is not participating in the listserv.
+>
+> Content Guidelines: 
+>
+> * Avoid product promotion or denigration, either your own products or other vendor's. If a product has proved useful, state how it's been useful, not that it's "Great" or "Life-changing". 
+> * Respect the "closed" nature of the community: While all content could be subject to FOIA requests, do not share content with out permission of the poster.
+
+
+See: https://digital.gov/communities/community-guidelines/
+
+
+## How to join the community
+
+To unsubscribe from the list, create a new email message, addressed to: FEDRAMP-CSP-COMMUNITY-subscribe-request@listserv.gsa.gov. The message content does not matter and the sender's email address will be removed from the list. 
+

--- a/_docs/compliance/compliance-community.md
+++ b/_docs/compliance/compliance-community.md
@@ -32,17 +32,18 @@ Email us at [cloud-gov-compliance@gsa.gov](mailto:cloud-gov-compliance@gsa.gov) 
 
 ## Who can join?
 
-Open to compliance staff at CSPs that are listed at https://marketplace.fedramp.gov as authorized or in-process, or at a CSP has retained a 3PAO to pursue authorization.
+Open to compliance staff at CSPs that are listed at [FedRAMP Marketplace](https://marketplace.fedramp.gov) as authorized or in-process, or at compliance staff at a CSP has retained a 3PAO to pursue authorization.
 The cloud.gov compliance team will approve memberships.
 
 ## How to join?
 
-Send an email to [FEDRAMP-CSP-COMMUNITY-subscribe-request@listserv.gsa.gov](mailto:FEDRAMP-CSP-COMMUNITY-subscribe-request@listserv.gsa.gov) from the domain of your FedRAMP CSP. If you're unable to use that domain for this community, email from your preferred address
+Send an email to [cloud-gov-community@gsa.gov](mailto:cloud-gov-community@gsa.gov) from the domain of your FedRAMP CSP.
+
+If you're unable to use that domain for this community, email from your preferred address
 and provide an explanation and alternate means of 
-validation, such as an address you can use for confirmation. If your CSP has retained a 3PAO, provide a contact at the 3PAO who can affirm that they've been retained.
+validation, such as an address you can use for confirmation. 
 
-After you email the subscription address, you'll get an automated confirmation email. Reply "OK" and your request will be 
-
+If your CSP has retained a 3PAO, provide a contact at the 3PAO who can affirm that they've been retained, and CC: them on your email.
 
 ## Your communications are not private
 
@@ -61,94 +62,27 @@ Words matter. Choose words that create a safe, inclusive, respectful, and welcom
 * [Preferred terms for select population groups and communities](https://www.cdc.gov/healthcommunication/Preferred_Terms.html) - Centers for Disease Control and Prevention.
 
 
-{{< do-dont-table caption="When participating in the community, community members must follow the ground rules for discussions." >}}
-  {{< row >}}
-    {{< do-row >}} Use your official .gov or .mil email account. {{< /do-row >}}
-    {{< dont-row >}} Don’t use your personal email. {{< /dont-row >}}
-  {{< /row >}}
+### When participating in the community, community members must follow the ground rules for discussions
 
-  {{< row >}}
-    {{< do-row >}} Understand that you are acting in your official capacity and representing the government. {{< /do-row >}}
-    {{< dont-row >}} Don’t conduct yourself in a way that’s unbecoming of a government employee or contractor. {{< /dont-row >}}
-  {{< /row >}}
+| Preferred behavior | Discouraged behavior |
+| ------------------ | -------------------- |
+| Understand that you are participating in a professional community. | Don’t conduct yourself in a way that’s unbecoming of your organization. |
+| Respect your colleagues. Always assume the best of others. | Don’t make personal attacks. |
+| Be patient. Understand that community members have various experience levels.| Don’t be condescending or talk down to other people. |
+| Listen carefully and actively. Listen as much as you speak. | Don’t disrupt meetings, talks, or discussions, including mailing lists and chats. |
+| Review your message before pressing send. | Don’t use inappropriate language, images, or emojis. Don’t reply-all if your message may clutter other members’ inboxes. |
+| Share your objective experiences with tools or techniques| Don't endorse products or services or appear to recommend them in your professional capacity. |
+| Keep the conversation relevant and stay on point. Start a new thread if needed. Give others the time and space to participate. | Don’t dominate conversations. Don’t interrupt or talk over other people. |
+| Respect members’ real, lived experiences. Recognize that people face systemic discrimination in a multitude of ways. | Don’t belittle others to make your point. |
+| Take legal questions to your organizations’s lawyers. | Don’t seek legal advice from the community. Don’t take conversations or shared experiences as interpretations of federal laws and policies. |
+| Treat other people's identities and cultures with respect. Spell and say their name correctly and use their [pronouns](https://digital.gov/resources/an-introduction-to-pronouns/). | Don’t make derogatory comments on race, color, sex, sexual orientation, gender identity, religion, national origin, age, disability, genetic information, marital status, parental status, political affiliation, or appearance. |
+| Ensure the community is free from harassment, including sexual harassment and sexual misconduct. | Don’t harass anyone. This includes, but is not limited to, retaliating against anyone who files a complaint. |
+| Remember that everything you write on the mailing list is a federal record and subject to release under FOIA. | Don’t assume your communications are private. |
+Use <a href="https://www.plainlanguage.gov/" class="usa-link usa-link--external">plain language</a>. | Don’t use confusing or overly technical language. |
 
-  {{< row >}}
-    {{< do-row >}} Follow your agency’s policies, including policies about using government equipment and IT systems and managing records. {{< /do-row >}}
-    {{< dont-row >}} Don’t violate your agency’s policies. {{< /dont-row >}}
-  {{< /row >}}
-
-  {{< row >}}
-    {{< do-row >}} Respect your colleagues. Always assume the best of others. {{< /do-row >}}
-    {{< dont-row >}} Don’t make personal attacks. {{< /dont-row >}}
-  {{< /row >}}
-
-  {{< row >}}
-    {{< do-row >}} Be patient. Understand that community members have various experience levels. {{< /do-row >}}
-    {{< dont-row >}} Don’t be condescending or talk down to other people. {{< /dont-row >}}
-  {{< /row >}}
-
-  {{< row >}}
-    {{< do-row >}} Listen carefully and actively. Listen as much as you speak. {{< /do-row >}}
-    {{< dont-row >}} Don’t disrupt meetings, talks, or discussions, including mailing lists and chats. {{< /dont-row >}}
-  {{< /row >}}
-
-  {{< row >}}
-    {{< do-row >}} Review your message before pressing send. {{< /do-row >}}
-    {{< dont-row >}} Don’t use inappropriate language, images, or emojis. Don’t reply-all if your message may clutter other members’ inboxes. {{< /dont-row >}}
-  {{< /row >}}
-
-  {{< row >}}
-    {{< do-row >}} Share government links and resources. {{< /do-row >}}
-    {{< dont-row >}} Don't name (endorse) commercial products or services or appear to recommend them in your professional capacity or on behalf of your agency. {{< /dont-row >}}
-  {{< /row >}}
-
-  {{< row >}}
-    {{< do-row >}} Keep the conversation relevant and stay on point. Start a new thread if needed. Give others the time and space to participate. {{< /do-row >}}
-    {{< dont-row >}} Don’t dominate conversations. Don’t interrupt or talk over other people. {{< /dont-row >}}
-  {{< /row >}}
-
-  {{< row >}}
-    {{< do-row >}} Respect members’ real, lived experiences. Recognize that people face systemic discrimination in a multitude of ways. {{< /do-row >}}
-    {{< dont-row >}} Don’t belittle others to make your point. {{< /dont-row >}}
-  {{< /row >}}
-
-  {{< row >}}
-    {{< do-row >}} Take legal questions to your agency’s lawyers. {{< /do-row >}}
-    {{< dont-row >}} Don’t seek legal advice from the community. Don’t take conversations or shared experiences as interpretations of federal laws and policies. {{< /dont-row >}}
-  {{< /row >}}
-
-  {{< row >}}
-    {{< do-row >}} Treat other people's identities and cultures with respect. Spell and say their name correctly and use their [pronouns](https://digital.gov/resources/an-introduction-to-pronouns/). {{< /do-row >}}
-    {{< dont-row >}} Don’t make derogatory comments on race, color, sex, sexual orientation, gender identity, religion, national origin, age, disability, genetic information, marital status, parental status, political affiliation, or appearance. {{< /dont-row >}}
-  {{< /row >}}
-
-  {{< row >}}
-    {{< do-row >}} Ensure the community is free from harassment, including sexual harassment and sexual misconduct. {{< /do-row >}}
-    {{< dont-row >}} Don’t harass anyone. This includes, but is not limited to, retaliating against anyone who files a complaint. {{< /dont-row >}}
-  {{< /row >}}
-
-  {{< row >}}
-    {{< do-row >}} Remember that everything you write on the mailing list is a federal record and subject to release under FOIA. {{< /do-row >}}
-    {{< dont-row >}} Don’t assume your communications are private. {{< /dont-row >}}
-  {{< /row >}}
-
-  {{< row >}}
-    {{< do-row >}} Use <a href="https://www.plainlanguage.gov/" class="usa-link usa-link--external">plain language</a>. {{< /do-row >}}
-    {{< dont-row >}} Don’t use confusing or overly technical language. {{< /dont-row >}}
-  {{< /row >}}
-
-  {{< row >}}
-    {{< do-row >}} Abide by the <a href="https://pra.digital.gov/" class="usa-link usa-link--external">Paperwork Reduction Act</a> when sending out a survey or other requests for feedback. {{< /do-row >}}
-    {{< dont-row >}} Don’t violate the Paperwork Reduction Act. {{< /dont-row >}}
-  {{< /row >}}
-
-  {{< row >}}
-    {{< do-row >}} Abide by <a href="https://www.usa.gov/government-works" class="usa-link usa-link--external">U.S. copyright laws</a> when using others' content. {{< /do-row >}}
-    {{< dont-row >}} Don’t violate U.S. copyright laws. {{< /dont-row >}}
-  {{< /row >}}
-{{< /do-dont-table >}}
 
 ## Manage your mailing list subscription
+
 Email us at [digitalgov@gsa.gov](mailto:digitalgov@gsa.gov) and we’ll help you manage your LISTSERV subscription. The most common requests are to:
 * receive a daily digest (instead of each individual message),
 * access the mailing list archive, and

--- a/_docs/compliance/compliance-community.md
+++ b/_docs/compliance/compliance-community.md
@@ -30,7 +30,7 @@ Email us at [cloud-gov-compliance@gsa.gov](mailto:cloud-gov-compliance@gsa.gov) 
 
 ## Who can join?
 
-Open to compliance staff at CSPs that are listed at [FedRAMP Marketplace](https://marketplace.fedramp.gov) as authorized or in-process, or at compliance staff at a CSP has retained a 3PAO to pursue authorization.
+Open to compliance staff at CSPs listed in the [FedRAMP Marketplace](https://marketplace.fedramp.gov) as authorized or in-process, or a CSP that has retained a 3PAO to pursue authorization.
 The cloud.gov compliance team will approve memberships.
 
 ## How to join?

--- a/_docs/compliance/compliance-community.md
+++ b/_docs/compliance/compliance-community.md
@@ -3,7 +3,7 @@ parent: compliance
 layout: docs
 sidenav: true
 title: Compliance community
-summary: cloud.gov support an email listserve for FedRAMP compliance practitioners 
+summary: cloud.gov supportx an email listserve for FedRAMP compliance practitioners 
 weight: 50
 redirect_from:
   - /docs/intro/security/for-assessors
@@ -37,11 +37,11 @@ The cloud.gov compliance team will approve memberships.
 
 ## How to join?
 
-Send an email to [cloud-gov-community@gsa.gov](mailto:cloud-gov-community@gsa.gov) from the domain of your FedRAMP CSP.
+Send an email to [cloud-gov-compliance@gsa.gov](mailto:cloud-gov-compliance@gsa.gov) from the domain of your FedRAMP CSP.
 
 If you're unable to use that domain for this community, email from your preferred address
 and provide an explanation and alternate means of 
-validation, such as an address you can use for confirmation. 
+validation, such as an CSP-based address you can use for confirmation. 
 
 If your CSP has retained a 3PAO, provide a contact at the 3PAO who can affirm that they've been retained, and CC: them on your email.
 
@@ -66,7 +66,7 @@ Words matter. Choose words that create a safe, inclusive, respectful, and welcom
 
 | Preferred behavior | Discouraged behavior |
 | ------------------ | -------------------- |
-| Understand that you are participating in a professional community. | Don’t conduct yourself in a way that’s unbecoming of your organization. |
+| Understand that you are participating in a professional community.  | Don’t conduct yourself in a way that’s unbecoming of your organization. |
 | Respect your colleagues. Always assume the best of others. | Don’t make personal attacks. |
 | Be patient. Understand that community members have various experience levels.| Don’t be condescending or talk down to other people. |
 | Listen carefully and actively. Listen as much as you speak. | Don’t disrupt meetings, talks, or discussions, including mailing lists and chats. |
@@ -83,7 +83,7 @@ Use <a href="https://www.plainlanguage.gov/" class="usa-link usa-link--external"
 
 ## Manage your mailing list subscription
 
-Email us at [digitalgov@gsa.gov](mailto:digitalgov@gsa.gov) and we’ll help you manage your LISTSERV subscription. The most common requests are to:
+Email us at [cloud-gov-compliance@gsa.gov](mailto:cloud-gov-compliance@gsa.gov) and we’ll help you manage your LISTSERV subscription. The most common requests are to:
 * receive a daily digest (instead of each individual message),
 * access the mailing list archive, and
 * unsubscribe.

--- a/_docs/compliance/compliance-community.md
+++ b/_docs/compliance/compliance-community.md
@@ -3,6 +3,7 @@ parent: compliance
 layout: docs
 sidenav: true
 title: Compliance community
+summary: cloud.gov support an email listserve for FedRAMP compliance practitioners 
 weight: 50
 redirect_from:
   - /docs/intro/security/for-assessors
@@ -15,28 +16,142 @@ redirect_from:
 
 Part of the mission of cloud.gov is to improve cloud adoption across the U.S. government, irrespective of vendor. In that vein, we support the FedRAMP®️ Compliance Practitioner Community of Practice, an email listserv supported by GSA's [Digital.gov](https://digital.gov/).
 
-The goal of the community is to bring together people working on FedRAMP compliance to address common questions and concerns. The 
+The goal of the community is to bring together people working on FedRAMP compliance to address common questions and concerns.  We strive to maintain an inclusive, professional community that engages in on-topic discussions. By voluntarily participating in this community, you are agreeing to abide by these guidelines and the [TTS code of conduct](https://handbook.tts.gsa.gov/about-us/code-of-conduct/). If you do not agree, email us at [cloud-gov-compliance@gsa.gov](mailto:cloud-gov-compliance@gsa.gov), and we will unsubscribe you from the LISTSERV mailing list.
 
-## Charter and rules of behavior
+When GSA becomes aware of alleged violations of the guidelines or code of conduct, we will review and evaluate the incident and determine an appropriate course of action. In accordance with GSA’s policies and legal guidance, the cloud.gov team implements this process.
 
-The following is the charter for the community. Suggestions for changes are welcome, either via the listserv or as issues/pull request to [this repository](https://github.com/cloud-gov/cg-site). Changes to the charter are approved by cloud.gov.
+Courses of action include:
 
-> Purpose: Provide a forum for compliance staff at cloud service providers (CSPs) that are FedRAMP-authorized, or pursuing FedRAMP authorization.
->
-> Membership: Open to compliance staff at CSPs listed at https://marketplace.fedramp.gov as authorized or in-process. If the CSP has retained a 3PAO to pursue authorization, they are also eligible for participation. The TTS cloud.gov compliance team will approve memberships.
->
-> Access: This will be a closed list. Membership and discussions will not be published nor searchable, but will be subject to FOIA. Discussions are not deemed policy-making or advising, as the FedRAMP PMO is not participating in the listserv.
->
-> Content Guidelines: 
->
-> * Avoid product promotion or denigration, either your own products or other vendor's. If a product has proved useful, state how it's been useful, not that it's "Great" or "Life-changing". 
-> * Respect the "closed" nature of the community: While all content could be subject to FOIA requests, do not share content with out permission of the poster.
+* taking no action,
+* sending a reminder for infractions, and
+* issuing a first or second notice for violations.
+
+Severe or repeated violations may result in temporary or permanent removal from the community.
+
+Email us at [cloud-gov-compliance@gsa.gov](mailto:cloud-gov-compliance@gsa.gov) to report an alleged violation.
+
+## Who can join?
+
+Open to compliance staff at CSPs that are listed at https://marketplace.fedramp.gov as authorized or in-process, or at a CSP has retained a 3PAO to pursue authorization.
+The cloud.gov compliance team will approve memberships.
+
+## How to join?
+
+Send an email to [FEDRAMP-CSP-COMMUNITY-subscribe-request@listserv.gsa.gov](mailto:FEDRAMP-CSP-COMMUNITY-subscribe-request@listserv.gsa.gov) from the domain of your FedRAMP CSP. If you're unable to use that domain for this community, email from your preferred address
+and provide an explanation and alternate means of 
+validation, such as an address you can use for confirmation. If your CSP has retained a 3PAO, provide a contact at the 3PAO who can affirm that they've been retained.
+
+After you email the subscription address, you'll get an automated confirmation email. Reply "OK" and your request will be 
 
 
-See: https://digital.gov/communities/community-guidelines/
+## Your communications are not private
+
+As a federal agency, GSA is subject to records access requests such as the Freedom of Information Act (FOIA). We must comply with requests for records made under FOIA. All communications made on the mailing lists are subject to release under FOIA, or potentially compromised by an adversary.  We are not in a position to background check participants beyond a cursory CSP domain validation.
+
+## Follow the ground rules
+
+We all have a responsibility to ensure the community is a safe space for everyone and free from harassment. It is appropriate to have and express differing opinions, as long as they are expressed in a respectful manner.
+
+When dealing with sensitive topics or during disagreements, written statements can often sound more aggressive than when we speak them out loud. Review your message before pressing send. Think about how it may appear to its recipients. Remember, each message goes to thousands of people. When in doubt, don’t send it out.
+
+Words matter. Choose words that create a safe, inclusive, respectful, and welcoming environment. Take a look at the following resources on inclusive language for additional information.
+
+* [Inclusive language guidelines](https://www.apa.org/about/apa/equity-diversity-inclusion/language-guidelines) - American Psychological Association
+* [Inclusive language](https://content-guide.18f.gov/our-style/inclusive-language/) - 18F Content Guide
+* [Preferred terms for select population groups and communities](https://www.cdc.gov/healthcommunication/Preferred_Terms.html) - Centers for Disease Control and Prevention.
 
 
-## How to join the community
+{{< do-dont-table caption="When participating in the community, community members must follow the ground rules for discussions." >}}
+  {{< row >}}
+    {{< do-row >}} Use your official .gov or .mil email account. {{< /do-row >}}
+    {{< dont-row >}} Don’t use your personal email. {{< /dont-row >}}
+  {{< /row >}}
 
-To unsubscribe from the list, create a new email message, addressed to: FEDRAMP-CSP-COMMUNITY-subscribe-request@listserv.gsa.gov. The message content does not matter and the sender's email address will be removed from the list. 
+  {{< row >}}
+    {{< do-row >}} Understand that you are acting in your official capacity and representing the government. {{< /do-row >}}
+    {{< dont-row >}} Don’t conduct yourself in a way that’s unbecoming of a government employee or contractor. {{< /dont-row >}}
+  {{< /row >}}
 
+  {{< row >}}
+    {{< do-row >}} Follow your agency’s policies, including policies about using government equipment and IT systems and managing records. {{< /do-row >}}
+    {{< dont-row >}} Don’t violate your agency’s policies. {{< /dont-row >}}
+  {{< /row >}}
+
+  {{< row >}}
+    {{< do-row >}} Respect your colleagues. Always assume the best of others. {{< /do-row >}}
+    {{< dont-row >}} Don’t make personal attacks. {{< /dont-row >}}
+  {{< /row >}}
+
+  {{< row >}}
+    {{< do-row >}} Be patient. Understand that community members have various experience levels. {{< /do-row >}}
+    {{< dont-row >}} Don’t be condescending or talk down to other people. {{< /dont-row >}}
+  {{< /row >}}
+
+  {{< row >}}
+    {{< do-row >}} Listen carefully and actively. Listen as much as you speak. {{< /do-row >}}
+    {{< dont-row >}} Don’t disrupt meetings, talks, or discussions, including mailing lists and chats. {{< /dont-row >}}
+  {{< /row >}}
+
+  {{< row >}}
+    {{< do-row >}} Review your message before pressing send. {{< /do-row >}}
+    {{< dont-row >}} Don’t use inappropriate language, images, or emojis. Don’t reply-all if your message may clutter other members’ inboxes. {{< /dont-row >}}
+  {{< /row >}}
+
+  {{< row >}}
+    {{< do-row >}} Share government links and resources. {{< /do-row >}}
+    {{< dont-row >}} Don't name (endorse) commercial products or services or appear to recommend them in your professional capacity or on behalf of your agency. {{< /dont-row >}}
+  {{< /row >}}
+
+  {{< row >}}
+    {{< do-row >}} Keep the conversation relevant and stay on point. Start a new thread if needed. Give others the time and space to participate. {{< /do-row >}}
+    {{< dont-row >}} Don’t dominate conversations. Don’t interrupt or talk over other people. {{< /dont-row >}}
+  {{< /row >}}
+
+  {{< row >}}
+    {{< do-row >}} Respect members’ real, lived experiences. Recognize that people face systemic discrimination in a multitude of ways. {{< /do-row >}}
+    {{< dont-row >}} Don’t belittle others to make your point. {{< /dont-row >}}
+  {{< /row >}}
+
+  {{< row >}}
+    {{< do-row >}} Take legal questions to your agency’s lawyers. {{< /do-row >}}
+    {{< dont-row >}} Don’t seek legal advice from the community. Don’t take conversations or shared experiences as interpretations of federal laws and policies. {{< /dont-row >}}
+  {{< /row >}}
+
+  {{< row >}}
+    {{< do-row >}} Treat other people's identities and cultures with respect. Spell and say their name correctly and use their [pronouns](https://digital.gov/resources/an-introduction-to-pronouns/). {{< /do-row >}}
+    {{< dont-row >}} Don’t make derogatory comments on race, color, sex, sexual orientation, gender identity, religion, national origin, age, disability, genetic information, marital status, parental status, political affiliation, or appearance. {{< /dont-row >}}
+  {{< /row >}}
+
+  {{< row >}}
+    {{< do-row >}} Ensure the community is free from harassment, including sexual harassment and sexual misconduct. {{< /do-row >}}
+    {{< dont-row >}} Don’t harass anyone. This includes, but is not limited to, retaliating against anyone who files a complaint. {{< /dont-row >}}
+  {{< /row >}}
+
+  {{< row >}}
+    {{< do-row >}} Remember that everything you write on the mailing list is a federal record and subject to release under FOIA. {{< /do-row >}}
+    {{< dont-row >}} Don’t assume your communications are private. {{< /dont-row >}}
+  {{< /row >}}
+
+  {{< row >}}
+    {{< do-row >}} Use <a href="https://www.plainlanguage.gov/" class="usa-link usa-link--external">plain language</a>. {{< /do-row >}}
+    {{< dont-row >}} Don’t use confusing or overly technical language. {{< /dont-row >}}
+  {{< /row >}}
+
+  {{< row >}}
+    {{< do-row >}} Abide by the <a href="https://pra.digital.gov/" class="usa-link usa-link--external">Paperwork Reduction Act</a> when sending out a survey or other requests for feedback. {{< /do-row >}}
+    {{< dont-row >}} Don’t violate the Paperwork Reduction Act. {{< /dont-row >}}
+  {{< /row >}}
+
+  {{< row >}}
+    {{< do-row >}} Abide by <a href="https://www.usa.gov/government-works" class="usa-link usa-link--external">U.S. copyright laws</a> when using others' content. {{< /do-row >}}
+    {{< dont-row >}} Don’t violate U.S. copyright laws. {{< /dont-row >}}
+  {{< /row >}}
+{{< /do-dont-table >}}
+
+## Manage your mailing list subscription
+Email us at [digitalgov@gsa.gov](mailto:digitalgov@gsa.gov) and we’ll help you manage your LISTSERV subscription. The most common requests are to:
+* receive a daily digest (instead of each individual message),
+* access the mailing list archive, and
+* unsubscribe.
+
+When you email us, please include the name of the community and what you’d like to update.

--- a/_docs/compliance/compliance-community.md
+++ b/_docs/compliance/compliance-community.md
@@ -5,10 +5,6 @@ sidenav: true
 title: Compliance community
 summary: cloud.gov supports an email listserve for FedRAMP compliance practitioners 
 weight: 50
-redirect_from:
-  - /docs/intro/security/for-assessors
-  - /intro/security/for-assessors
-  - /overview/security/for-assessors/
 ---
 
 

--- a/_docs/compliance/compliance-community.md
+++ b/_docs/compliance/compliance-community.md
@@ -3,7 +3,7 @@ parent: compliance
 layout: docs
 sidenav: true
 title: Compliance community
-summary: cloud.gov supports an email listserve for FedRAMP compliance practitioners 
+summary: cloud.gov supports an email listserv for FedRAMP compliance practitioners 
 weight: 50
 ---
 

--- a/_docs/compliance/compliance-community.md
+++ b/_docs/compliance/compliance-community.md
@@ -76,7 +76,7 @@ Words matter. Choose words that create a safe, inclusive, respectful, and welcom
 | Treat other people's identities and cultures with respect. Spell and say their name correctly and use their [pronouns](https://digital.gov/resources/an-introduction-to-pronouns/). | Don’t make derogatory comments on race, color, sex, sexual orientation, gender identity, religion, national origin, age, disability, genetic information, marital status, parental status, political affiliation, or appearance. |
 | Ensure the community is free from harassment, including sexual harassment and sexual misconduct. | Don’t harass anyone. This includes, but is not limited to, retaliating against anyone who files a complaint. |
 | Remember that everything you write on the mailing list is a federal record and subject to release under FOIA. | Don’t assume your communications are private. |
-Use <a href="https://www.plainlanguage.gov/" class="usa-link usa-link--external">plain language</a>. | Don’t use confusing or overly technical language. |
+| Use <a href="https://www.plainlanguage.gov/" class="usa-link usa-link--external">plain language</a>. | Don’t use confusing or overly technical language. |
 
 
 ## Manage your mailing list subscription

--- a/_docs/compliance/compliance-community.md
+++ b/_docs/compliance/compliance-community.md
@@ -3,7 +3,7 @@ parent: compliance
 layout: docs
 sidenav: true
 title: Compliance community
-summary: cloud.gov supportx an email listserve for FedRAMP compliance practitioners 
+summary: cloud.gov supports an email listserve for FedRAMP compliance practitioners 
 weight: 50
 redirect_from:
   - /docs/intro/security/for-assessors
@@ -16,7 +16,9 @@ redirect_from:
 
 Part of the mission of cloud.gov is to improve cloud adoption across the U.S. government, irrespective of vendor. In that vein, we support the FedRAMP®️ Compliance Practitioner Community of Practice, an email listserv supported by GSA's [Digital.gov](https://digital.gov/).
 
-The goal of the community is to bring together people working on FedRAMP compliance to address common questions and concerns.  We strive to maintain an inclusive, professional community that engages in on-topic discussions. By voluntarily participating in this community, you are agreeing to abide by these guidelines and the [TTS code of conduct](https://handbook.tts.gsa.gov/about-us/code-of-conduct/). If you do not agree, email us at [cloud-gov-compliance@gsa.gov](mailto:cloud-gov-compliance@gsa.gov), and we will unsubscribe you from the LISTSERV mailing list.
+The goal of the community is to bring together people working on FedRAMP compliance to address common questions and concerns.  We strive to maintain an inclusive, professional community that engages in on-topic discussions. The community is not associated with the FedRAMP Program Management Office.
+
+By voluntarily participating in this community, you are agreeing to abide by these guidelines and the [TTS code of conduct](https://handbook.tts.gsa.gov/about-us/code-of-conduct/). If you do not agree, email us at [cloud-gov-compliance@gsa.gov](mailto:cloud-gov-compliance@gsa.gov), and we will unsubscribe you from the LISTSERV mailing list.
 
 When GSA becomes aware of alleged violations of the guidelines or code of conduct, we will review and evaluate the incident and determine an appropriate course of action. In accordance with GSA’s policies and legal guidance, the cloud.gov team implements this process.
 

--- a/_posts/2023-08-01-fedramp-csp-community.md
+++ b/_posts/2023-08-01-fedramp-csp-community.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Announcing FedRAMP CSP Community mailing list
+date: July 3, 2023
+excerpt: "Email cloud-gov-compliance@gsa.gov from your CSP email to join"
+---
+
+Part of the mission of cloud.gov is to improve cloud adoption across the U.S. government, irrespective of vendor. In that vein, we support the FedRAMP®️ Compliance Practitioner Community of Practice, an email listserv supported by GSA's [Digital.gov](https://digital.gov/).
+
+The goal of the community is to bring together people working on FedRAMP compliance to address common questions and concerns.  We strive to maintain an inclusive, professional community that engages in on-topic discussions. The community is not associated with the FedRAMP Program Management Office.
+
+The list is open to compliance staff at CSPs that are listed at [FedRAMP Marketplace](https://marketplace.fedramp.gov) as authorized or in-process, or at compliance staff at a CSP has retained a 3PAO to pursue authorization.
+
+You can read all about at [cloud.gov Compliance Community](https://cloud.gov/docs/compliance/compliance-community/), and join today by sending an email to [cloud-gov-compliance@gsa.gov](mailto:cloud-gov-compliance@gsa.gov) from the domain of your FedRAMP CSP.

--- a/_posts/2023-08-01-fedramp-csp-community.md
+++ b/_posts/2023-08-01-fedramp-csp-community.md
@@ -9,6 +9,6 @@ Part of the mission of cloud.gov is to improve cloud adoption across the U.S. go
 
 The goal of the community is to bring together people working on FedRAMP compliance to address common questions and concerns.  We strive to maintain an inclusive, professional community that engages in on-topic discussions. The community is not associated with the FedRAMP Program Management Office.
 
-The list is open to compliance staff at CSPs that are listed at [FedRAMP Marketplace](https://marketplace.fedramp.gov) as authorized or in-process, or at compliance staff at a CSP has retained a 3PAO to pursue authorization.
+The list is open to compliance staff at CSPs listed at [FedRAMP Marketplace](https://marketplace.fedramp.gov) as authorized or in-process, or at compliance staff at a CSP has retained a 3PAO to pursue authorization.
 
-You can read all about at [cloud.gov Compliance Community](https://cloud.gov/docs/compliance/compliance-community/), and join today by sending an email to [cloud-gov-compliance@gsa.gov](mailto:cloud-gov-compliance@gsa.gov) from the domain of your FedRAMP CSP.
+You can read all about this at [cloud.gov Compliance Community](({{ site.baseurl }}{% link _docs/compliance/compliance-community.md %})), and join today by sending an email to [cloud-gov-compliance@gsa.gov](mailto:cloud-gov-compliance@gsa.gov) from the domain of your FedRAMP CSP.

--- a/_posts/2023-08-01-fedramp-csp-community.md
+++ b/_posts/2023-08-01-fedramp-csp-community.md
@@ -9,6 +9,6 @@ Part of the mission of cloud.gov is to improve cloud adoption across the U.S. go
 
 The goal of the community is to bring together people working on FedRAMP compliance to address common questions and concerns.  We strive to maintain an inclusive, professional community that engages in on-topic discussions. The community is not associated with the FedRAMP Program Management Office.
 
-The list is open to compliance staff at CSPs listed at [FedRAMP Marketplace](https://marketplace.fedramp.gov) as authorized or in-process, or at compliance staff at a CSP has retained a 3PAO to pursue authorization.
+The list is open to compliance staff at CSPs listed at the [FedRAMP Marketplace](https://marketplace.fedramp.gov) as authorized or in-process, or when a CSP has retained a 3PAO to pursue authorization.
 
 You can read all about this at [cloud.gov Compliance Community](({{ site.baseurl }}{% link _docs/compliance/compliance-community.md %})), and join today by sending an email to [cloud-gov-compliance@gsa.gov](mailto:cloud-gov-compliance@gsa.gov) from the domain of your FedRAMP CSP.

--- a/_posts/2023-08-01-fedramp-csp-community.md
+++ b/_posts/2023-08-01-fedramp-csp-community.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Announcing FedRAMP CSP Community mailing list
-date: July 3, 2023
+date: August 1, 2023
 excerpt: "Email cloud-gov-compliance@gsa.gov from your CSP email to join"
 ---
 


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Describe CSP CoP
- The code of conduct is largely lifted from https://digital.gov/communities/community-guidelines/
- The email address will change as soon we get cloud-gov-community@gsa.gov, or community@cloud.gov, provided to us (SNow ticket is in progress)
- Pages changed:
   *  https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/peterb/fedramp-cop/docs/compliance/compliance-community/
   * https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/peterb/fedramp-cop/2023/08/01/fedramp-csp-community/


## Security Considerations
Announcing public information. None
