### PR TITLE
Update entity IDs to drop spurious protocol

### DIFF
--- a/_docs/orgs-spaces/sso.md
+++ b/_docs/orgs-spaces/sso.md
@@ -72,7 +72,7 @@ This is the environment where we test the configuration first. It matches our pr
 
 #### Entity ID
 
-- <https://login.fr-stage.cloud.gov>
+- `login.fr-stage.cloud.gov`
 
 #### OIDC Configuration
 
@@ -90,7 +90,7 @@ The same configuration as our staging environment, just with production hostname
 
 #### Entity ID
 
-- <https://login.fr.cloud.gov>
+- `login.fr.cloud.gov`
 
 #### OIDC Configuration
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Our entity ID does not actually include a protocol (https://). In a recent IDP integration, we discovered that including the protocol can cause an error due to the audience restriction not matching the actual audience (the entity ID). It appears some IDPs remove the protocol automatically and some do not, OR prior customers have used our metadata endpoint instead of manually configuring the integration. In any case, the correct value is the login hostname with no protocol.

You can see our actual entity ID (no protocol) in our [staging](https://login.fr-stage.cloud.gov/saml/metadata) and [production](https://login.fr.cloud.gov/saml/metadata) metadata. 

## Security Considerations

None; updates to public information