### PR TITLE
fix-issue-2440: Fixing documentation in User Acceptance as per #2440

### DIFF
--- a/_pages/pages/documentation/add-user.md
+++ b/_pages/pages/documentation/add-user.md
@@ -33,7 +33,7 @@ As a new user to the platform, you will be sent an invitation via email. The lin
 
 **Note:** 
 * If a user already belongs to these agencies FDIC, EPA, NIH, GSA, DOJ, OMB or has existing cloud.gov credentials they can use their existing account login information to authenticate into Pages.
-* Decap CMS users **must** login to <https://pages.cloud.gov/> prior to using the content editor.
+* Decap CMS users **must** login to [pages.cloud.gov](https://pages.cloud.gov/) prior to using the content editor.
 
 ## Who should be added
 

--- a/_pages/pages/documentation/add-user.md
+++ b/_pages/pages/documentation/add-user.md
@@ -29,13 +29,11 @@ If you are having trouble locating who the organization manager is you can reach
 
 ## User Acceptance
 
-As a new user to the platform you will be sent an invitation via email. The link in the email will take you directly to the cloud.gov login page to authenticate your credentials.  You will need to create a cloud.gov account and then use these credentials to login to Pages. 
+As a new user to the platform, you will be sent an invitation via email. The link in the email will take you directly to the cloud.gov login page to authenticate your credentials.  You will need to create a cloud.gov account and then use these credentials to login to Pages. 
 
-\*Note if a user already belongs to these agencies FDIC, EPA, NIH, GSA, DOJ, OMB or has existing cloud.gov credentials they can use their existing account login information to authenticate into Pages.
-
-
-  
-Decap CMS users **must** login to pages.cloud.gov prior to using the content editor.
+**Note:** 
+* If a user already belongs to these agencies FDIC, EPA, NIH, GSA, DOJ, OMB or has existing cloud.gov credentials they can use their existing account login information to authenticate into Pages.
+* Decap CMS users **must** login to <https://pages.cloud.gov/> prior to using the content editor.
 
 ## Who should be added
 

--- a/_pages/pages/documentation/permissions.md
+++ b/_pages/pages/documentation/permissions.md
@@ -45,7 +45,7 @@ As a new user to the platform, you will be sent an invitation via email. The lin
 
 **Note:** 
 * If a user already belongs to these agencies FDIC, EPA, NIH, GSA, DOJ, OMB or has existing cloud.gov credentials they can use their existing account login information to authenticate into Pages.
-* Netlify CMS users **must** login to <https://pages.cloud.gov/> prior to using the content editor.
+* Netlify CMS users **must** login to [pages.cloud.gov](https://pages.cloud.gov/) prior to using the content editor.
 
 ## Site permissions
 

--- a/_pages/pages/documentation/permissions.md
+++ b/_pages/pages/documentation/permissions.md
@@ -41,12 +41,11 @@ Pages Users within an Organization will be able to see all of the Sites in the O
 
 ## User Acceptance
 
-As a new user to the platform you will be sent an invitation via email. The link in the email will take you directly to the cloud.gov login page to authenticate your credentials.  You will need to create a cloud.gov account and then use these credentials to login to Pages.
+As a new user to the platform, you will be sent an invitation via email. The link in the email will take you directly to the cloud.gov login page to authenticate your credentials.  You will need to create a cloud.gov account and then use these credentials to login to Pages.
 
-\*Note if a user already belongs to these agencies FDIC, EPA, NIH, GSA, DOJ, OMB or has existing cloud.gov credentials they can use their existing account login information to authenticate into Pages.
-
-
-Netlify CMS users **must** login to pages.cloud.gov prior to using the content editor.
+**Note:** 
+* If a user already belongs to these agencies FDIC, EPA, NIH, GSA, DOJ, OMB or has existing cloud.gov credentials they can use their existing account login information to authenticate into Pages.
+* Netlify CMS users **must** login to <https://pages.cloud.gov/> prior to using the content editor.
 
 ## Site permissions
 


### PR DESCRIPTION
Fixing documentation in Pages > User Acceptance as per #2440. Updated "User Acceptance" in in following two files:

_pages/pages/documentation/add-user.md 
_pages/pages/documentation/permissions.md

Changes made are:
1.  Placed a `comma(,)` in the statement: As a new user to the platform`,` you will be sent an invitation via email.
2. Made Note as subheading for  "User Acceptance".
3. Replaced plain-text `pages.cloud.gov` with a URL as: [pages.cloud.gov](https://pages.cloud.gov/).

<img width="1032" alt="image" src="https://github.com/cloud-gov/cg-site/assets/59294845/1bfc1023-56ef-4fa9-9589-372d839f3af0">
