### PR TITLE
Add a missing word to website-api.md

### DIFF
--- a/_kbarticlespages/website-api.md
+++ b/_kbarticlespages/website-api.md
@@ -127,7 +127,7 @@ Once your server API can connect to the database, execute queries at specific ro
 
 ### Serve content to the Pages website
 
-Now, you’re ready to request dynamic content from your static. In our example, the Pages-hosted site is a single [index.html](https://github.com/cloud-gov/pages-example-api-website) file with some CSS and image assets and a few lines of JavaScript to make the request and display the dynamic content. We’re using an already minified version of the U.S. Web Design System (USWDS) library from a Content Delivery Network (CDN) so there are no build tasks, transpiling, preprocessing, or compiling in this project – just a simple static site with some nav and the basic structure of a table, waiting to be filled with dynamic content.
+Now, you’re ready to request dynamic content from your static site. In our example, the Pages-hosted site is a single [index.html](https://github.com/cloud-gov/pages-example-api-website) file with some CSS and image assets and a few lines of JavaScript to make the request and display the dynamic content. We’re using an already minified version of the U.S. Web Design System (USWDS) library from a Content Delivery Network (CDN) so there are no build tasks, transpiling, preprocessing, or compiling in this project – just a simple static site with some nav and the basic structure of a table, waiting to be filled with dynamic content.
 
 There are two steps left: Making the HTTP request to the server app, and then displaying the response that the server app provides. Both are handled with straightforward JavaScript.
 


### PR DESCRIPTION
Add what seems like a missing word.

## Changes proposed in this pull request:
- It seemed like there was a missing word in the ["Serve content to the Pages website"](https://cloud.gov/pages/knowledge-base/website-api/#serve-content-to-the-pages-website) section.

## Security Considerations
Verbiage change, no security impact.
