### PR TITLE
feat: Post on Pages default to node20

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 * @cloud-gov/platform-ops
-
+* @cloud-gov/pages-ops

--- a/_pages/pages/documentation/getting-started-with-netlify-cms.md
+++ b/_pages/pages/documentation/getting-started-with-netlify-cms.md
@@ -34,7 +34,6 @@ If your site is already up and running, please follow the instructions on [Decap
 
 For examples of existing configurations, see the Pages starter:
 - [Pages USWDS 11ty](https://github.com/cloud-gov/pages-uswds-11ty/blob/main/admin/config.yml)
-- [Pages USWDS Gatsby](https://github.com/cloud-gov/pages-uswds-gatsby/blob/main/static/admin/config.yml)
 
 ### Configuration Requirements
 To use Decap CMS, you must authenticate with Github, and in order for Pages to facilitate this, your Decap CMS configuration should include the following:

--- a/_pages/pages/documentation/monorepos-on-pages.md
+++ b/_pages/pages/documentation/monorepos-on-pages.md
@@ -13,28 +13,26 @@ Monorepos on Pages follow the same rules as any other Pages site; as long as Pag
 
 The following is an example of using Pages to build a site that is in a subfolder of a monorepo using the `script-only` option for a `node`-based site.
 
-See [federalist-monorepo-test](https://github.com/18F/federalist-monorepo-test) for the full working example.
-
-1. Like any other `script-only` site, create a `package.json` file in the project root with an entry in the `scripts` section with a key of `federalist`.
+1. Like any other `script-only` site, create a `package.json` file in the project root with an entry in the `scripts` section with a key of `pages`.
 ```
 // package.json
 {
   ...
   "scripts": {
-       "federalist": "do some stuff here"
+       "pages": "do some stuff here"
   },
   ...
 }
 ```
 
-2. When the `federalist` script runs, change the working directory to the appropriate folder, install any dependencies, run any build steps, and revert the working directory.
+2. When the `pages` script runs, change the working directory to the appropriate folder, install any dependencies, run any build steps, and revert the working directory.
 ```
 // package.json
 {
   ...
   "scripts": {
        "build:subproject1": "cd subproject1 && npm install && npm run build && cd ..",
-       "federalist": "npm run build:subproject1"
+       "pages": "npm run build:subproject1"
   },
   ...
 }
@@ -48,7 +46,7 @@ See [federalist-monorepo-test](https://github.com/18F/federalist-monorepo-test) 
   "scripts": {
        "build:subproject1": "cd subproject1 && npm install && npm run build && cd ..",
        "link:subproject1": "ln -sf ./subproject1/dist _site",
-       "federalist": "npm run build:subproject1 && npm run link:subproject1"
+       "pages": "npm run build:subproject1 && npm run link:subproject1"
   },
   ...
 }

--- a/_posts/2025-01-07-pages-build-default-node20.md
+++ b/_posts/2025-01-07-pages-build-default-node20.md
@@ -1,0 +1,10 @@
+---
+layout: post
+date: January 8th, 2025
+title: "New cloud.gov Pages default Node.js version for site builds"
+excerpt: Pages site builds will default to use Node.js version 20
+---
+
+The cloud.gov Pages team updated the default Node.js version for customer site builds from 18 to 20 on January, 8th 2025. We [currently support LTS Node.js versions](https://cloud.gov/pages/documentation/node-on-pages/#specifying-a-node-version:~:text=Pages%20only%20supports%20active%20and%20maintenance%20LTS%20(Long%20Term%20Support)%20Node%20releases%2C) 18, 20, and 22 for site builds. If you want to continue to use Node.js v18, be sure to pin it using [engines](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#engines) in your site’s package.json file or with a [.npmrc file](https://cloud.gov/pages/documentation/node-on-pages/#specifying-a-node-version). The Node.js team announced they [will end support for v18 midway through 2025](https://nodejs.org/en/about/previous-releases#nodejs-releases), so we encourage you to make sure your sites work with v20 or v22.
+
+If you have any questions about updating your Node.js version or are experiencing any problems, please contact us at [pages-support@cloud.gov](mailto:pages-support@cloud.gov).


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds new post on Pages default build node version update to 20
- Removes broken link to gatsby netlfiy admin
- Removes broken links to old monorepo example and changes to use the `pages` npm script moniker
- Add `pages-ops` to codeowners

## Security Considerations
Adds `pages-ops` to codeowners