### PR TITLE
Update identity provider list

### DIFF
--- a/_docs/management/leveraging-authentication.md
+++ b/_docs/management/leveraging-authentication.md
@@ -7,11 +7,26 @@ redirect_from:
 title: Leveraging cloud.gov authentication
 ---
 
-cloud.gov uses Cloud Foundry's [User Account and Authentication (UAA) server](https://docs.cloudfoundry.org/concepts/architecture/uaa.html) to provide identity management capabilities for the cloud.gov platform.
+cloud.gov uses Cloud Foundry's [User Account and Authentication (UAA) server](https://docs.cloudfoundry.org/concepts/architecture/uaa.html) to provide identity access capabilities for the cloud.gov platform.
 
-App developers can leverage cloud.gov's UAA instance as a backend that brokers authentication with [supported identity providers]({{ site.baseurl }}{% link _docs/getting-started/accounts.md %}#get-access-to-cloudgov) (currently EPA, FDIC, GSA, NSF, and a cloud.gov provider that supports other agencies). You can use cloud.gov's authentication brokering if the users that you need to authenticate in your application are federal employees and contractors who can use those authentication methods.
+You can leverage cloud.gov's authentication system to enable users to log into your application. This service handles only authentication, not authorization -- it's up to your application to manage what they can access within the application. The supported identity providers are:
 
-This service handles only authentication, not authorization -- it's up to your application to manage what they can access within the application. Once you set it up, you can direct your users to the [list of ways to get cloud.gov access]({{ site.baseurl }}{% link _docs/getting-started/accounts.md %}#get-access-to-cloudgov); they don't need any org or space roles, they just need to be able to log into cloud.gov.
+- DOJ.gov
+- ED.gov
+- EPA.gov
+- FDIC.gov
+- FEC.gov
+- FRTIB.gov
+- GSA.gov
+- MCC.gov
+- NIH.gov
+- OMB.gov
+- ONRR.gov
+- SSA.gov
+
+In addition, you can direct users with a valid federal email address to the [list of ways to get cloud.gov access]({{ site.baseurl }}{% link _docs/getting-started/accounts.md %}#get-access-to-cloudgov) to sign up for a cloud.gov account; they don't need any org or space roles, they just need to be able to log into cloud.gov.
+
+You can use cloud.gov's authentication brokering if the users that you need to authenticate in your application are federal employees and contractors who can use those authentication methods.
 
 ## Using cloud.gov authentication
 


### PR DESCRIPTION
NSF is no longer registered as an IdP, but many other agencies are.

## Changes proposed in this pull request:
- Remove NSF
- Add many others

## Security Considerations
[Note the any security considerations here, or make note of why there are none]

None, this is just a documentation update; the list of IdPs is already on the login page.