### PR TITLE
update links for OSS policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-## Welcome!
+# Contributing
 
 We're so glad you're thinking about contributing to an 18F open source project! If you're unsure or afraid of anything, just ask or submit the issue or pull request anyways. The worst that can happen is that you'll be politely asked to change something. We appreciate any sort of contribution, and don't want a wall of rules to get in the way of that.
 
-Before contributing, we encourage you to read our CONTRIBUTING policy (you are here), our LICENSE, and our README, all of which should be in this repository. If you have any questions, or want to read more about our underlying policies, you can consult the 18F Open Source Policy GitHub repository at https://github.com/18f/open-source-policy, or just shoot us an email/official government letterhead note to [18f@gsa.gov](mailto:18f@gsa.gov).
+Before contributing, we encourage you to read our CONTRIBUTING policy (you are here), our LICENSE, and our README, all of which should be in this repository. If you have any questions, or want to read more about our underlying policies, you can consult the [GSA Open Source Policy](https://open.gsa.gov/oss/), or just shoot us an email/official government letterhead note to [support@cloud.gov](mailto:support@cloud.gov).
 
 ## Public domain
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -44,7 +44,7 @@
                     Vulnerability disclosure policy</a>
                 </li>
                 <li class="usa-footer__secondary-link">
-                  <a href="https://18f.gsa.gov/open-source-policy/">Open source policy</a>
+                  <a href="https://open.gsa.gov/oss/">Open source policy</a>
                 </li>
               </ul>
             </section>


### PR DESCRIPTION
## Changes proposed in this pull request:

- Replace https://18f.gsa.gov/open-source-policy/ with https://open.gsa.gov/oss-policy/
- Replace 18f@gsa.gov with support@cloud.gov in CONTRIBUTING.md

## Security Considerations

None, just fixing broken links
