### PR TITLE
document that redirect_uris for UAA Oauth clients must be full URLs

### DIFF
--- a/_docs/services/cloud-gov-identity-provider.md
+++ b/_docs/services/cloud-gov-identity-provider.md
@@ -45,8 +45,9 @@ cf create-service-key \
     }'
 ```
 
-This will create a cloud.gov identity provider and make the credentials available to you via a service key.
-The `redirect_uri` array registers your app's redirect uris with your service provider.
+> **Please note that `APP_AUTH_REDIRECT_ROUTE` and `APP_LOGOUT_REDIRECT_ROUTE` must be full URLs (e.g. `https://<your-domain>/auth`) and not just paths on your app.**
+
+This will create a cloud.gov identity provider and make the credentials available to you via a service key. The `redirect_uri` array registers your app's redirect uris with your service provider.
 
 You can retrieve your credentials with the name of the instance and service key:
 
@@ -83,6 +84,8 @@ cf create-service-key \
       "allowpublic": true
     }'
 ```
+
+> **Please note that `APP_AUTH_REDIRECT_ROUTE` and `APP_LOGOUT_REDIRECT_ROUTE` must be full URLs (e.g. `https://<your-domain>/auth`) and not just paths on your app.**
 
 ### If you can't find your service keys
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- document that redirect_uris for UAA Oauth clients must be full URLs, which is not clear from the current documentation

## Security Considerations

None, the documentation is public and does not expose any sensitive information
