### PR TITLE
Update link target

### DIFF
--- a/_pages/pages/documentation/search.md
+++ b/_pages/pages/documentation/search.md
@@ -8,7 +8,7 @@ sidenav: pages-documentation
 
 It's easy to add search functionality to a site.
 
-We recommend using [Search.gov][], a free site search and search analytics service for federal web sites. You will need to [register](https://search.usa.gov/signup) for Search.gov and follow their [instructions](https://search.gov/blog/go-live.html) to integrate this service with your Pages site. For full details, visit [Search.gov][]. 
+We recommend using [Search.gov][], a free site search and search analytics service for federal web sites. You will need to [register](https://search.usa.gov/signup) for Search.gov and follow their [instructions](https://search.gov/get-started/searchgov-for-cloudgov-pages.html) to integrate this service with your Pages site. For full details, visit [Search.gov][]. 
 
 If you'd prefer another solution, you can configure a tool like [lunrjs](https://lunrjs.com/) that creates a search function run using the client browser. An example of this is at the [18F blog](https://18f.gsa.gov/blog/). This avoids any dependency on another service, but the search results are not as robust.
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Search.gov has a Pages-specific help page, and we'd like the "instructions" link to point to that page, rather than our go-live guide.

## Security Considerations
None, just updating the target of the link from one page on a website to a different one.
