### PR TITLE
CNB update to core docs

### DIFF
--- a/_docs/deployment/custom-buildpacks.md
+++ b/_docs/deployment/custom-buildpacks.md
@@ -13,11 +13,17 @@ title: More languages (custom buildpacks)
 weight: 30
 ---
 
-Cloud Foundry (the underlying open source project behind cloud.gov) uses [buildpacks]({{site.baseurl }}/docs/getting-started/concepts/#buildpacks) to allow your applications to be deployed. cloud.gov [officially supports]({{ site.baseurl }}/pricing/) a set of buildpacks, and it also allows you to provide your own.
+Cloud Foundry (the underlying open source project behind Cloud.gov) uses [buildpacks]({{site.baseurl }}/docs/getting-started/concepts/#buildpacks) to allow your applications to be deployed. Cloud.gov officially supports a set of "system buildpacks", but it also allows you to provide your own.
 
-Once you push your code using a custom buildpack, cloud.gov cannot update it for you. You are responsible for keeping it up to date. Please see [this description of responsibilities]({{ site.baseurl }}/docs/technology/responsibilities/).
+Once you push your code using a custom buildpack, Cloud.gov cannot update it for you. You are responsible for keeping it up to date. Please see [this description of responsibilities]({{ site.baseurl }}/docs/technology/responsibilities/).
 
 ## Example custom buildpacks
+
+### Cloud Native Buildpacks
+
+The Cloud Native community has over the last few years developed a [Cloud Native Buildpack (CNB) ecosystem](https://buildpacks.io/). CNBs are the next stage in the evolution of buildpacks, and will eventually replace what are now (in 2025) called Classic Buildpacks. The CNBs provide better control, compliance and maintainability than either Classic Buildpacks or pre-built Docker images.
+
+A simple [Hello World example in NodeJS](https://github.com/cloud-gov/cf-hello-worlds/tree/main/nodejs) shows how to deploy an app to Cloud.gov using either the default Classic Buildpack, or a Cloud Native Buildpack via a `lifecycle` option.
 
 ### apt-buildpack
 

--- a/_docs/getting-started/concepts.md
+++ b/_docs/getting-started/concepts.md
@@ -93,4 +93,10 @@ If none of these strategies will help you deploy single-language applications, y
 
 **Custom buildpacks:** If your application can't use a standard buildpack, you can use a [custom buildpack]({{ site.baseurl }}{% link _docs/deployment/custom-buildpacks.md %}). When you use a custom buildpack, you're responsible for keeping your buildpack up-to-date and patching vulnerabilities in it. See [this chart illustrating your responsibilities]({{ site.baseurl }}{% link _docs/technology/responsibilities.md %}) for more detail.
 
-**Cloud Native Buildpacks:** In early 2025, Cloud Foundry provided the option to deploy applications using [Cloud Native Buildpacks](https://buildpacks.io/), with the
+**Cloud Native Buildpacks:** In early 2025, Cloud Foundry provided the option to deploy applications using [Cloud Native Buildpacks](https://buildpacks.io/), through the use of the `lifecycle` option in your manifest, or as a `cf push` option. You can see a basic example of this with the [NodeJS Hello World example](https://github.com/cloud-gov/cf-hello-worlds/tree/main/nodejs), where `manifest-cnb.yml` includes the following to specify the lifecycle and buildpack:
+
+```  
+  lifecycle: cnb
+  buildpacks:
+  - docker://gcr.io/paketo-buildpacks/nodejs
+```

--- a/_docs/getting-started/concepts.md
+++ b/_docs/getting-started/concepts.md
@@ -92,3 +92,5 @@ Or with a URL:
 If none of these strategies will help you deploy single-language applications, you can [explicitly specify a set of buildpacks to run in sequence](https://docs.cloudfoundry.org/buildpacks/use-multiple-buildpacks.html), one for each language.
 
 **Custom buildpacks:** If your application can't use a standard buildpack, you can use a [custom buildpack]({{ site.baseurl }}{% link _docs/deployment/custom-buildpacks.md %}). When you use a custom buildpack, you're responsible for keeping your buildpack up-to-date and patching vulnerabilities in it. See [this chart illustrating your responsibilities]({{ site.baseurl }}{% link _docs/technology/responsibilities.md %}) for more detail.
+
+**Cloud Native Buildpacks:** In early 2025, Cloud Foundry provided the option to deploy applications using [Cloud Native Buildpacks](https://buildpacks.io/), with the

--- a/_docs/technology/responsibilities.md
+++ b/_docs/technology/responsibilities.md
@@ -23,7 +23,7 @@ Here's a chart to illustrate this in three example use cases:
 
 App #1 uses a [standard buildpack]({{ site.baseurl }}{% link _docs/getting-started/concepts.md %}#buildpacks). (A buildpack provides support for a programming language.) The customer is only responsible for the app code and its dependencies.
 
-App #2 uses a [custom buildpack]({{ site.baseurl }}{% link _docs/deployment/custom-buildpacks.md %}), so the customer's responsibility expands from the app code to managing the custom buildpack and its dependencies. If you choose to use a custom buildpack, you are responsible for:
+App #2 uses a [custom buildpack or a Cloud Native Buildpack]({{ site.baseurl }}{% link _docs/deployment/custom-buildpacks.md %}), so the customer's responsibility expands from the app code to managing the custom buildpack and its dependencies. If you choose to use a custom buildpack, you are responsible for:
 
 * Ensuring your application framework/runtime and all dependencies are supported versions with no known vulnerabilities.
 * Continually updating your runtime and dependencies as new vulnerabilities are discovered and fixed.

--- a/_docs/technology/responsibilities.md
+++ b/_docs/technology/responsibilities.md
@@ -23,11 +23,13 @@ Here's a chart to illustrate this in three example use cases:
 
 App #1 uses a [standard buildpack]({{ site.baseurl }}{% link _docs/getting-started/concepts.md %}#buildpacks). (A buildpack provides support for a programming language.) The customer is only responsible for the app code and its dependencies.
 
-App #2 uses a [custom buildpack or a Cloud Native Buildpack]({{ site.baseurl }}{% link _docs/deployment/custom-buildpacks.md %}), so the customer's responsibility expands from the app code to managing the custom buildpack and its dependencies. If you choose to use a custom buildpack, you are responsible for:
+App #2 uses a [custom buildpack]({{ site.baseurl }}{% link _docs/deployment/custom-buildpacks.md %}), so the customer's responsibility expands from the app code to managing the custom buildpack and its dependencies. If you choose to use a custom buildpack, you are responsible for:
 
 * Ensuring your application framework/runtime and all dependencies are supported versions with no known vulnerabilities.
 * Continually updating your runtime and dependencies as new vulnerabilities are discovered and fixed.
 * Maintaining a best practice baseline configuration for your application framework/runtime that meets all applicable security standards.
+
+Examples of custom buildpacks includes [Cloud Native Buildpacks](https://buildpacks.io) as they are not yet (in early 2025) available within the Cloud.gov authorization boundary.
 
 App #3 is a Docker setup, where the customer is fully responsible for their Docker container and custom image. [Learn about this feature.]({{ site.baseurl }}{% link _docs/deployment/docker.md %})
 


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Introduce (quietly) the notion of CNBs and where they fall into our customer's responsibilities.
- I've updated this: `cloud.gov [officially supports]({{ site.baseurl }}/pricing/) a set of buildpacks` because I think the pricing page used to also include the "Responsibilities"
- More about CNBs will likely be a news item or KB item (probably this PI)

## Security Considerations
Safe. Fleshes out our docs with references to open source material.
