### PR TITLE
Added an example command for the template

### DIFF
--- a/_posts/2023-8-1-postgresql-versions-update.md
+++ b/_posts/2023-8-1-postgresql-versions-update.md
@@ -14,3 +14,9 @@ Please note that users are still able to explicitly set any of the [currently su
 ```shell
 cf create-service aws-rds <database-plan> <database-name> -c '{"version":"<desired-version>"}'
 ```
+
+For example,
+
+```shell
+cf create-service aws-rds micro-psql my-test-service -c '{"version":"15"}'
+```

--- a/_posts/2023-8-1-postgresql-versions-update.md
+++ b/_posts/2023-8-1-postgresql-versions-update.md
@@ -15,8 +15,8 @@ Please note that users are still able to explicitly set any of the [currently su
 cf create-service aws-rds <database-plan> <database-name> -c '{"version":"<desired-version>"}'
 ```
 
-For example,
+For example:
 
 ```shell
-cf create-service aws-rds micro-psql my-test-service -c '{"version":"15"}'
+cf create-service aws-rds micro-psql my-test-service -c '{"version":"14"}'
 ```


### PR DESCRIPTION
Added an example Cloud Foundry command for the template command provided
in the announcement.

## Changes proposed in this pull request:
Added an example Cloud Foundry command for the template command provided
in the announcement.

## Security Considerations
There are no security considerations, because this merely shows an example
invocation of Cloud Foundry CLI. This is similar to the examples previously
provided in the documentation here: 

https://cloud.gov/docs/services/relational-database/
