### PR TITLE
Update Pages pricing and terms

### DIFF
--- a/_pages/pages/features.md
+++ b/_pages/pages/features.md
@@ -67,7 +67,7 @@ title: cloud.gov Pages - Features
       <ul>
         <li>Execute an Interagency Agreement in weeks.</li>
         <li>Unlimited storage and bandwidth for your sites.</li>
-        <li>Unlimited sites for your team.</li>
+        <li>Five custom domains included, with more available.</li>
         <li>Pages’s content delivery network seamlessly keeps your site up and running even when traffic spikes.</li>
         <li>No hidden charges.</li>
       </ul>

--- a/_pages/pages/pricing.md
+++ b/_pages/pages/pricing.md
@@ -7,7 +7,7 @@ title: cloud.gov Pages - Pricing
 
 <section class="usa-section">
   <div class="grid-row">
-    <h1 class="margin-top-0">Platform Access to Pages for only $24,949/year</h1>
+    <h1 class="margin-top-0">Platform Access to Pages for only $35,000/year</h1>
   </div>
   <div class="grid-row usa-prose">
     <p class="usa-intro">Included in subscription:</p>
@@ -17,8 +17,13 @@ title: cloud.gov Pages - Pricing
       <li>Web-based configuration page for managing individual sites.</li>
       <li>Highly scalable content delivery network (CDN) to ensure uptime.</li>
       <li>Automatic HTTPS certificates and renewals for all your websites.</li>
-      <li>Unlimited sites for your office.</li>
+      <li>Five custom domains for your office.</li>
+      <li>Unlimited preview sites for development.</li>
       <li>No charges for storage or bandwidth.</li>
     </ul>
+  </div>
+  <div class="grid-row">
+    <p class="usa-intro">Additional custom domains available: 3 domains for $21,000/year</p>
+    <p>Pricing shown is effective beginning December 1, 2023.</p>
   </div>
 </section>


### PR DESCRIPTION
Fixes #2411 

## Changes proposed in this pull request:
- Change `pages/features` and `pages/pricing` to reflect new pricing and terms effective December 1, 2023

## Preview
Pricing page: [current](https://cloud.gov/pages/pricing/) / [preview](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/2411-update-pages-pricing/pages/pricing/)

Features page: [current](https://cloud.gov/pages/features/) / [preview](https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/2411-update-pages-pricing/pages/features/)

## Security Considerations
None. This is a content change to reflect changing information.
