### PR TITLE
remove dead links

### DIFF
--- a/_docs/ops/configuration-management.md
+++ b/_docs/ops/configuration-management.md
@@ -142,5 +142,3 @@ Whenever possible, the proposed changes should be tested locally. Because of the
 
 * Last modified on: {% last_modified_at %}
 * [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
-* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (from 2020-02-05 to 2022-11-08)
-* [Much older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)

--- a/_docs/ops/contingency-plan.md
+++ b/_docs/ops/contingency-plan.md
@@ -212,6 +212,7 @@ This plan is most effective if all core cloud.gov team members know about it, re
   * 2023-08-01: Replace Twitter for StatusPage fallback
   * 2023-07-28: Link correction for internal plans
   * 2023-06-13: Add link to internal contingency plan runbook
-* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
+* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2020-02-05)
+* [Older document history](https://github.com/cloud-gov/cg-site/commits/main/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)
 
 For assessment purposes, updates to [internal contingency plans](https://github.com/cloud-gov/internal-docs/blob/main/docs/runbooks/Platform/contingency.md) should be included along with public documentation updates.

--- a/_docs/ops/contingency-plan.md
+++ b/_docs/ops/contingency-plan.md
@@ -137,7 +137,7 @@ After these steps are complete, updates will be deployed per usual policy using 
 All alerts automatically get delivered to the Cloud Operations team via GSA email.  If GSA email is unavailable, the [Prometheus Alert Manager](https://alertmanager.fr.cloud.gov) provides current alerts.
 
 ### GSA SecureAuth
-Cloud Operations will update the `opslogin` UAA instance to allow temporary access via password authentication for any accounts that require access during a disruption in service. The runbook is included in `internal-docs/runbook/contingency.md` 
+Cloud Operations will update the `opslogin` UAA instance to allow temporary access via password authentication for any accounts that require access during a disruption in service. The runbook is included in `internal-docs/runbook/contingency.md`
 
 When the disruption in service is resolved, Cloud Operations will disable password authentication for all accounts.
 
@@ -170,7 +170,7 @@ recovery of the PaaS is a prerequisite for recovering the Pages service. A
 full recovery of the PaaS should include the running Pages service. If Pages
 needs to be recovered separately, a [cloud.gov Pages contingency
 plan](https://docs.google.com/document/d/1YG6oucagNO_ZmmlsLPdQeFABCiVcY1BYuhDEEvDwe4Q/edit)
-is available internally. 
+is available internally.
 
 ## Statuspage
 
@@ -182,11 +182,8 @@ The full Continuity of Operations Plan (COOP) and Disaster Recovery Plan (DRP) a
 
 * [TTS Devolution of Operations Playbook (Jan 2020)](https://drive.google.com/file/d/1sfSVhVPBteobeqhqnyb152z1PqboOKJI/view)
 * [TTS Google COOP Site](https://sites.google.com/a/gsa.gov/continuity/home/coming-soon---customized-hsso-pages/ocsit)
-* [TTS-wide Emergency Contact Spreadsheet](https://docs.google.com/spreadsheets/d/1-Hhv5S0M03W4JY1k-CM5vxrZildHUdMaxAoqLTWF2Ts/edit#gid=1295161336)
 * [cloud.gov COOP/DRP resources](https://github.com/cloud-gov/internal-docs/blob/main/docs/runbooks/Platform/contingency.md#coop)
 * [(deprecated) TTS Emergency Personnel Roster](https://docs.google.com/spreadsheets/d/1ITXXOu2IAntV8r6snIYHyXlRt1MgIlxpr-GudDP8tqQ/edit#gid=0)
-
-
 
 ## How this document works
 
@@ -211,12 +208,10 @@ This plan is most effective if all core cloud.gov team members know about it, re
 
 ### Page information
 
-* Last modified on: {% last_modified_at %} 
+* Last modified on: {% last_modified_at %}
   * 2023-08-01: Replace Twitter for StatusPage fallback
   * 2023-07-28: Link correction for internal plans
   * 2023-06-13: Add link to internal contingency plan runbook
 * [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
-* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (from 2020-02-05 to 2022-11-08)
-* [Much older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)
 
 For assessment purposes, updates to [internal contingency plans](https://github.com/cloud-gov/internal-docs/blob/main/docs/runbooks/Platform/contingency.md) should be included along with public documentation updates.

--- a/_docs/ops/continuous-integration.md
+++ b/_docs/ops/continuous-integration.md
@@ -46,4 +46,5 @@ This is where all customer workloads live. All the same rules apply to our produ
 ### Page information
 
 * Last modified on: {% last_modified_at %}
-* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
+* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2020-02-05)
+* [Older document history](https://github.com/cloud-gov/cg-site/commits/main/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)

--- a/_docs/ops/continuous-integration.md
+++ b/_docs/ops/continuous-integration.md
@@ -47,5 +47,3 @@ This is where all customer workloads live. All the same rules apply to our produ
 
 * Last modified on: {% last_modified_at %}
 * [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
-* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (from 2020-02-05 to 2022-11-08)
-* [Much older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)

--- a/_docs/ops/continuous-monitoring.md
+++ b/_docs/ops/continuous-monitoring.md
@@ -265,4 +265,5 @@ Examples:
 ### Page information
 
 * Last modified on: {% last_modified_at %}
-* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
+* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2020-02-05)
+* [Older document history](https://github.com/cloud-gov/cg-site/commits/main/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)

--- a/_docs/ops/continuous-monitoring.md
+++ b/_docs/ops/continuous-monitoring.md
@@ -266,5 +266,3 @@ Examples:
 
 * Last modified on: {% last_modified_at %}
 * [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
-* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (from 2020-02-05 to 2022-11-08)
-* [Much older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)

--- a/_docs/ops/maintenance-list.md
+++ b/_docs/ops/maintenance-list.md
@@ -97,7 +97,7 @@ As part of platform automation, and Concourse and Terraform run a `plan-bootstra
 
 ### Monitor production deployment jobs
 
-The Concourse jobs for deploying `production-cf` and `production-logsearch` are setup for manual operator release.  Keep track of when changes are ready to deploy in production since these are customer facing and make sure deployment of these jobs are done during normal platform support hours and during pre-determined times as described [here](https://cloud.gov/docs/overview/customer-service-objectives/). 
+The Concourse jobs for deploying `production-cf` and `production-logsearch` are setup for manual operator release.  Keep track of when changes are ready to deploy in production since these are customer facing and make sure deployment of these jobs are done during normal platform support hours and during pre-determined times as described [here](https://cloud.gov/docs/overview/customer-service-objectives/).
 
 ## Monitor AWS alerts
 
@@ -143,4 +143,5 @@ If you see a way to make this checklist better, just submit a PR to the
 
 ## Page information
 
-To view modifications to this page, review the [git commit history](https://github.com/cloud-gov/cg-site/commits/master/_docs/ops/maintenance-list.md).
+* Last modified on: {% last_modified_at %}
+* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)

--- a/_docs/ops/maintenance-list.md
+++ b/_docs/ops/maintenance-list.md
@@ -144,4 +144,5 @@ If you see a way to make this checklist better, just submit a PR to the
 ## Page information
 
 * Last modified on: {% last_modified_at %}
-* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
+* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2020-02-05)
+* [Older document history](https://github.com/cloud-gov/cg-site/commits/main/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)

--- a/_docs/ops/security-ir-checklist.md
+++ b/_docs/ops/security-ir-checklist.md
@@ -96,5 +96,3 @@ If we've leaked secrets in Github, _once the Incident Response team has told us 
 
 * Last modified on: {% last_modified_at %}
 * [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
-* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (from 2020-02-05 to 2022-11-08)
-* [Much older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)

--- a/_docs/ops/security-ir-checklist.md
+++ b/_docs/ops/security-ir-checklist.md
@@ -95,4 +95,5 @@ If we've leaked secrets in Github, _once the Incident Response team has told us 
 ### Page information
 
 * Last modified on: {% last_modified_at %}
-* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
+* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2020-02-05)
+* [Older document history](https://github.com/cloud-gov/cg-site/commits/main/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)

--- a/_docs/ops/security-ir.md
+++ b/_docs/ops/security-ir.md
@@ -258,7 +258,5 @@ Guidelines for addressing Low-sev issues:
 
 * Last modified on: {% last_modified_at %}
 * [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
-* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (from 2020-02-05 to 2022-11-08)
-* [Much older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)
 
 [FedRAMP ISSO TRR reps]: https://docs.google.com/document/d/1jGddQkjkQ6e9B0UTq9hfQqHe0btAbTeBGL_DxkozAcg/edit

--- a/_docs/ops/security-ir.md
+++ b/_docs/ops/security-ir.md
@@ -257,6 +257,7 @@ Guidelines for addressing Low-sev issues:
 ### Page information
 
 * Last modified on: {% last_modified_at %}
-* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
+* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2020-02-05)
+* [Older document history](https://github.com/cloud-gov/cg-site/commits/main/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)
 
 [FedRAMP ISSO TRR reps]: https://docs.google.com/document/d/1jGddQkjkQ6e9B0UTq9hfQqHe0btAbTeBGL_DxkozAcg/edit

--- a/_docs/ops/service-disruption-guide.md
+++ b/_docs/ops/service-disruption-guide.md
@@ -133,4 +133,5 @@ They also have a baseline expectation that we have good answers to the following
 ### Page information
 
 * Last modified on: {% last_modified_at %}
-* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
+* [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2020-02-05)
+* [Older document history](https://github.com/cloud-gov/cg-site/commits/main/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)

--- a/_docs/ops/service-disruption-guide.md
+++ b/_docs/ops/service-disruption-guide.md
@@ -134,5 +134,3 @@ They also have a baseline expectation that we have good answers to the following
 
 * Last modified on: {% last_modified_at %}
 * [Recent document history](https://github.com/cloud-gov/cg-site/commits/main/{{ page.path }}) (since 2022-11-08)
-* [Older document history](https://github.com/cloud-gov/cg-site/commits/master/{{ page.path }}) (from 2020-02-05 to 2022-11-08)
-* [Much older document history](https://github.com/cloud-gov/cg-site/commits/master/content/docs/ops/{{ page.slug }}.md) (before 2020-02-05)


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove links that no longer work, including outdated emergency contact spreadsheet link and links to the `master` branch on this repo, which no longer exists

## Security Considerations

These links don't work and having inaccurate/outdated contingency information on our website is misleading
