### PR TITLE
Update log retention docs

### DIFF
--- a/_docs/compliance/logging-requirements.md
+++ b/_docs/compliance/logging-requirements.md
@@ -11,8 +11,7 @@ This document outlines how our platform enables cloud.gov customers to comply wi
 
 ### Basic Logging Categories
 
-- Cloud.gov currently retains logs in "active" storage (using ELK) for 6 months (to facilitate frequent use and ease of access), and 18 months in cold storage (using s3).
-- Cloud.gov will meet requirements by updating "active" storage to 12 months.
+- Cloud.gov currently retains logs in "active" storage (using OpenSearch) for 12 months (to facilitate frequent use and ease of access), and 18 months in cold storage (using S3).
 
 ### Minimum Logging Data
 

--- a/_docs/deployment/logs.md
+++ b/_docs/deployment/logs.md
@@ -25,7 +25,7 @@ cf logs APPNAME --recent
 
 ### Example log
 
-```
+```shell
   	2015-03-16T17:37:47.82-0400 [DEA/1]      OUT Starting app instance (index 0) with guid GUID
   	2015-03-16T17:37:50.85-0400 [DEA/1]      ERR Instance (index 0) failed to start accepting connections
   	2015-03-16T17:37:53.54-0400 [API/0]      OUT App instance exited with guid GUID0 payload: {"cc_partition"=>"default", "droplet"=>"GUID0", "version"=>"GUID1", "instance"=>"GUID2", "index"=>0, "reason"=>"CRASHED", "exit_status"=>127, "exit_description"=>"failed to accept connections within health check timeout", "crash_timestamp"=>1426541870}
@@ -61,21 +61,19 @@ The default time period is "Last 15 minutes". To change the time period of data 
 
 You can also view several dashboards that present different visualizations of your log data. You can select these by going to "Dashboard" at left and clicking "Open" in the top toolbar.
 
-
 !["Select dashboards"]({{site.baseurl}}/assets/images/content/select-dashboard.png)
 
 These visualizations are provided via OpenSearch Dashboards. You can learn more about
 OpenSearch in our [Cloud.gov Knowledge Base](https://search.usa.gov/search/docs?affiliate=cloud.gov&dc=9299&query=OpenSearch)
 and in the [OpenSearch Dashboards documentation](https://opensearch.org/docs/latest/).
 
-
 ### Structured logging
 
 If your application logs are output in JSON, they will be easily searchable in [logs.fr.cloud.gov](https://logs.fr.cloud.gov/). Some tools that make this easier:
 
-- Node: [bunyan](https://www.npmjs.com/package/bunyan)
-- Python: [python-json-logger](https://github.com/madzak/python-json-logger)
-- Ruby: [log_formatter](https://rubygems.org/gems/log_formatter/)
+* Node: [bunyan](https://www.npmjs.com/package/bunyan)
+* Python: [python-json-logger](https://github.com/madzak/python-json-logger)
+* Ruby: [log_formatter](https://rubygems.org/gems/log_formatter/)
 
 ## How to automatically copy your logs elsewhere
 
@@ -83,12 +81,16 @@ If you want to set up your own storage for your application logs, you can set up
 
 Create the user provided service and point it toward the endpoint where you want to send your logs:
 
-      cf create-user-provided-service my-log-drain \
-        -l syslog-tls://<your-log-drain-service-endpont>
+```shell
+cf create-user-provided-service my-log-drain \
+  -l syslog-tls://<your-log-drain-service-endpont>
+```
 
 Then, bind the service you created to the app that you want connect:
 
-      cf bind-service my-app my-log-drain
+```shell
+cf bind-service my-app my-log-drain
+```
 
 If your log storage system cannot receive logs via `syslog` or `https`, it may be possible to forward
 the logs to an application running on cloud.gov, which then sends the logs to your logging system.
@@ -101,6 +103,7 @@ which are then sent to the application, and so on. This loop can quickly overwhe
 dropped logs and unnecessary resource consumption.
 
 An example manifest for a log shipper application might look like:
+
 ```yml
 ---
 # manifest.yml

--- a/_docs/deployment/logs.md
+++ b/_docs/deployment/logs.md
@@ -49,7 +49,7 @@ If you receive `Error dialing trafficcontroller server`:
 
 To view and search your logs on the web, including historic log data, visit [https://logs.fr.cloud.gov/](https://logs.fr.cloud.gov/).
 
-Logs are currently retained for 365 days for live search (three years offline), and you will only see data for applications deployed within the [orgs](http://docs.cloudfoundry.org/concepts/roles.html#orgs) and [spaces](http://docs.cloudfoundry.org/concepts/roles.html#spaces) where you have access.
+Logs are currently retained for 365 days for live search (30 months offline), and you will only see data for applications deployed within the [orgs](http://docs.cloudfoundry.org/concepts/roles.html#orgs) and [spaces](http://docs.cloudfoundry.org/concepts/roles.html#spaces) where you have access.
 
 After logging in, you'll see the App Overview dashboard.
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update documentation about log retention to specify that logs are kept offline for **30 months**, not **3 years**.  The 30 month cold storage retention period is specified by M-21-31, which says that logs must be kept in "hot storage" for 12 months, then for an **additional 18 months** in cold storage. So we keep logs in cold storage for 30 months total (12 + 18), not 3 years, which would be 36 months.
- Update documentation about M-21-31 compliance to reflect updated 12 month log retention in OpenSearch

## Security Considerations

Updating our documentation about log retention to match requirements of M-21-31
