### PR TITLE
remove references to agencies with SSO integration

### DIFF
--- a/_docs/getting-started/accounts.md
+++ b/_docs/getting-started/accounts.md
@@ -8,8 +8,7 @@ weight: -100
 
 ## Get access to cloud.gov
 
-* **If you're in EPA, GSA, or NSF:** You automatically have access and can log in using your agency credentials.
-* **If you're in FDIC:** Some FDIC staff automatically have access and can log in using agency credentials. If you try to log in and receive a "status message is null" error, contact the FDIC identity team to be added to the cloud.gov access group.
+* **If your agency has integrated SSO with cloud.gov:** You can see a list of agencies which have integrated SSO on the [cloud.gov login page](https://login.fr.cloud.gov/login). If you are a member of one of these agencies, you automatically have access and can log in using your agency credentials.
 * **If you're in another agency:** If you have a U.S. federal government email address, you can [sign up for access](https://account.fr.cloud.gov/signup).
 * **Otherwise:** If your team uses cloud.gov and you don't have a federal government email address (such as if you're a contractor), ask a teammate to [invite you]({{ site.baseurl }}{% link _docs/orgs-spaces/roles.md %}).
 
@@ -17,7 +16,7 @@ weight: -100
 
 ### Agency single sign-on accounts
 
-If you have an EPA, FDIC, GSA, or NSF email address, sign in using your agency credentials. Follow [these instructions to log in]({{ site.baseurl }}{% link _docs/getting-started/setup.md %}).
+If your agency has integrated SSO with cloud.gov, you can sign in using your agency credentials. Follow [these instructions to log in]({{ site.baseurl }}{% link _docs/getting-started/setup.md %}).
 
 ### cloud.gov accounts
 
@@ -42,7 +41,6 @@ When you log into cloud.gov for the first time, follow the instructions to set t
     1. Enter your old password into the `Old Password` input
     1. Then create and enter the new password into `New Password` input and confirm it in the `Repeat New Password` input
     1. Finally, click *CHANGE*
-
 
 #### To reset your password
 

--- a/_docs/management/leveraging-authentication.md
+++ b/_docs/management/leveraging-authentication.md
@@ -2,14 +2,14 @@
 parent: management
 layout: docs
 sidenav: true
-redirect_from: 
+redirect_from:
     - /docs/apps/leveraging-authenication/
 title: Leveraging cloud.gov authentication
 ---
 
 cloud.gov uses Cloud Foundry's [User Account and Authentication (UAA) server](https://docs.cloudfoundry.org/concepts/architecture/uaa.html) to provide identity management capabilities for the cloud.gov platform.
 
-App developers can leverage cloud.gov's UAA instance as a backend that brokers authentication with [supported identity providers]({{ site.baseurl }}{% link _docs/getting-started/accounts.md %}#get-access-to-cloudgov) (currently EPA, FDIC, GSA, NSF, and a cloud.gov provider that supports other agencies). You can use cloud.gov's authentication brokering if the users that you need to authenticate in your application are federal employees and contractors who can use those authentication methods.
+App developers can leverage cloud.gov's UAA instance as a backend that brokers authentication with [supported identity providers]({{ site.baseurl }}{% link _docs/getting-started/accounts.md %}#get-access-to-cloudgov). You can use cloud.gov's authentication brokering if the users that you need to authenticate in your application are federal employees and contractors who can use those authentication methods.
 
 This service handles only authentication, not authorization -- it's up to your application to manage what they can access within the application. Once you set it up, you can direct your users to the [list of ways to get cloud.gov access]({{ site.baseurl }}{% link _docs/getting-started/accounts.md %}#get-access-to-cloudgov); they don't need any org or space roles, they just need to be able to log into cloud.gov.
 
@@ -24,6 +24,7 @@ You will first need to register all instances (such as dev, staging, and product
 UAA handles authentication according to the [OpenID Connect](http://openid.net/connect/) specification, which is "a simple identity layer on top of the OAuth 2.0 protocol."
 
 There are two important cloud.gov URLs you will need to use:
+
 - `https://login.fr.cloud.gov/oauth/authorize`, which is where you will direct the user to login with their agency credentials
 - `https://uaa.fr.cloud.gov/oauth/token`, which is where you will exchange auth codes for auth tokens
 
@@ -34,10 +35,10 @@ If you are already familiar with OAuth 2.0, you might know where to go from here
 First, generate a link (or redirect the user) to the authorize URL with these
 query parameters:
 
-* `client_id=<CLIENT_ID>` (you can retrieve your `client_id` via `cf service-key`)
-* `response_type=code`
-* `redirect_uri=<A REGISTERED CALLBACK URL>` (required if you have multiple registered callback URLs)
-* `state=<ANYTHING>` (optional)
+- `client_id=<CLIENT_ID>` (you can retrieve your `client_id` via `cf service-key`)
+- `response_type=code`
+- `redirect_uri=<A REGISTERED CALLBACK URL>` (required if you have multiple registered callback URLs)
+- `state=<ANYTHING>` (optional)
 
 You only need to provide `redirect_uri` if you have multiple registered callback URLs for a single
 UAA registration (for instance, if you have both an "app.cloud.gov" URL and a production URL).
@@ -63,16 +64,16 @@ Once the user successfully logs in with their credentials, your app will
 receive a `GET` request to the callback URL associated with the registered
 app. The `GET` request will include query parameters:
 
-* `code=<A UNIQUE ACCESS CODE>`
-* (optional) `state=<VALUE FROM STATE PARAM IN AUTHORIZE LINK>`
+- `code=<A UNIQUE ACCESS CODE>`
+- (optional) `state=<VALUE FROM STATE PARAM IN AUTHORIZE LINK>`
 
 Now your site's backend will need to exchange the access code for an
 access token. Here is where things get fun.
 
-1.  First, exchange the `code` for an authorization token by sending a
-    `POST` request to the token endpoint
-    (`https://uaa.fr.cloud.gov/oauth/token`) with the following form-encoded
-    parameters:
+1. First, exchange the `code` for an authorization token by sending a
+  `POST` request to the token endpoint
+  (`https://uaa.fr.cloud.gov/oauth/token`) with the following form-encoded
+  parameters:
 
     - `code=<CODE FROM QUERY PARAM IN CALLBACK REQUEST>`
     - `grant_type=authorization_code`
@@ -81,29 +82,29 @@ access token. Here is where things get fun.
     - `client_secret=<CLIENT_SECRET>` (you can retrieve your `client_secret` via `cf service-key`)
     - `redirect_uri=<A REGISTERED CALLBACK URL>` (required if you have multiple registered callback URLs)
 
-2.  If everything works and UAA is able to verify your request, the response
-    from that `POST` request will be JSON encoded and will contain these
-    important members:
+2. If everything works and UAA is able to verify your request, the response
+  from that `POST` request will be JSON encoded and will contain these
+  important members:
 
     - `access_token` - a [JSON Web Token](https://jwt.io/)
     - `expires_in` - time in seconds until the `access_token` expires
     - `refresh_token` - a refresh token that can be exchanged for another
       `access_token` when the current one expires
 
-3.  The `access_token` is a JSON Web Token that can be decoded using a
-    library such as [node-jsonwebtoken](https://github.com/auth0/node-jsonwebtoken).
-    See https://jwt.io/ for a list of libraries for various languages. 
-    
-    Verify the token's signature using cloud.gov's JWK Set and the RSA256 alogrithm. This step ensures the
-    token is authentic. The JWK Set for cloud.gov's UAA is located at `https://uaa.fr.cloud.gov/token_keys`. 
-    
-    Decode the token to get the authenticated user's `email`, which you can then use within
-    your application to identify and/or authorize the user.
+3. The `access_token` is a JSON Web Token that can be decoded using a
+  library such as [node-jsonwebtoken](https://github.com/auth0/node-jsonwebtoken).
+  See <https://jwt.io/> for a list of libraries for various languages.
+  
+  Verify the token's signature using cloud.gov's JWK Set and the RSA256 alogrithm. This step ensures the
+  token is authentic. The JWK Set for cloud.gov's UAA is located at `https://uaa.fr.cloud.gov/token_keys`.
+  
+  Decode the token to get the authenticated user's `email`, which you can then use within
+  your application to identify and/or authorize the user.
 
-    If you get an expired token error at some point in the future, you can
-    exchange the `refresh_token` from the previous step to get a new `access_token`,
-    so you might want to securely save the `refresh_token` associated with the
-    authenticated user.
+  If you get an expired token error at some point in the future, you can
+  exchange the `refresh_token` from the previous step to get a new `access_token`,
+  so you might want to securely save the `refresh_token` associated with the
+  authenticated user.
 
 #### Logging users out of UAA and your application
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Having explicit references to which agencies have SSO integrated is unnecessary and likely to be a continual source of outdated documentation, so removing those explicit references

## Security Considerations

None, just updating documentation for maintainability
