### PR TITLE
fix: remove references to chat.18f.gov to appease the link bot

### DIFF
--- a/_docs/getting-started/code-samples.md
+++ b/_docs/getting-started/code-samples.md
@@ -171,7 +171,7 @@ Did we miss a tip or useful resource that you think we should add? [Submit a sug
 
 ### Join the communities
 
-* [The public DevOps channel on 18F's Slack (sign up at chat.18f.gov).](https://chat.18f.gov/)
+* [The public DevOps channel on TTS's Slack (sign up at with this form).](https://docs.google.com/forms/d/1vcsvQ64qt5mYNyVajcwtYDRMqEOyPzsXZBGM5c4_BD8/edit)
 * [Cloud Foundry communities (Slack, newsletters, mail lists)](https://www.cloudfoundry.org/community/)
 
 Want more?

--- a/_pages/pages/features.md
+++ b/_pages/pages/features.md
@@ -110,7 +110,7 @@ title: cloud.gov Pages - Features
     </div>
     <div class="tablet:grid-col-4 bar-top">
       <p>Join our Slack community to connect and learn from other Pages users across the federal government.</p>
-      <a class="cg-arrow" href="https://chat.18f.gov/">Join the Slack channel</a>
+      <a class="cg-arrow" href="https://docs.google.com/forms/d/1vcsvQ64qt5mYNyVajcwtYDRMqEOyPzsXZBGM5c4_BD8/edit">Join the Slack channel</a>
     </div>
     <div class="tablet:grid-col-4 bar-top">
       <p>The Pages team wants to learn from your experience so we can improve the product for all our users.</p>

--- a/_pages/pages/federalist-migration.md
+++ b/_pages/pages/federalist-migration.md
@@ -63,7 +63,7 @@ title: cloud.gov Pages - Federalist Migration
           You can migrate your account on your own or stop by weekly Pages office hours. You can receive the invite by notifying us at <a href="mailto:inquiries@cloud.gov">inquiries@cloud.gov</a>.
         </p>
         <p>
-          Some information will still be available at the <a href="https://federalistapp.18f.gov">Federalist site</a> but we’re gradually transitioning this to a read-only page before finally turning it off. 
+          Some information will still be available at the <a href="https://federalistapp.18f.gov">Federalist site</a> but we’re gradually transitioning this to a read-only page before finally turning it off.
         </p>
       </div>
     </div>
@@ -101,7 +101,7 @@ title: cloud.gov Pages - Federalist Migration
     </div>
     <div class="tablet:grid-col-4 bar-top">
       <p>Join our Slack community to connect and learn from other Pages users across the federal government.</p>
-      <a class="cg-arrow" href="https://chat.18f.gov/">Join the Slack channel</a>
+      <a class="cg-arrow" href="https://docs.google.com/forms/d/1vcsvQ64qt5mYNyVajcwtYDRMqEOyPzsXZBGM5c4_BD8/edit">Join the Slack channel</a>
     </div>
     <div class="tablet:grid-col-4 bar-top">
       <p>The Pages team wants to learn from your experience so we can improve the product for all our users.</p>

--- a/_pages/sign-up.md
+++ b/_pages/sign-up.md
@@ -81,7 +81,7 @@ can do.
 <h4>Join the communities</h4>
         <ul>
             <li>
-            <a href="https://chat.18f.gov/">The public DevOps channel on 18F's Slack (sign up at chat.18f.gov).</a>
+            <a href="https://docs.google.com/forms/d/1vcsvQ64qt5mYNyVajcwtYDRMqEOyPzsXZBGM5c4_BD8/edit">The public DevOps channel on TTS's Slack (sign up at using this form).</a>TTS Slack
             </li>
             <li>
             <a href="https://www.cloudfoundry.org/community/">Cloud Foundry communities (Slack, newsletters, mail lists)</a>


### PR DESCRIPTION
## Changes proposed in this pull request:
- remove references to chat.18f.gov to appease the link bot


## Security Considerations
None