### PR TITLE
Fix links to sample customer diagram PDFs

### DIFF
--- a/_docs/compliance/diagrams.md
+++ b/_docs/compliance/diagrams.md
@@ -11,8 +11,8 @@ These diagrams can help you build a System Security Plan for an application, or 
 
 You can use these realistic sample diagrams as inspiration for your own diagrams for your customer system.
 
-* [Example #1 SVG]({{ site.baseurl }}/assets/images/content/example-diagram-1.svg) - A frontend website application and a backend API application, connected to a database.
-* [Example #2 SVG]({{ site.baseurl }}/assets/images/content/example-diagram-2.svg) - An application connected to a database and a Redis queue, with authentication, and with a connection to an external email service (not provided by cloud.gov).
+* [Example #1 PDF]({{ site.baseurl }}/assets/documents/example-diagram-1.pdf) ([SVG]({{ site.baseurl }}/assets/images/content/example-diagram-1.svg)) - A frontend website application and a backend API application, connected to a database.
+* [Example #2 PDF]({{ site.baseurl }}/assets/documents/example-diagram-2.pdf) ([SVG]({{ site.baseurl }}/assets/images/content/example-diagram-2.svg)) - An application connected to a database and a Redis queue, with authentication, and with a connection to an external email service (not provided by cloud.gov).
 
 ## Customer systems
 

--- a/_docs/compliance/diagrams.md
+++ b/_docs/compliance/diagrams.md
@@ -11,8 +11,8 @@ These diagrams can help you build a System Security Plan for an application, or 
 
 You can use these realistic sample diagrams as inspiration for your own diagrams for your customer system.
 
-* [Example #1 PDF]({{ site.baseurl }}/assets/images/content/example-diagram-1.pdf) ([SVG]({{ site.baseurl }}/assets/images/content/example-diagram-1.svg)) - A frontend website application and a backend API application, connected to a database.
-* [Example #2 PDF]({{ site.baseurl }}/assets/images/content/example-diagram-2.pdf) ([SVG]({{ site.baseurl }}/assets/images/content/example-diagram-2.svg)) - An application connected to a database and a Redis queue, with authentication, and with a connection to an external email service (not provided by cloud.gov).
+* [Example #1 SVG]({{ site.baseurl }}/assets/images/content/example-diagram-1.svg) - A frontend website application and a backend API application, connected to a database.
+* [Example #2 SVG]({{ site.baseurl }}/assets/images/content/example-diagram-2.svg) - An application connected to a database and a Redis queue, with authentication, and with a connection to an external email service (not provided by cloud.gov).
 
 ## Customer systems
 


### PR DESCRIPTION
## Changes proposed in this pull request:

I clicked these links and they were broken, and I saw that the documents moved to https://github.com/cloud-gov/cg-site/tree/main/_assets/documents instead of https://github.com/cloud-gov/cg-site/tree/main/_assets/images/content so I fixed the links.

## Security Considerations

None