### PR TITLE
Add TOC functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,3 +31,5 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 gem "html-proofer", "~> 3.10"
 
 gem "addressable", ">= 2.8.0"
+
+gem 'jekyll-toc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,9 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
+    jekyll-toc (0.19.0)
+      jekyll (>= 3.9)
+      nokogiri (~> 1.12)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.4.0)
@@ -120,6 +123,7 @@ DEPENDENCIES
   jekyll-redirect-from
   jekyll-seo-tag
   jekyll-sitemap
+  jekyll-toc
   tzinfo-data
 
 RUBY VERSION

--- a/_assets/css/styles.scss
+++ b/_assets/css/styles.scss
@@ -695,7 +695,6 @@ blockquote .source {
 
 #table-of-contents ul#toc {
   padding: 0;
-  list-style-type: decimal;
   list-style-position: inside;
 }
 

--- a/_assets/css/styles.scss
+++ b/_assets/css/styles.scss
@@ -693,20 +693,8 @@ blockquote .source {
   background-color: color($theme-color-accent-warm-light);
 }
 
-#table-of-contents ol#toc {
+#table-of-contents ol {
+  font-size: .9rem;
   padding: 0;
   list-style-position: inside;
-}
-
-#table-of-contents h2 {
-  display: none;
-}
-
-#table-of-contents ol {
-  display: none;
-  font-size: .9rem;
-}
-
-#table-of-contents h2 + ol {
-  display: block;
 }

--- a/_assets/css/styles.scss
+++ b/_assets/css/styles.scss
@@ -698,6 +698,15 @@ blockquote .source {
   list-style-position: inside;
 }
 
-#table-of-contents ul {
+#table-of-contents h2 {
+  display: none;
+}
+
+#table-of-contents ol {
+  display: none;
   font-size: .9rem;
+}
+
+#table-of-contents h2 + ol {
+  display: block;
 }

--- a/_assets/css/styles.scss
+++ b/_assets/css/styles.scss
@@ -685,12 +685,20 @@ blockquote .source {
   color: #90a959;
 }
 
-ul#toc {
-  background-color: #f5f5f0;
-  padding: 2em;
-  font-size: .9rem;
+#table-of-contents {
+  @include u-border($theme-color-base-lighter);
+  border-width: 1px;
+  border-style: solid;
+  padding: 0 2em;
+  background-color: color($theme-color-accent-warm-light);
 }
 
-ul#toc, ul#toc ul {
-  list-style: none;
+#table-of-contents ul#toc {
+  padding: 0;
+  list-style-type: decimal;
+  list-style-position: inside;
+}
+
+#table-of-contents ul {
+  font-size: .9rem;
 }

--- a/_assets/css/styles.scss
+++ b/_assets/css/styles.scss
@@ -684,3 +684,13 @@ blockquote .source {
 .highlight .ss {
   color: #90a959;
 }
+
+ul#toc {
+  background-color: #f5f5f0;
+  padding: 2em;
+  font-size: .9rem;
+}
+
+ul#toc, ul#toc ul {
+  list-style: none;
+}

--- a/_assets/css/styles.scss
+++ b/_assets/css/styles.scss
@@ -693,7 +693,7 @@ blockquote .source {
   background-color: color($theme-color-accent-warm-light);
 }
 
-#table-of-contents ul#toc {
+#table-of-contents ol#toc {
   padding: 0;
   list-style-position: inside;
 }

--- a/_config.yml
+++ b/_config.yml
@@ -258,7 +258,7 @@ defaults:
 
 toc:
   min_level: 1
-  max_level: 1
+  max_level: 2
   ordered_list: true
   no_toc_section_class: no_toc_section
   list_id: toc

--- a/_config.yml
+++ b/_config.yml
@@ -173,13 +173,13 @@ permalink: pretty
 markdown: kramdown
 url: "https://cloud.gov"
 plugins:
+  - jekyll-toc
   - jekyll-feed
   - jekyll-paginate-v2
   - jekyll-redirect-from
   - jekyll-sitemap
   - jekyll-seo-tag
   - jekyll-last-modified-at
-  - jekyll-toc
 
 ############################################################
 # Site configuration for the Jekyll 3 Pagination Gem

--- a/_config.yml
+++ b/_config.yml
@@ -249,3 +249,10 @@ feed:
 
 include:
   - .well-known
+
+# _config.yml
+defaults:
+  - scope:
+      path: ""
+    values:
+      toc: true

--- a/_config.yml
+++ b/_config.yml
@@ -252,7 +252,39 @@ include:
 
 defaults:
   - scope:
-      path: ""
+      path: "_docs/compliance"
+    values:
+      toc: true
+  - scope:
+      path: "_docs/deployment"
+    values:
+      toc: true
+  - scope:
+      path: "_docs/getting-started"
+    values:
+      toc: true
+  - scope:
+      path: "_docs/management"
+    values:
+      toc: true
+  - scope:
+      path: "_docs/orgs-spaces"
+    values:
+      toc: true
+  - scope:
+      path: "_docs/overview"
+    values:
+      toc: true
+  - scope:
+      path: "_docs/pricing"
+    values:
+      toc: true
+  - scope:
+      path: "_docs/services"
+    values:
+      toc: true
+  - scope:
+      path: "_docs/technology"
     values:
       toc: true
 

--- a/_config.yml
+++ b/_config.yml
@@ -173,13 +173,13 @@ permalink: pretty
 markdown: kramdown
 url: "https://cloud.gov"
 plugins:
-  - jekyll-toc
   - jekyll-feed
   - jekyll-paginate-v2
   - jekyll-redirect-from
   - jekyll-sitemap
   - jekyll-seo-tag
   - jekyll-last-modified-at
+  - jekyll-toc
 
 ############################################################
 # Site configuration for the Jekyll 3 Pagination Gem
@@ -289,7 +289,7 @@ defaults:
       toc: true
 
 toc:
-  min_level: 1
+  min_level: 2
   max_level: 2
   ordered_list: true
   no_toc_section_class: no_toc_section

--- a/_config.yml
+++ b/_config.yml
@@ -179,6 +179,7 @@ plugins:
   - jekyll-sitemap
   - jekyll-seo-tag
   - jekyll-last-modified-at
+  - jekyll-toc
 
 ############################################################
 # Site configuration for the Jekyll 3 Pagination Gem

--- a/_config.yml
+++ b/_config.yml
@@ -250,9 +250,19 @@ feed:
 include:
   - .well-known
 
-# _config.yml
 defaults:
   - scope:
       path: ""
     values:
       toc: true
+
+toc:
+  min_level: 1
+  max_level: 1
+  ordered_list: true
+  no_toc_section_class: no_toc_section
+  list_id: toc
+  list_class: section-nav
+  sublist_class: ''
+  item_class: toc-entry
+  item_prefix: toc-

--- a/_docs/compliance/cisa-directives.md
+++ b/_docs/compliance/cisa-directives.md
@@ -2,10 +2,8 @@
 parent: compliance
 layout: docs
 sidenav: true
-title: CISA Directives
+title: CISA Emergency Directives
 ---
-
-# CISA Emergency Directives
 
 The Cybersecurity and Infrastructure Security Agency (CISA) periodically issues “[Emergency Directives](https://cyber.dhs.gov/directives/),” which require action by cloud.gov, as a FedRAMP-authorized service.
 
@@ -17,68 +15,67 @@ In response to CISA Emergency Directives, cloud.gov will:
 
 We will no longer be publicly providing our specific compliance status, as future directives could apply to components in the cloud.gov system.
 
-# FY2022
+## FY2022
 
-## CISA Emergency Directive 22-03, “Mitigate VMware Vulnerabilities.”
+### CISA Emergency Directive 22-03, “Mitigate VMware Vulnerabilities.”
 
 In response to CISA Emergency Directive 22-03, “Mitigate VMware Vulnerabilities”
 (https://www.cisa.gov/emergency-directive-22-03)
 cloud.gov has provided required applicability information in our FedRAMP secure repository: https://community.max.gov/x/mjypgg. Customers can use the FedRAMP repository, or open a cloud.gov support request.
 
-## CISA Emergency Directive 22-02, “Mitigate log4j Vulnerability”
+### CISA Emergency Directive 22-02, “Mitigate log4j Vulnerability”
 
 Please see our page, [Log4J Vulnerability / ED 22-02 Update](https://cloud.gov/2021/12/22/log4j_vulnerability_bod_22-02_update/).
 
-# FY2021
+## FY2021
 
-## CISA Emergency Directive 21-04: Windows Print Spooler
+### CISA Emergency Directive 21-04: Windows Print Spooler
 
 In response to CISA Emergency Directive 21-04, “Mitigate Windows Print Spooler Service Vulnerability” (https://cyber.dhs.gov/ed/21-04/), cloud.gov has provided required applicability information in our FedRAMP secure repository: https://community.max.gov/x/mjypgg
 
 We do not publicly provide specific directive compliance status. Authorized customers can access our FedRAMP package as described at https://cloud.gov/docs/overview/fedramp-tracker/#start-the-ato-process
 
-## CISA Emergency Directive 21-03 for Pulse Connect Secure: Not impacted
+### CISA Emergency Directive 21-03 for Pulse Connect Secure: Not impacted
 
 Cloud.gov has NO instances of Pulse Connect Secure
 
-On April 20, 2021, the DHS Cybersecurity and Infrastructure Security Agency 
-(CISA) published Emergency Directive 21-03: "Mitigate Pulse Connect Secure Product Vulnerabilities" 
+On April 20, 2021, the DHS Cybersecurity and Infrastructure Security Agency
+(CISA) published Emergency Directive 21-03: "Mitigate Pulse Connect Secure Product Vulnerabilities"
 ([https://cyber.dhs.gov/ed/21-03/](https://cyber.dhs.gov/ed/21-03/))
 
 Status: The cloud.gov system has no instances of Pulse Connect Secure. We are fully compliant with ED-21-03.
 
-## CISA Emergency Directive 21-02 for Microsoft Exchange: Not impacted
+### CISA Emergency Directive 21-02 for Microsoft Exchange: Not impacted
 
 cloud.gov has NO instances of Microsoft Exchange on-premises.
 
-On March 3, 2021, the DHS Cybersecurity and Infrastructure Security Agency 
-(CISA) published Emergency Directive 21-02: "Mitigate Microsoft Exchange On-Premises Product Vulnerabilities" 
+On March 3, 2021, the DHS Cybersecurity and Infrastructure Security Agency
+(CISA) published Emergency Directive 21-02: "Mitigate Microsoft Exchange On-Premises Product Vulnerabilities"
 ([https://cyber.dhs.gov/ed/21-02/](https://cyber.dhs.gov/ed/21-02/))
-
 
 Status: The cloud.gov system has no instances of Microsoft Exchange on-premises. We are fully compliant with ED-21-02.
 
-## CISA Emergency Directive 21-01: Mitigate SolarWinds Orion Code Compromise: Not impacted
+### CISA Emergency Directive 21-01: Mitigate SolarWinds Orion Code Compromise: Not impacted
 
 On December 13, 2020, the DHS Cybersecurity and Infrastructure Security Agency (CISA) published [Emergency Directive 21-01, “Mitigate SolarWinds Orion Code Compromise”](https://cyber.dhs.gov/ed/21-01/).
 
 We want to assure cloud.gov customers that the SolarWinds Orion code compromise is not applicable to cloud.gov. There are no SolarWinds components in the cloud.gov system.
 
-# FY2020
+## FY2020
 
-## CISA Directive 20-04 for Netlogon Elevation of Privilege: cloud.gov is fully compliant
+### CISA Directive 20-04 for Netlogon Elevation of Privilege: cloud.gov is fully compliant
 
 On September 18, 2020, the DHS Cybersecurity and Infrastructure Security Agency (CISA) published Emergency Directive 20-04, [Mitigate Netlogon Elevation of Privilege Vulnerability from August 2020 Patch Tuesday](https://cyber.dhs.gov/ed/20-04/).
 
 The FedRAMP PMO requested that cloud.gov (and all CSPs) notify agency customers on our compliance status with the directive, which is that **cloud.gov has zero systems impacted by this vulnerability**.
 
-## CISA Directive 20-03 for Windows DNS: cloud.gov is fully compliant
+### CISA Directive 20-03 for Windows DNS: cloud.gov is fully compliant
 
 On July 16, 2020, the DHS Cybersecurity and Infrastructure Security Agency (CISA) published Emergency Directive 20-03, [Mitigate Windows DNS Server Vulnerability from July 2020 Patch Tuesday](https://cyber.dhs.gov/ed/20-03/).
 
 The FedRAMP PMO requested that cloud.gov (and all CSPs) notify agency customers on our compliance status with the directive, which is that **cloud.gov has zero systems impacted by this vulnerability**.
 
-## CISA Directive 20-02: Mitigate Windows Vulnerabilities
+### CISA Directive 20-02: Mitigate Windows Vulnerabilities
 
 On January 15, 2020, the FedRAMP program office directed all authorized cloud service providers to comply with Department of Homeland Security (DHS) Cybersecurity and Infrastructure Security Agency (CISA) Emergency Directive 20-02, [Mitigate Windows Vulnerabilities from January 2020 Patch Tuesday](https://cyber.dhs.gov/ed/20-02/)
 

--- a/_docs/compliance/meeting-tic-requirements.md
+++ b/_docs/compliance/meeting-tic-requirements.md
@@ -27,7 +27,7 @@ If you need agency user or developer traffic to traverse a TIC
 point, then some of the architectural guidance related to TIC 2.2
 is provided below.
 
-### Restricting developer and operator access to cloud.gov services
+## Restricting developer and operator access to cloud.gov services
 
 You can ensure that developer and operator access to cloud.gov
 services traverses your agency's TIC so that you can monitor all
@@ -70,7 +70,7 @@ cloud.gov's TLS endpoint is not restricted, but rather accessible over the open 
 
 Your agency can accomplish this by establishing an operational requirement that all administrative access to cloud.gov services happens via the agency network. You can further enforce this requirement with a technical control: Prevent users in your domain from using the cloud.gov API except from your agency's TIC egress range. Requests from an IP origin that does not match the range we have on record for your TIC (the dotted/dashed line in the diagram) will be rejected.
 
-### Restricting usage of your application
+## Restricting usage of your application
 
 You may also need to restrict access through the "front door" of your deployed applications, such as administrator access to a Wordpress site, or public access to an internal-only service. The diagram below shows where you can implement this restriction.
 

--- a/_docs/deployment/assets.md
+++ b/_docs/deployment/assets.md
@@ -2,14 +2,14 @@
 parent: deployment
 layout: docs
 sidenav: true
-redirect_from: 
+redirect_from:
     - /docs/apps/assets/
 title: Building static assets
 ---
 
 Applications with non-trivial static assets (Javascript and CSS files) often include a build step to bundle and minify files.
 
-### Build assets on CI
+## Build assets on CI
 
 For applications [deployed from a continuous integration service]({{ site.baseurl }}{% link _docs/management/continuous-deployment.md %}), building assets on CI is a natural fit. Before deploying to cloud.gov, the CI service runs the asset build process. Then the compiled assets are pushed to cloud.gov along with the application code. Here's a minimal example for Travis CI:
 
@@ -35,7 +35,7 @@ Examples in the wild:
 
 * [eRegulations: Notice & Comment](https://github.com/eregs/notice-and-comment)
 
-### Build assets on cloud.gov
+## Build assets on cloud.gov
 
 If the application and build process are implemented in the same language, assets can be built directly on cloud.gov on application start. Here's a minimal example for a node.js application:
 

--- a/_docs/deployment/docker.md
+++ b/_docs/deployment/docker.md
@@ -33,17 +33,19 @@ Here are some considerations to keep in mind when deciding to use Docker images 
 
 <!-- Based on the table in this slide: https://twitter.com/benbravo73/status/781125385777999872 -->
 
-### Runtime differences
+## Runtime differences
 
 Pushing an application using a Docker image creates the same type of container in the same runtime as using a buildpack does. When you supply a Docker image for your application, Cloud Foundry:
+
 1. fetches the Docker image
-1. uses the image layers to construct a base filesystem 
+1. uses the image layers to construct a base filesystem
 1. uses the image metadata to determine the command to run, environment vars, user id, and port to expose (if any)
-1. creates an app specification based on the steps above 
+1. creates an app specification based on the steps above
 1. passes the app specification on to diego (the multi-host container management system) to be run as a linux container.
 
 No Docker components are involved in this process - your applications are run under the `garden-runc` runtime (versus `containerd` in Docker). Both `garden-runc` and `containerd` are layers built on top of the Open Container Initiative's `runc` package. They have significant overlap in the types of problems they solve and in many of the ways they try to solve them.
 For example, both `garden-runc` and `containerd`:
+
 - use cgroups to limit resource usage
 - use process namespaces to isolate processes
 - combine image layers into a single root filesystem
@@ -51,12 +53,11 @@ For example, both `garden-runc` and `containerd`:
 
 Additionally, since containers are running in Cloud Foundry, most or all of the other components of the Docker ecosystem are are replaced with Cloud Foundry components, such as service discovery, process monitoring, virtual networking, routing, volumes, etc. This means most Docker-specific guidance, checklists, etc., will not be directly applicable for applications within Cloud Foundry, regardless of whether they're pushed as Docker images or buildpack applications.
 
-
-#### Docker as tasks
+### Docker as tasks
 
 There is [a Cloud Foundry API for tasks creation](http://v3-apidocs.cloudfoundry.org/version/3.31.0/index.html#tasks). This allows single, one-off tasks to be triggered through the API.
 
-### Using non-standard ports in Docker containers
+## Using non-standard ports in Docker containers
 
 When you assign a route to an app running on cloud.gov using the `*.app.cloud.gov` domain, external ports 80 and 443 are mapped to a dynamically assigned internal port on the container(s) running your app. You can't change the internal port assigned to your app if it's been assigned an `*.app.cloud.gov` domain, but you can use alternate ports if your app is assigned [an internal route](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#internal-routes) on cloud.gov.
 
@@ -68,19 +69,21 @@ In this scenario, if you want to enable external traffic to reach your Docker ap
 
 * Enable container-to-container traffic by [adding a new network policy](https://cli.cloudfoundry.org/en-US/v6/add-network-policy.html) specifying the source app (your nginx proxy) and the destination app (your Docker app) as well as the port and protocol for the traffic.
 
-### Docker + Cloud Foundry examples
+## Docker + Cloud Foundry examples
 
-#### Spring Music
+### Spring Music
 
 We often use the [Spring Music app](https://github.com/cloudfoundry-samples/spring-music) to demonstrate the use of database services on Cloud Foundry. The same application works when bundled [into a Docker image](https://fabianlee.org/2018/05/24/docker-running-a-spring-boot-based-app-in-a-docker-container/), and works identically.
 
 For example, push it to cloud.gov using a prebuilt Docker image with an in-memory database:
-```
+
+```shell
 cf push my-spring --docker-image pburkholder/my-springmusic -m 1016M
 ```
 
 Then create a database service, bind it, and restage the app to use the database:
-```
+
+```shell
 cf create-service aws-rds micro-psql my-spring-db
 cf bind-service my-spring my-spring-db
 cf restage my-spring

--- a/_docs/deployment/managed-services.md
+++ b/_docs/deployment/managed-services.md
@@ -11,39 +11,39 @@ redirect_from:
 
 Managed services provide applications with on-demand access to services outside of the stateless application environment. Typical managed services include databases, queues, and key-value stores.
 
-### List services
+## List services
 
 To create a service instance and binding for use with an application, you first need to identify the available services and their respective plans.
 
-```
-% cf marketplace
+```shell
+cf marketplace
 ```
 
 See [the services guide]({{ site.baseurl }}{% link _docs/services/intro.md %}) as well.
 
-### Create a service instance
+## Create a service instance
 
 Target the org and space which will hold the app to which the service instance will be bound.
 
-```
-% cf target -o ORG -s SPACE
+```shell
+cf target -o ORG -s SPACE
 ```
 
 Create a new service instance by specifying a service, plan, and a name of your choice for the service instance. Note that service instance names must be unique and can be renamed. For some services, you'll need to include additional parameters in your create-service command -- refer to [the services guide]({{ site.baseurl }}{% link _docs/services/intro.md %}) for details.
 
-```
-% cf create-service SERVICE_NAME PLAN_NAME INSTANCE_NAME
+```shell
+cf create-service SERVICE_NAME PLAN_NAME INSTANCE_NAME
 ```
 
-### Sharing service instances
+## Sharing service instances
 
 Sharing of service instances allows users to share service instances between spaces inside their organization as a way to consolidate service instance usage and avoid data duplication in their service instances.  Users need to be aware that sharing service instances between spaces has limitations and can expose data in those service instances across environment boundaries.  Please see [Sharing Service Instances](https://docs.cloudfoundry.org/devguide/services/sharing-instances.html) for more information on limitations and security concerns.
 
-```
-% cf share-service SERVICE-INSTANCE -s OTHER-SPACE [-o OTHER-ORG]
+```shell
+cf share-service SERVICE-INSTANCE -s OTHER-SPACE [-o OTHER-ORG]
 ```
 
-### Bind the service instance
+## Bind the service instance
 
 For services that apply to an application ([Elasticsearch]({{ site.baseurl }}{% link _docs/services/aws-elasticsearch.md %}), [Redis]({{ site.baseurl }}{% link _docs/services/aws-elasticache.md %}), [relational databases (RDS)]({{ site.baseurl }}{% link _docs/services/relational-database.md %}), and [S3]({{ site.baseurl }}{% link _docs/services/s3.md %})), the service instance must be bound to the application which will access it. (The [CDN service]({{ site.baseurl }}{% link _docs/services/cdn-route.md %}), [identity provider]({{ site.baseurl }}{% link _docs/services/cloud-gov-identity-provider.md %}), and [service account]({{ site.baseurl }}{% link _docs/services/cloud-gov-service-account.md %}) have different instructions, available in their service documentation.)
 
@@ -62,7 +62,7 @@ A service binding will be created with the next `cf push`.
 
 Alternatively, a service instance can also bound to an existing application via the `cf` CLI:
 
-```
+```shell
 % cf bind-service APPLICATION INSTANCE_NAME
 ```
 
@@ -99,7 +99,7 @@ In this case, `url` alone could be sufficient for establishing a connection from
 
 The contents of the `VCAP_SERVICES` environment variable contain the credentials to access your service. Treat the contents of this and all other environment variables as sensitive.
 
-### Access the service configuration
+## Access the service configuration
 
 Configuration and credentials for the bound service can be accessed in several ways:
 
@@ -107,11 +107,11 @@ Configuration and credentials for the bound service can be accessed in several w
 * Through a language-specific module such as [cfenv](https://www.npmjs.org/package/cfenv) for node.js.
 * Through buildpack-populated environment variables as in the [Ruby buildpack](http://docs.cloudfoundry.org/buildpacks/ruby/ruby-service-bindings.html#vcap-services-defines-database-url).
 
-#### Node.js example
+### Node.js example
 
 To access the elasticsearch service described above with a node app:
 
-**package.json**
+`package.json`:
 
 ```javascript
 // ...
@@ -123,7 +123,7 @@ To access the elasticsearch service described above with a node app:
 // ...
 ```
 
-**app.js**
+`app.js`:
 
 ```javascript
 // ...
@@ -138,9 +138,9 @@ var client = new elasticsearch.Client({
 // ...
 ```
 
-#### Ruby on Rails example
+### Ruby on Rails example
 
-**config/initializers/elasticsearch.rb**
+`config/initializers/elasticsearch.rb`:
 
 ```ruby
 # we use "production" env for all things at cloud.gov

--- a/_docs/deployment/static.md
+++ b/_docs/deployment/static.md
@@ -2,7 +2,7 @@
 parent: deployment
 layout: docs
 sidenav: true
-redirect_from: 
+redirect_from:
     - /docs/apps/static/
 title: Deploying static sites
 ---
@@ -11,11 +11,11 @@ To push static content to the web, use the Staticfile buildpack. Examples of sta
 
 To set up a "hello world" demo or a more complex static site, see the [Cloud Foundry Staticfile buildpack documentation](https://docs.cloudfoundry.org/buildpacks/staticfile/index.html). It includes ["hello world" instructions](https://docs.cloudfoundry.org/buildpacks/staticfile/index.html#sample) and a full list of configuration options, including how to set up basic authentication and configure nginx (the underlying web server).
 
-### Builds
+## Builds
 
 If you are using a static site generator (e.g. [Jekyll](#jekyll) or [Hugo](http://gohugo.io/)) and/or it requires dependencies to be installed at deploy-time, you should set up [continuous deployment]({{ site.baseurl }}{% link _docs/management/continuous-deployment.md %}). This way, the build happens in your Continuous Integration (CI) system rather than during the deploy itself within Cloud Foundry. This helps to make your deployments more reliable, have a smaller footprint, and reduce downtime.
 
-### Jekyll
+## Jekyll
 
 Deploying a [Jekyll](http://jekyllrb.com/) site requires a few things:
 
@@ -34,7 +34,7 @@ Deploying a [Jekyll](http://jekyllrb.com/) site requires a few things:
 
 See [18F/notalone](https://github.com/18F/notalone) for an example.
 
-### Redirect all traffic
+## Redirect all traffic
 
 If a site moves to a different domain name, you can use [cf-redirect](https://github.com/18F/cf-redirect) to redirect all traffic from the old domain to the new domain.
 

--- a/_docs/getting-started/code-samples.md
+++ b/_docs/getting-started/code-samples.md
@@ -5,17 +5,18 @@ layout: docs
 sidenav: true
 ---
 
-##  Java app   
+##  Java app
 
-#### Learn how to deploy a Java web application in your sandbox. 
+#### Learn how to deploy a Java web application in your sandbox.
 
 ##### Install the CloudFoundry command line interface (CLI)
 
 Since cloud.gov is based on the open-source Cloud Foundry project, it uses the Cloud Foundry CLI. Download and install the CLI for your system:
 
-* [Windows (64-bit)](https://cli.run.pivotal.io/stable?release=windows64&source=github)
-* [Mac (64-bit)](https://cli.run.pivotal.io/stable?release=macosx64&source=github)
-* [All Downloads](https://github.com/cloudfoundry/cli#downloads)
+* [Windows (64-bit)](https://packages.cloudfoundry.org/stable?release=windows64-exe&version=v8&source=github)
+* [Mac (64-bit) / Intel](https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=v8&source=github)
+* [Mac (64-bit) / ARM](https://packages.cloudfoundry.org/stable?release=macosarm-binary&version=v8&source=github)
+* [All Downloads](https://github.com/cloudfoundry/cli?tab=readme-ov-file#downloads)
 
 Test your install with following command:
 
@@ -82,9 +83,9 @@ View your application logs with `cf logs --recent` or with the web-based logview
 
 If you’re done, you can delete your app by running `cf delete <APPNAME>` (it’s up to you whether to keep it running for more experiments or delete it).
 
-##  Other languages   
+##  Other languages
 
-### Try a simple "Hello world" app in .Net Core, PHP, Python, R, Ruby, NodeJS or Clojure in your sandbox. 
+### Try a simple "Hello world" app in .Net Core, PHP, Python, R, Ruby, NodeJS or Clojure in your sandbox.
 
 #### Install the CloudFoundry command line interface (CLI)
 

--- a/_docs/getting-started/code-samples.md
+++ b/_docs/getting-started/code-samples.md
@@ -5,11 +5,9 @@ layout: docs
 sidenav: true
 ---
 
-##  Java app
+## Prerequisites
 
-#### Learn how to deploy a Java web application in your sandbox.
-
-##### Install the CloudFoundry command line interface (CLI)
+### Install the CloudFoundry command line interface (CLI)
 
 Since cloud.gov is based on the open-source Cloud Foundry project, it uses the Cloud Foundry CLI. Download and install the CLI for your system:
 
@@ -22,11 +20,13 @@ Test your install with following command:
 
 `cf help`
 
-#### Deploy the sample app
+## Java app
+
+### Deploy the sample app
 
 Now that you have your account and the CLI installed, let’s deploy a Java web application by downloading the application code, connecting to cloud.gov, and “pushing” the application.
 
-##### Download the application code from cloud.gov's GitHub repository
+#### Download the application code from cloud.gov's GitHub repository
 
 If you have Git installed:
 
@@ -38,13 +38,13 @@ If you don’t have Git installed, download [`main.zip`](https://github.com/clou
 
 `cd cf-sample-app-spring-main`
 
-##### Connect to cloud.gov
+#### Connect to cloud.gov
 
 `cf login -a https://api.fr.cloud.gov --sso`
 
 Complete the login in your browser at [https://login.fr.cloud.gov/passcode](https://login.fr.cloud.gov/passcode). You’ll get a one-time passcode, which you then paste into your terminal.
 
-##### Push the application
+#### Push the application
 
 `cf push`
 
@@ -52,7 +52,7 @@ The `push` command will upload your sample app, prepare it for cloud.gov, then a
 
 `cf push`
 
-```
+```shell
 Using manifest file ...
 
 Creating app cf-spring in org / space
@@ -67,7 +67,7 @@ buildpacks:        python
 state     since #0   running   2017-12-02 12:53:29 PM
 ```
 
-##### View your application
+#### View your application
 
 Use your browser to visit the `routes:` from the push command (in the above example, https://flask-example-fluent-okapi.app.cloud.gov). Your browser should display something like this:
 
@@ -75,7 +75,7 @@ Use your browser to visit the `routes:` from the push command (in the above exam
 
 Congratulations! You now have a running webapp built on the [Java Spring framework.](https://spring.io)
 
-##### Exploring other cloud.gov features
+#### Exploring other cloud.gov features
 
 Visit the dashboard — [https://dashboard.fr.cloud.gov/](https://dashboard.fr.cloud.gov/) — to see your options for managing your application via your browser.
 
@@ -83,31 +83,19 @@ View your application logs with `cf logs --recent` or with the web-based logview
 
 If you’re done, you can delete your app by running `cf delete <APPNAME>` (it’s up to you whether to keep it running for more experiments or delete it).
 
-##  Other languages
+## Other languages
 
-### Try a simple "Hello world" app in .Net Core, PHP, Python, R, Ruby, NodeJS or Clojure in your sandbox.
+Try a simple "Hello world" app in .Net Core, PHP, Python, R, Ruby, NodeJS or Clojure in your sandbox.
 
-#### Install the CloudFoundry command line interface (CLI)
-
-Since cloud.gov is based on the open-source Cloud Foundry project, it uses the Cloud Foundry CLI. Download and install the CLI for your system:
-
-*   [Windows (64-bit)](https://cli.run.pivotal.io/stable?release=windows64&source=github)
-*   [Mac (64-bit)](https://cli.run.pivotal.io/stable?release=macosx64&source=github)
-*   [All Downloads](https://github.com/cloudfoundry/cli#downloads)
-
-Test your install with following command:
-
-`cf help`
-
-#### Deploy a Hello World app
+### Deploy a Hello World app
 
 Now that you have your account and the CLI installed, let’s download the "Hello World" samples, choose one, connect to cloud.gov and "push" the application code.
 
-##### Download the Hello World code examples from cloud.gov's GitHub repository
+#### Download the Hello World code examples from cloud.gov's GitHub repository
 
 If you have Git installed:
 
-```
+```shell
 git clone https://github.com/cloud-gov/cf-hello-worlds
 cd cf-hello-worlds
 ```
@@ -116,7 +104,7 @@ If you don’t have Git installed, download [`main.zip`](https://github.com/clou
 
 `cd cf-hello-worlds-main`
 
-##### Choose a framework
+#### Choose a framework
 
 There are subdirectories for a number of different language + framework combinations. Choose an <example>, then
 
@@ -126,13 +114,13 @@ E.g., `cd python-flask`
 
 Regardless of the framework you choose, the remaining steps are all the same.
 
-##### Connect to cloud.gov
+#### Connect to cloud.gov
 
 `cf login -a https://api.fr.cloud.gov --sso`
 
 Complete the login in your browser at [https://login.fr.cloud.gov/passcode](https://login.fr.cloud.gov/passcode). You’ll get a one-time passcode, which you then paste into your terminal.
 
-##### Push the application
+#### Push the application
 
 `cf push`
 
@@ -140,7 +128,7 @@ The `push` command will upload your sample app, prepare it for cloud.gov, then a
 
 `cf push`
 
-```
+```shell
 Using manifest file ...
 
 Creating app dotnet-core in org / space
@@ -156,13 +144,13 @@ buildpacks:        python
 #0   running   2017-12-02 12:53:29 PM
 ```
 
-##### View your application
+#### View your application
 
-Use your browser to visit the `routes:` from the push command (in the above example, https://flask-example-fluent-okapi.app.cloud.gov). It should just display `Hello World from` and the name of your programming language example.
+Use your browser to visit the `routes:` from the push command (in the above example, <https://flask-example-fluent-okapi.app.cloud.gov>). It should just display `Hello World from` and the name of your programming language example.
 
 Congratulations! You now have a running web app built on the language and framework of your choice.
 
-##### Exploring other cloud.gov features
+#### Exploring other cloud.gov features
 
 Visit the dashboard — [https://dashboard.fr.cloud.gov/](https://dashboard.fr.cloud.gov/) — to see your options for managing your application via your browser.
 
@@ -178,17 +166,18 @@ Did we miss a tip or useful resource that you think we should add? [Submit a sug
 
 #### Additional sample applications
 
-*   [Drupal example](https://github.com/18F/cf-ex-drupal8/)
-*   [WordPress example](https://github.com/18F/cf-ex-wordpress)
-*   [Cloud Foundry community collection of sample applications](https://github.com/cloudfoundry-samples)
-*   [SpringMusic: Java + any of MySQL, Oracle, Postgres or Redis](https://github.com/cloudfoundry-samples/spring-music)
+* [Drupal example](https://github.com/cloud-gov/cf-ex-drupal8/)
+* [WordPress example](https://github.com/cloud-gov/cf-ex-wordpress)
+* [Cloud Foundry community collection of sample applications](https://github.com/cloudfoundry-samples)
+* [SpringMusic: Java + any of MySQL, Oracle, Postgres or Redis](https://github.com/cloudfoundry-samples/spring-music)
 
 #### Join the communities
 
-*   [The public DevOps channel on 18F's Slack (sign up at chat.18f.gov).](https://chat.18f.gov/)
-*   [Cloud Foundry communities (Slack, newsletters, mail lists)](https://www.cloudfoundry.org/community/)
+* [The public DevOps channel on 18F's Slack (sign up at chat.18f.gov).](https://chat.18f.gov/)
+* [Cloud Foundry communities (Slack, newsletters, mail lists)](https://www.cloudfoundry.org/community/)
 
 Want more?
+
 ----------
 
 Upgrade to a paid package to get full access to the platform and permanent spaces for hosting longer term demos and web applications in production. Email us at [inquiries@cloud.gov]({{site.inquiries_email}}) to learn more about what cloud.gov can do.

--- a/_docs/getting-started/code-samples.md
+++ b/_docs/getting-started/code-samples.md
@@ -20,13 +20,11 @@ Test your install with following command:
 
 `cf help`
 
-## Java app
-
-### Deploy the sample app
+## Deploy a sample Java app
 
 Now that you have your account and the CLI installed, let’s deploy a Java web application by downloading the application code, connecting to cloud.gov, and “pushing” the application.
 
-#### Download the application code from cloud.gov's GitHub repository
+### Download the application code from cloud.gov's GitHub repository
 
 If you have Git installed:
 
@@ -38,13 +36,13 @@ If you don’t have Git installed, download [`main.zip`](https://github.com/clou
 
 `cd cf-sample-app-spring-main`
 
-#### Connect to cloud.gov
+### Connect to cloud.gov
 
 `cf login -a https://api.fr.cloud.gov --sso`
 
 Complete the login in your browser at [https://login.fr.cloud.gov/passcode](https://login.fr.cloud.gov/passcode). You’ll get a one-time passcode, which you then paste into your terminal.
 
-#### Push the application
+### Push the application
 
 `cf push`
 
@@ -67,7 +65,7 @@ buildpacks:        python
 state     since #0   running   2017-12-02 12:53:29 PM
 ```
 
-#### View your application
+### View your application
 
 Use your browser to visit the `routes:` from the push command (in the above example, https://flask-example-fluent-okapi.app.cloud.gov). Your browser should display something like this:
 
@@ -75,7 +73,7 @@ Use your browser to visit the `routes:` from the push command (in the above exam
 
 Congratulations! You now have a running webapp built on the [Java Spring framework.](https://spring.io)
 
-#### Exploring other cloud.gov features
+### Exploring other cloud.gov features
 
 Visit the dashboard — [https://dashboard.fr.cloud.gov/](https://dashboard.fr.cloud.gov/) — to see your options for managing your application via your browser.
 
@@ -158,20 +156,20 @@ View your application logs with `cf logs --recent` or with the web-based logview
 
 If you’re done, you can delete your app by running `cf delete <APPNAME>` (it’s up to you whether to keep it running for more experiments or delete it).
 
-### Additional resources
+## Additional resources
 
 If you've run into any issues with these tutorials, please [Contact support at cloud.gov](mailto:support@cloud.gov). We're happy to help.
 
 Did we miss a tip or useful resource that you think we should add? [Submit a suggestion on GitHub](https://github.com/cloud-gov/cg-site/issues/new) or [send us an email](mailto:inquiries@cloud.gov?subject=%5BSuggestion%5D%20&body=%0A%0A%0A%0ARefcode:%20quickstart).
 
-#### Additional sample applications
+### Additional sample applications
 
 * [Drupal example](https://github.com/cloud-gov/cf-ex-drupal8/)
 * [WordPress example](https://github.com/cloud-gov/cf-ex-wordpress)
 * [Cloud Foundry community collection of sample applications](https://github.com/cloudfoundry-samples)
 * [SpringMusic: Java + any of MySQL, Oracle, Postgres or Redis](https://github.com/cloudfoundry-samples/spring-music)
 
-#### Join the communities
+### Join the communities
 
 * [The public DevOps channel on 18F's Slack (sign up at chat.18f.gov).](https://chat.18f.gov/)
 * [Cloud Foundry communities (Slack, newsletters, mail lists)](https://www.cloudfoundry.org/community/)

--- a/_docs/getting-started/reference.md
+++ b/_docs/getting-started/reference.md
@@ -10,7 +10,7 @@ weight: -50
 
 Learn how to deploy and manage your applications, so you can deliver your digital services to the people who need them.
 
-### Learning and reference
+## Learning and reference
 
 New here? Start with the top of the sidebar and work your way down. The docs include both guides and reference material for you.
 
@@ -21,6 +21,6 @@ Shortcuts to common tasks:
 - [Custom domains]({{ site.baseurl }}{% link _docs/management/custom-domains.md %})
 - [Managing teammates]({{ site.baseurl }}{% link _docs/orgs-spaces/roles.md %})
 
-### cloud.gov team docs
+## cloud.gov team docs
 
 cloud.gov is an open source project based on [Cloud Foundry](https://www.cloudfoundry.org/) with additional components built by our team and other community members. We maintain our code and team documentation publicly here, and we invite you to read it, contribute to it, and adapt it for other projects. See [our list of repositories](https://github.com/cloud-gov/).

--- a/_docs/management/continuous-deployment.md
+++ b/_docs/management/continuous-deployment.md
@@ -2,7 +2,7 @@
 parent: management
 layout: docs
 sidenav: true
-redirect_from: 
+redirect_from:
     - /docs/apps/continuous-deployment/
 title: Continuous deployment
 ---
@@ -120,7 +120,6 @@ deploy:
 
 For details, see [Jekyll's Continuous Integration guide](http://jekyllrb.com/docs/continuous-integration/travis-ci/).
 
-
 ### CircleCI
 
 See [Getting Started with CircleCI](https://circleci.com/docs/1.0/getting-started/) -- you'll need to set up a CircleCI account and give it access to your code repository.
@@ -130,7 +129,7 @@ In your code repository, use the following template to set up your `circle.yml` 
 ```yaml
 dependencies:
   pre:
-    - curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
+    - curl -v -L -o cf-cli_amd64.deb 'https://packages.cloudfoundry.org/stable?release=debian64&version=v8&source=github'
     - sudo dpkg -i cf-cli_amd64.deb
     - cf -v
 
@@ -157,7 +156,7 @@ See the [GitHub Actions documentation](https://help.github.com/en/actions) to ge
 
 #### Usage
 
-After following the instructions for setting up a [cloud.gov service account](https://cloud.gov/docs/services/cloud-gov-service-account/), store your username (CG_USERNAME) and password (CG_PASSWORD) as [encrypted secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets). 
+After following the instructions for setting up a [cloud.gov service account](https://cloud.gov/docs/services/cloud-gov-service-account/), store your username (CG_USERNAME) and password (CG_PASSWORD) as [encrypted secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets).
 
 #### Sample workflow
 
@@ -185,7 +184,7 @@ jobs:
       run: dotnet restore
       
     - name: Build
-      run: dotnet build 
+      run: dotnet build
       
   deploy:
     runs-on: ubuntu-latest
@@ -195,7 +194,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Deploy to cloud.gov
         uses: cloud-gov/cg-cli-tools@main
-        with: 
+        with:
           cf_api: https://api.fr.cloud.gov
           cf_username: ${{ secrets.CG_USERNAME }}
           cf_password: ${{ secrets.CG_PASSWORD }}

--- a/_docs/management/database-backup-restore.md
+++ b/_docs/management/database-backup-restore.md
@@ -10,7 +10,7 @@ title: Perform a database backup or restore
 
 Use this procedure to perform a database backup or restore operation by using `cf-service-connect` to import and export data.
 
-### Install or update plugin
+## Install or update plugin
 
 This process requires the [cf-service-
 connect](https://github.com/18F/cf-service-connect) plugin that folks on the
@@ -21,15 +21,15 @@ latest version installed before starting. If you need to update the plugin, you
 need to uninstall it first before you can install the new version. To uninstall
 a plugin, run this command:
 
-```
+```shell
 cf uninstall-plugin <plugin name>
 ```
 
 Then follow the installation instructions found in the plugin's documentation.
 
-### Database backup or data export
+## Database backup or data export
 
-```
+```shell
 # Target the environment you're exporting from
 cf target [-o <org name>] -s <space name>
 
@@ -55,9 +55,9 @@ cf delete-service-key <service name> SERVICE_CONNECT
 
 Once these steps are complete, you may also want to upload a copy of the backup to the Drive folder.
 
-### Database restore or data import
+## Database restore or data import
 
-```
+```shell
 # Target the environment you're restoring into
 cf target [-o <org name>] -s <space name>
 

--- a/_docs/management/plugins.md
+++ b/_docs/management/plugins.md
@@ -2,21 +2,21 @@
 parent: management
 layout: docs
 sidenav: true
-redirect_from: 
+redirect_from:
     - /docs/apps/plugins/
 title: CF CLI plugins
 ---
 
 Cloud Foundry includes a framework for plugins for the `cf` command-line interface, so that you can use and build additional command-line features for managing your orgs, spaces, and applications.
 
-### Using Plugins
+## Using Plugins
 
 You install plugins locally on your system using the `cf install-plugin` command. [Detailed instructions on using plugins](https://docs.cloudfoundry.org/devguide/installcf/use-cli-plugins.html) can be found at the Cloud Foundry site, but there are two main means of fetching plugins:
 
 1. You can download a compiled plugin binary from a remote site and install it from local disk.
 2. You can specify a plugin-repo to pull compiled plugins from. The standard Cloud Foundry directory is at [plugins.cloudfoundry.org](https://plugins.cloudfoundry.org/).
 
-### Developing Plugins
+## Developing Plugins
 
 The Cloud Foundry CLI is written in Go and compiled down to an executable. This means that plugins aren’t able to be dynamically linked into the main CLI's code. Instead, plugins are also Go applications that inherit from a base interface and implement a few predefined commands. These applications then run as little localized servers essentially and get commands via RPC from the CF CLI. [The whole architecture is described in depth on the Cloud Foundry site](https://github.com/cloudfoundry/cli/tree/master/plugin/plugin_examples). Any plugin you might write will have to implement two commands from the CF Plugin interface:
 
@@ -25,7 +25,7 @@ The Cloud Foundry CLI is written in Go and compiled down to an executable. This 
 
 Then you can compile your own plugin and install it. Plugins are able to call any of the commands already in the CLI. They also can read from stdin if you need them to be interactive. It is also possible to have a plugin implement multiple commands through dispatching within the `Run` method if that's preferable.
 
-### What plugins can't do
+## What plugins can't do
 
 Plugins are only invoked when they are explicitly called within the CLI. In this sense, they resemble [Slack's outgoing webhooks](https://api.slack.com/outgoing-webhooks). There currently isn’t any support for plugins to register themselves to be called at specific points in the deployment cycle, as there is in other deployment mechanisms.
 

--- a/_docs/management/using-ssh.md
+++ b/_docs/management/using-ssh.md
@@ -2,7 +2,7 @@
 parent: management
 layout: docs
 sidenav: true
-redirect_from: 
+redirect_from:
     - /docs/apps/using-ssh/
 title: Using SSH
 ---
@@ -14,7 +14,7 @@ ssh`](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-comma
 command, which lets you securely log in to an application instance where you can
 perform debugging, environment inspection, and other tasks.
 
-### Application debugging tips
+## Application debugging tips
 
 **Configure your shell**: If you're trying to debug your app, you'll need to [configure your session to match your application's environment](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-env) by running `/tmp/lifecycle/shell`.
 
@@ -32,7 +32,7 @@ SSH access is enabled by default. Space Developers can disable SSH access to ind
 
 You should [disable SSH access for production applications]({{ site.baseurl }}{% link _docs/deployment/production-ready.md %}#prevent-non-auditable-changes-to-production-apps) to ensure you can audit changes to those applications.
 
-## SSH version information 
+## SSH version information
 
 Application containers use the SSH-2.0 protocol. The SSH service uses the [Cloud Foundry SSH implementation](https://github.com/cloudfoundry/diego-ssh). For more on how Cloud Foundry implements SSH, refer to Cloud Foundry's documentation on [Understanding Application SSH](https://docs.cloudfoundry.org/concepts/diego/ssh-conceptual.html).
 

--- a/_docs/overview/cloudgov-benefits.md
+++ b/_docs/overview/cloudgov-benefits.md
@@ -18,19 +18,19 @@ redirect_from:
   - /overview/overview/why-available-other-agencies
 ---
 
-## 1. Security
+## Security
 
 cloud.gov is built on the open source [Cloud Foundry project](http://www.cloudfoundry.org/), which is run by a non-profit foundation with many commercial members and an active community of contributors. Cloud Foundry’s “stemcell” capability allows cloud.gov to deploy all apps on a hardened operating system image that is tightly audited for compliance with federal standards. We are continually improving the security of the platform, which in turn centrally improves the security of your products that are running on the platform.
 
 cloud.gov enforces an immutable infrastructure. Instead of logging into a live system to make a change, we deploy an entirely new system with security updates applied. That ensures any foothold which might have been exploited by hackers gets wiped away at the same time. The same is true for applications deployed on cloud.gov. When vulnerabilities in a software stack are identified, we can re-deploy applications that use it on a clean and updated baseline. This happens independently of the application team’s availability, as often as needed, and without downtime.
 
-## 2. Compliance with federal requirements
+## Compliance with federal requirements
 
 cloud.gov has a [Provisional Authority to Operate (P-ATO) at the Moderate impact level from the FedRAMP Joint Authorization Board (JAB)]({{ site.baseurl }}{% link _docs/overview/fedramp-tracker.md %}). When you deploy a system on cloud.gov, you can [leverage this P-ATO](https://www.fedramp.gov/faqs/) as part of your agency ATO.
 
 Of the [261 security controls](https://nvd.nist.gov/800-53/Rev4/impact/moderate) required for FISMA Moderate-impact systems, as many as 60 percent of the controls covered as part of the cloud.gov P-ATO can be partially or fully inherited for agency systems deployed on the cloud.gov platform. The decision of which controls apply to an IT system and/or which may be inherited from the underlying platform ultimately rests with your agency's Authorizing Official. However, this inheritability of controls can dramatically shorten the time and effort required to obtain an ATO for your system.
 
-## 3. Usability
+## Usability
 
 A Platform as a Service (PaaS) like cloud.gov can save you the resources of managing your own cloud deployments, but it has to work the way you need it to work. cloud.gov was built inside a government development environment by government developers. We face similar security and compliance requirements to the ones that other government teams do, and our coworkers on other teams deploy their applications on cloud.gov. We know first-hand that it works for government teams.
 

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -6,7 +6,6 @@ title: RDS - Relational databases
 description: "Persistent, relational databases using Amazon RDS"
 redirect_from:
   - /docs/apps/databases
-toc: true
 ---
 
 

--- a/_docs/services/relational-database.md
+++ b/_docs/services/relational-database.md
@@ -6,6 +6,7 @@ title: RDS - Relational databases
 description: "Persistent, relational databases using Amazon RDS"
 redirect_from:
   - /docs/apps/databases
+toc: true
 ---
 
 

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -18,8 +18,13 @@ This template is for a single page that does not have a date associated with it.
 
       <div id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose bg-white padding-y-8 padding-x-4">
         <h1>{{ page.title }}</h1>
-        {{ content | toc }}
+        
+        <div id="table-of-contents">
+          <h2>Table of Contents</h2>
+          {{ content | toc_only }}
+        </div>
 
+        {{ content }}
 
         <div class="grid-row">
           <div class="grid-col flex-4"></div>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -18,7 +18,7 @@ This template is for a single page that does not have a date associated with it.
 
       <div id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose bg-white padding-y-8 padding-x-4">
         <h1>{{ page.title }}</h1>
-        {{ content }}
+        {{ content | toc }}
 
 
         <div class="grid-row">

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -19,8 +19,10 @@ This template is for a single page that does not have a date associated with it.
       <div id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose bg-white padding-y-8 padding-x-4">
         <h1>{{ page.title }}</h1>
 
-        {% assign toc_content = content | toc_only | strip %}
-        {% if toc_content != '' %}
+        {% assign toc_content = content | toc_only | strip | strip_newlines %}
+        {% assign empty_toc_content = '<ol id="toc" class="section-nav"></ol>' %}
+
+        {% if toc_content != '' and toc_content != empty_toc_content %}
           <h2>Table of Contents</h2>
           <div id="table-of-contents">
             {{ toc_content }}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -19,6 +19,10 @@ This template is for a single page that does not have a date associated with it.
       <div id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose bg-white padding-y-8 padding-x-4">
         <h1>{{ page.title }}</h1>
         
+        {% if page.some_variable %}
+        <h2>FOOBAR</h2>
+        {% endif %}
+
         <div id="table-of-contents">
           <h2>Table of Contents</h2>
           {{ content | toc_only }}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -18,16 +18,15 @@ This template is for a single page that does not have a date associated with it.
 
       <div id="main-content" class="usa-layout-docs__main desktop:grid-col-8 usa-prose bg-white padding-y-8 padding-x-4">
         <h1>{{ page.title }}</h1>
-        
-        {% if page.some_variable %}
-        <h2>FOOBAR</h2>
-        {% endif %}
 
-        <div id="table-of-contents">
+        {% assign toc_content = content | toc_only | strip %}
+        {% if toc_content != '' %}
           <h2>Table of Contents</h2>
-          {{ content | toc_only }}
-        </div>
-
+          <div id="table-of-contents">
+            {{ toc_content }}
+          </div>
+        {% endif %}
+      
         {{ content }}
 
         <div class="grid-row">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,7 +16,7 @@ This is used in blog posts. The index page can be found at blog/index.html
             {{ page.date | date: '%B %d, %Y' }}
           </div>
         </div>
-        {{ content }}
+        {{ content | toc }}
         <div class="grid-row">
           <div class="grid-col flex-4"></div>
           <div class="grid-col flex-1"><p><a href="{{ site.github_url }}/edit/{{ site.github_branch }}/{{ page.relative_path }}">Suggest edits</a></p></div>

--- a/_posts/2017-03-27-release-notes.md
+++ b/_posts/2017-03-27-release-notes.md
@@ -35,7 +35,7 @@ We upgraded the Cloud Foundry deployment to [v254](https://github.com/cloudfound
 As part of the Cloud Foundry upgrade, the base filesystem used for running your application has been updated to address several security vulnerabilities. You should [restage your application](http://cli.cloudfoundry.org/en-US/cf/restage.html) to [incorporate fixes in the base filesystem](https://docs.cloudfoundry.org/devguide/deploy-apps/stacks.html#cli-commands) and ensure you’re running the most recent language version supported by your [buildpack](https://docs.cloudfoundry.org/buildpacks/).
 
 - [USN-3183-2: GnuTLS vulnerability](https://www.ubuntu.com/usn/usn-3183-2/)
-- [USN-3189-2: Linux kernel (Xenial HWE) vulnerabilities](https://www.ubuntu.com/usn/usn-3189-2/)
+- [USN-3189-2: Linux kernel (Xenial HWE) vulnerabilities](https://ubuntu.com/security/notices/USN-3189-2)
 - [USN-3213-1: GD library vulnerabilities](https://www.ubuntu.com/usn/USN-3213-1/)
 - [USN-3220-2: Linux kernel (Xenial HWE) vulnerability](https://www.ubuntu.com/usn/usn-3220-2/)
 - [USN-3222-1: ImageMagick vulnerabilities](https://www.ubuntu.com/usn/USN-3222-1/)

--- a/_posts/2017-05-05-release-notes.md
+++ b/_posts/2017-05-05-release-notes.md
@@ -35,7 +35,7 @@ We upgraded the Cloud Foundry deployment to [v257](https://github.com/cloudfound
 - [Diego 1.14.1](https://github.com/cloudfoundry/diego-release/releases/tag/v1.14.1)
 - [RootFS cflinuxfs2 1.115.0](https://github.com/cloudfoundry/cflinuxfs2/releases/tag/1.115.0), which address vulnerabilities described in these security notices:
     - [USN-3246-1: Eject vulnerability](https://www.ubuntu.com/usn/usn-3246-1/)
-    - [USN-3259-1: Bind vulnerabilities](https://www.ubuntu.com/usn/usn-3259-1/)
+    - [USN-3259-1: Bind vulnerabilities](https://ubuntu.com/security/notices/USN-3259-1)
     - [USN-3263-1: FreeType vulnerability](https://www.ubuntu.com/usn/usn-3263-1/)
 - Stemcell 3312.23, which address vulnerabilities described in these security notices:
   - [USN-3249-2: Linux kernel (Xenial HWE) vulnerability](https://www.ubuntu.com/usn/usn-3249-2/)

--- a/_posts/2017-06-01-release-notes.md
+++ b/_posts/2017-06-01-release-notes.md
@@ -40,5 +40,5 @@ We upgraded the Cloud Foundry deployment to [v262](https://github.com/cloudfound
   - [USN-3282-1: FreeType vulnerabilities](https://www.ubuntu.com/usn/USN-3282-1/)
   - [USN-3283-1: rtmpdump vulnerabilities](https://www.ubuntu.com/usn/USN-3283-1/)
   - [USN-3287-1: Git vulnerability](https://www.ubuntu.com/usn/USN-3287-1/)
-  - [USN-3294-1: Bash vulnerabilities](https://www.ubuntu.com/usn/USN-3294-1/)
+  - [USN-3294-1: Bash vulnerabilities](https://ubuntu.com/security/notices/USN-3294-1)
   - [USN-3295-1: JasPer vulnerabilities](https://www.ubuntu.com/usn/USN-3295-1/)

--- a/_posts/2017-07-07-release-notes.md
+++ b/_posts/2017-07-07-release-notes.md
@@ -32,7 +32,7 @@ You should [restage your application](http://cli.cloudfoundry.org/en-US/cf/resta
   - [USN-3309-1: Libtasn1 vulnerability](https://www.ubuntu.com/usn/USN-3309-1/)
   - [USN-3304-1: Sudo vulnerability](https://www.ubuntu.com/usn/USN-3304-1/)
   - [USN-3212-2: LibTIFF regression](https://www.ubuntu.com/usn/USN-3212-2/)
-  - [USN-3302-1: ImageMagick vulnerabilities](https://www.ubuntu.com/usn/USN-3302-1/)
+  - [USN-3302-1: ImageMagick vulnerabilities](https://ubuntu.com/security/notices/USN-3302-1)
 - [Diego 1.19.0](https://github.com/cloudfoundry/diego-release/releases/tag/v1.19.0)
 - Stemcell 3312.29
 - Buildpack updates:

--- a/_posts/2017-08-16-release-notes.md
+++ b/_posts/2017-08-16-release-notes.md
@@ -28,7 +28,7 @@ We upgraded the Cloud Foundry deployment to [v270](https://github.com/cloudfound
 * [USN-3347-1: Libgcrypt vulnerabilities](https://usn.ubuntu.com/usn/usn-3347-1/)
 * [USN-3349-1: NTP vulnerabilities](https://usn.ubuntu.com/usn/usn-3349-1/)
 * [USN-3353-1: Heimdal vulnerability](https://usn.ubuntu.com/usn/usn-3353-1/)
-* [USN-3356-1: Expat vulnerability](https://usn.ubuntu.com/usn/usn-3356-1)
+* [USN-3356-1: Expat vulnerability](https://ubuntu.com/security/notices/USN-3356-1)
 * [USN-3363-1: ImageMagick vulnerabilities](https://usn.ubuntu.com/usn/usn-3363-1/)
 * [USN-3363-2: ImageMagick regression](https://usn.ubuntu.com/usn/usn-3363-2/)
 * [USN-3364-2: Linux kernel (Xenial HWE) vulnerabilities](https://usn.ubuntu.com/usn/usn-3364-2/)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cg-site",
   "version": "1.3.0",
   "scripts": {
-    "start": "run-p watch:* watch:static:*",
+    "start": "bundle install && run-p watch:* watch:static:*",
     "watch:jekyll": "bundle exec jekyll serve",
     "watch:static:js": "npx copy-and-watch --watch _assets/js/* assets/js",
     "watch:static:docs": "parcel watch --no-hmr _assets/documents/* --dist-dir assets/documents",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "scripts": {
     "start": "bundle install && run-p watch:* watch:static:*",
-    "watch:jekyll": "bundle exec jekyll serve",
+    "watch:jekyll": "bundle exec jekyll serve --incremental",
     "watch:static:js": "npx copy-and-watch --watch _assets/js/* assets/js",
     "watch:static:docs": "parcel watch --no-hmr _assets/documents/* --dist-dir assets/documents",
     "watch:css": "parcel watch --no-hmr _assets/css/styles.scss --dist-dir assets/css",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "scripts": {
     "start": "bundle install && run-p watch:* watch:static:*",
-    "watch:jekyll": "bundle exec jekyll serve --incremental",
+    "watch:jekyll": "bundle exec jekyll serve",
     "watch:static:js": "npx copy-and-watch --watch _assets/js/* assets/js",
     "watch:static:docs": "parcel watch --no-hmr _assets/documents/* --dist-dir assets/documents",
     "watch:css": "parcel watch --no-hmr _assets/css/styles.scss --dist-dir assets/css",


### PR DESCRIPTION
## Changes proposed in this pull request:

In order to improve the navigation of pages with lots of headings (e.g. https://cloud.gov/docs/services/relational-database/), this PR experiments with adding a table of contents to the top of the page using the [`jekyll-toc` plugin](https://github.com/toshimaru/jekyll-toc).

TOC is enabled on all `_docs` entries. Examples:

- Lots of headers: https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/add-toc-functionality/docs/services/relational-database/
- No headers, No TOC: https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.sites.pages.cloud.gov/preview/cloud-gov/cg-site/add-toc-functionality/docs/overview/customer-service-objectives/

## Security Considerations

None, just hopefully improving the UI/UX of our docs
