### PR TITLE
Bruce usab netlifycms dot org is now decapcsm

### DIFF
--- a/_data/pages/navigation.yml
+++ b/_data/pages/navigation.yml
@@ -56,8 +56,8 @@ sidenav:
         href: /pages/documentation/sandbox/
       - text: "21st Century IDEA"
         href: /pages/documentation/21st-century-idea/
-      - text: Getting started with Netlify CMS
-        href: /pages/documentation/getting-started-with-netlify-cms/
+      - text: Getting started with Decap CMS
+        href: /pages/documentation/getting-started-with-decap-cms/
       - text: Included with Pages
         href: /pages/documentation/included-with-pages/
       - text: Instructional demos

--- a/_pages/pages/documentation/add-user.md
+++ b/_pages/pages/documentation/add-user.md
@@ -35,7 +35,7 @@ As a new user to the platform you will be sent an invitation via email. The link
 
 
   
-Netlify CMS users **must** login to pages.cloud.gov prior to using the content editor.
+Decap CMS users **must** login to pages.cloud.gov prior to using the content editor.
 
 ## Who should be added
 

--- a/_pages/pages/documentation/getting-started-with-netlify-cms.md
+++ b/_pages/pages/documentation/getting-started-with-netlify-cms.md
@@ -1,17 +1,17 @@
 ---
-title: Getting started with Netlify CMS
-permalink: /pages/documentation/getting-started-with-netlify-cms/
+title: Getting started with Decap CMS
+permalink: /pages/documentation/getting-started-with-decap-cms/
 layout: docs
 navigation: pages
 sidenav: pages-documentation
 ---
 
-Pages recently integrated support for Netlify CMS, an open source content management system for your Github-based content that provides editors with a friendly UI and workflow.
+Pages recently integrated support for Decap CMS, an open source content management system for your Github-based content that provides editors with a friendly UI and workflow.
 
 ### Building a new site from template
-The Pages templates include pre-configured Netlify CMS functionality. To begin utilizing:
+The Pages templates include pre-configured Decap CMS functionality. To begin utilizing:
 1. select the [template]({{site.baseurl}}/pages/documentation/templates/) that you wish to use as your base site
-2. navigate to the new GitHub repository that Pages created, and **update** the Netlify CMS configuration to point to the current repository
+2. navigate to the new GitHub repository that Pages created, and **update** the Decap CMS configuration to point to the current repository
 
 ```
     # 11ty: /admin/config.yml
@@ -24,10 +24,10 @@ The Pages templates include pre-configured Netlify CMS functionality. To begin u
 ```
 3. when you are done, your configuration should look something like the one in [configuration requirements](#configuration-requirements)
 
-4. once your site is rebuilt in Pages, Netlify CMS is ready to use! Navigate to `https://<your site url>/admin` and edit away.
+4. once your site is rebuilt in Pages, Decap CMS is ready to use! Navigate to `https://<your site url>/admin` and edit away.
 
-### Adding Netlify CMS to existing site
-If your site is already up and running, please follow the instructions on [Netlify's Add To Your Site](https://www.netlifycms.org/docs/add-to-your-site/) page to add Netlify CMS. Please pay particular attention to the location of the admin folder depending on your static site generator.
+### Adding Decap CMS to existing site
+If your site is already up and running, please follow the instructions on [Decap's Add To Your Site](https://decapcms.org/docs/add-to-your-site/) page to add Decap CMS. Please pay particular attention to the location of the admin folder depending on your static site generator.
 
 - 11ty: `/admin/config.yml`
 - Gatsby or Hugo: `/static/admin/config.yml`
@@ -37,7 +37,7 @@ For examples of existing configurations, see the Pages starter:
 - [Pages USWDS Gatsby](https://github.com/cloud-gov/pages-uswds-gatsby/blob/main/static/admin/config.yml)
 
 ### Configuration Requirements
-To use Netlify CMS, you must authenticate with Github, and in order for Pages to facilitate this, your Netlify CMS configuration should include the following:
+To use Decap CMS, you must authenticate with Github, and in order for Pages to facilitate this, your Decap CMS configuration should include the following:
 
 ```
 
@@ -55,10 +55,10 @@ To use Netlify CMS, you must authenticate with Github, and in order for Pages to
     ...
 ```
 
-See [Netlify CMS Backends Overview](https://decapcms.org/docs/backends-overview/) for a full description of the configuration options.
+See [Decap CMS Backends Overview](https://decapcms.org/docs/backends-overview/) for a full description of the configuration options.
 
 ### Authentication Requirements
-Because Pages facilitates the authentication with Github, we require users of Netlify CMS to be Pages users in addition to having `write` permissions to the Github repository.
+Because Pages facilitates the authentication with Github, we require users of Decap CMS to be Pages users in addition to having `write` permissions to the Github repository.
 
-### Getting familiar with Netlify CMS
-To learn more about Netlify CMS and how it may help you manage content changes on your Pages site, please visit [netlifycms.org/]([https://www.netlifycms.org/)
+### Getting familiar with Decap CMS
+To learn more about Decap CMS and how it may help you manage content changes on your Pages site, please visit [decapcms.org](https://www.decapcms.org/)

--- a/_pages/pages/documentation/getting-started-with-netlify-cms.md
+++ b/_pages/pages/documentation/getting-started-with-netlify-cms.md
@@ -55,10 +55,10 @@ To use Netlify CMS, you must authenticate with Github, and in order for Pages to
     ...
 ```
 
-See [Netlify CMS Backends Overview](https://www.netlifycms.org/docs/backends-overview) for a full description of the configuration options.
+See [Netlify CMS Backends Overview](https://decapcms.org/docs/backends-overview/) for a full description of the configuration options.
 
 ### Authentication Requirements
 Because Pages facilitates the authentication with Github, we require users of Netlify CMS to be Pages users in addition to having `write` permissions to the Github repository.
 
 ### Getting familiar with Netlify CMS
-To learn more about Netlify CMS and how it may help you manage content changes on your Pages site, please visit [netlifycms.org/](https://www.netlifycms.org/)
+To learn more about Netlify CMS and how it may help you manage content changes on your Pages site, please visit [netlifycms.org/]([https://www.netlifycms.org/)


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update Netlify CMS references and links to the transitioned Decap CMS org

## Security Considerations
None
