### PR TITLE
Fix meta description on news page

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -20,7 +20,7 @@ site, this is the place to do it.
     {%- if page.title -%}{{- page.title | strip_html }} | {% endif -%}{{ site.title -}}
   {% endcapture %}
   {% capture description %}
-    {%- if page.url == "/" OR page.url == "/news/" -%}
+    {%- if page.url == "/" or page.url == "/news/index.html" -%}
       {{- site.description -}}
     {%- elsif page.description -%}
       {{- page.description | truncate: 160 -}}

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -20,7 +20,7 @@ site, this is the place to do it.
     {%- if page.title -%}{{- page.title | strip_html }} | {% endif -%}{{ site.title -}}
   {% endcapture %}
   {% capture description %}
-    {%- if page.url == "/" -%}
+    {%- if page.url == "/" OR page.url == "/news/" -%}
       {{- site.description -}}
     {%- elsif page.description -%}
       {{- page.description | truncate: 160 -}}

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -20,7 +20,7 @@ site, this is the place to do it.
     {%- if page.title -%}{{- page.title | strip_html }} | {% endif -%}{{ site.title -}}
   {% endcapture %}
   {% capture description %}
-    {%- if page.url == "/" or page.url == "/news/index.html" -%}
+    {%- if page.url == "/" or page.url == "/news/index.html" or page.url == "/knowledge-base/index.html" -%}
       {{- site.description -}}
     {%- elsif page.description -%}
       {{- page.description | truncate: 160 -}}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Uses the main site description for the news page meta description, this resolves the page url unfurling this:
![Screenshot 2024-10-01 at 11 11 47 AM](https://github.com/user-attachments/assets/6948ae5b-d5f7-4e11-ab23-cb5678f0b3cd)

## Security Considerations
None
